### PR TITLE
Support embree 4 for fixing compile error

### DIFF
--- a/src/backends/llvm/llvm_accel.h
+++ b/src/backends/llvm/llvm_accel.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#if __has_include(<embree4/rtcore.h>)
 #include <embree4/rtcore.h>
+#else
+#include <embree3/rtcore.h>
+#endif
 
 #include <core/stl.h>
 #include <core/thread_pool.h>

--- a/src/backends/llvm/llvm_accel.h
+++ b/src/backends/llvm/llvm_accel.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 
 #include <core/stl.h>
 #include <core/thread_pool.h>

--- a/src/backends/llvm/llvm_device.h
+++ b/src/backends/llvm/llvm_device.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <embree3/rtcore_device.h>
+#include <embree4/rtcore_device.h>
 #include <runtime/device.h>
 
 namespace llvm {

--- a/src/backends/llvm/llvm_device.h
+++ b/src/backends/llvm/llvm_device.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#if __has_include(<embree4/rtcore_device.h>)
 #include <embree4/rtcore_device.h>
+#else
+#include <embree3/rtcore_device.h>
+#endif
 #include <runtime/device.h>
 
 namespace llvm {

--- a/src/backends/llvm/llvm_mesh.h
+++ b/src/backends/llvm/llvm_mesh.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <embree3/rtcore.h>
+#include <embree4/rtcore.h>
 #include <rtx/mesh.h>
 #include "llvm_accel.h"
 

--- a/src/backends/llvm/llvm_mesh.h
+++ b/src/backends/llvm/llvm_mesh.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#if __has_include(<embree4/rtcore.h>)
 #include <embree4/rtcore.h>
+#else
+#include <embree3/rtcore.h>
+#endif
 #include <rtx/mesh.h>
 #include "llvm_accel.h"
 


### PR DESCRIPTION
The submodule src/ext/embree pointing embree 4
while `LUISA_COMPUTE_EMBREE_DOWNLOAD_VERSION` is set to `3.15.5`.

This causes compilation error for non AMD64 or non x86_64 targets
since these targets build embree from scratch using the submodule
and llvm backends of LuisaCompute only support embree 3.
(See llvm_accel.{h,cpp}, llvm_mesh.h, llvm_device.h)

This is a small PR that resolves the compilation error.

