### PR TITLE
DX12 CUDA interop for buffers

### DIFF
--- a/include/luisa/backends/ext/dx_cuda_interop.h
+++ b/include/luisa/backends/ext/dx_cuda_interop.h
@@ -1,14 +1,36 @@
 #pragma once
 #include <luisa/runtime/rhi/device_interface.h>
-
+#include <luisa/backends/ext/native_resource_ext.hpp>
 namespace luisa::compute {
 class DxCudaInterop : public DeviceExtension {
 protected:
     ~DxCudaInterop() noexcept = default;
 
 public:
+    static constexpr luisa::string_view name = "DxCudaInterop";
+
+    template<typename T>
+    Buffer<T> create_shared_buffer(unsigned size, void** cuda_ptr) 
+    {
+        auto buffer = ResourceGenerator::create_native_buffer<T>(GetBufferInfo(sizeof(T)*size), GetDevice());
+        *cuda_ptr = reinterpret_cast<void*>(cuda_buffer(buffer.handle()));
+        return buffer;
+    }
+    template<typename T>
+    Image<T> create_shared_image(PixelStorage storage, unsigned width, unsigned height, void** cuda_ptr)
+    {
+        auto buffer = ResourceGenerator::create_native_image<T>(GetImageInfo(sizeof(T) * size), GetDevice(), storage, {width,height}, 1);
+        *cuda_ptr = reinterpret_cast<void*>(cuda_texture(buffer.handle()));
+        return buffer;
+    }
+
+protected:
     virtual uint64_t cuda_buffer(uint64_t dx_buffer_handle) noexcept = 0;
     virtual uint64_t cuda_texture(uint64_t dx_texture_handle) noexcept = 0;
     virtual uint64_t cuda_event(uint64_t dx_event_handle) noexcept = 0;
+
+    //virtual BufferCreationInfo GetImageInfo(unsigned sizeInBytes, unsigned int, unsigned height) = 0;
+    virtual BufferCreationInfo GetBufferInfo(unsigned sizeInBytes) = 0;
+    virtual DeviceInterface* GetDevice() = 0;
 };
 }// namespace luisa::compute

--- a/src/backends/dx/DXApi/LCDevice.cpp
+++ b/src/backends/dx/DXApi/LCDevice.cpp
@@ -83,6 +83,15 @@ LCDevice::LCDevice(Context &&ctx, DeviceConfig const *settings)
         [](DeviceExtension *ext) {
             delete static_cast<DxDirectMLExt *>(ext);
         });
+
+    exts.try_emplace(
+        DxCudaInterop::name,
+        [](LCDevice* device) -> DeviceExtension* {
+        return new DxCudaInteropImpl(*device);
+        },
+        [](DeviceExtension* ext) {
+            delete static_cast<DxCudaInteropImpl*>(ext);
+        });
 }
 LCDevice::~LCDevice() {
 }

--- a/src/backends/dx/DXApi/cuda_interop.cpp
+++ b/src/backends/dx/DXApi/cuda_interop.cpp
@@ -1,5 +1,5 @@
 #include "ext.h"
-#define LCDX_ENABLE_CUDA
+
 #ifdef LCDX_ENABLE_CUDA
 #include <cuda.h>
 #include <cuda_runtime_api.h>

--- a/src/backends/dx/DXApi/ext.h
+++ b/src/backends/dx/DXApi/ext.h
@@ -161,13 +161,17 @@ public:
     void destroy_depth_buffer(uint64_t handle) noexcept override;
 };
 class DxCudaInteropImpl : public luisa::compute::DxCudaInterop {
-    Device &_device;
+    LCDevice& _device;
 
 public:
+    DxCudaInteropImpl(LCDevice& device) : _device{ device } {}
+protected:
     uint64_t cuda_buffer(uint64_t dx_buffer) noexcept override;
     uint64_t cuda_texture(uint64_t dx_texture) noexcept override;
     uint64_t cuda_event(uint64_t dx_event) noexcept override;
-    DxCudaInteropImpl(Device &device) : _device{device} {}
+    virtual BufferCreationInfo GetBufferInfo(unsigned sizeInBytes) override;
+    virtual DeviceInterface* GetDevice() override;
+
 };
 
 class DStorageExtImpl final : public DStorageExt, public vstd::IOperatorNewBase {

--- a/src/backends/dx/Resource/DefaultBuffer.cpp
+++ b/src/backends/dx/Resource/DefaultBuffer.cpp
@@ -26,7 +26,7 @@ DefaultBuffer::DefaultBuffer(
         auto buffer = CD3DX12_RESOURCE_DESC::Buffer(byteSize, D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
         ThrowIfFailed(device->device->CreateCommittedResource(
             &prop,
-            D3D12_HEAP_FLAG_NONE,
+            D3D12_HEAP_FLAG_SHARED,//D3D12_HEAP_FLAG_NONE,
             &buffer,
             initState,
             nullptr,

--- a/src/backends/dx/Resource/GpuAllocator.cpp
+++ b/src/backends/dx/Resource/GpuAllocator.cpp
@@ -56,7 +56,7 @@ uint64 GpuAllocator::AllocateBufferHeap(
     ALLOCATION_DESC desc;
     desc.HeapType = heapType;
     desc.Flags = ALLOCATION_FLAGS::ALLOCATION_FLAG_STRATEGY_BEST_FIT;
-    desc.ExtraHeapFlags = D3D12_HEAP_FLAGS::D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS | D3D12_HEAP_FLAGS::D3D12_HEAP_FLAG_SHARED;
+    desc.ExtraHeapFlags = D3D12_HEAP_FLAGS::D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
     desc.CustomPool = reinterpret_cast<Pool *>(custom_pool);
     D3D12_RESOURCE_ALLOCATION_INFO info;
     info.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;

--- a/src/backends/dx/Resource/GpuAllocator.cpp
+++ b/src/backends/dx/Resource/GpuAllocator.cpp
@@ -56,7 +56,7 @@ uint64 GpuAllocator::AllocateBufferHeap(
     ALLOCATION_DESC desc;
     desc.HeapType = heapType;
     desc.Flags = ALLOCATION_FLAGS::ALLOCATION_FLAG_STRATEGY_BEST_FIT;
-    desc.ExtraHeapFlags = D3D12_HEAP_FLAGS::D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS;
+    desc.ExtraHeapFlags = D3D12_HEAP_FLAGS::D3D12_HEAP_FLAG_ALLOW_ONLY_BUFFERS | D3D12_HEAP_FLAGS::D3D12_HEAP_FLAG_SHARED;
     desc.CustomPool = reinterpret_cast<Pool *>(custom_pool);
     D3D12_RESOURCE_ALLOCATION_INFO info;
     info.Alignment = D3D12_DEFAULT_RESOURCE_PLACEMENT_ALIGNMENT;


### PR DESCRIPTION
Only buffer interop is implemented. The mapping needs to be destroyed when buffer is released, however yet to be implemented.