### PR TITLE
Fix invalid_reference_casting error on rust 1.74.0-nightly.

### DIFF
--- a/src/rust/luisa_compute_ir/src/lib.rs
+++ b/src/rust/luisa_compute_ir/src/lib.rs
@@ -114,7 +114,7 @@ impl<K: Hash + Eq, V> NestedHashMap<K, V> {
     pub(crate) fn insert(&mut self, k: K, v: V) {
         unsafe {
             let inner = self.inner.as_ref() as *const _ as *mut NestedHashMapInner<K, V>;
-            let inner = &mut *inner;
+            let inner = inner.as_mut().unwrap();
             inner.map.insert(k, v);
         }
     }


### PR DESCRIPTION
This pull request fixes a use of `&mut *` which threw an error on my rust version because of [`invalid_reference_casting`](https://doc.rust-lang.org/beta/rustc/lints/listing/deny-by-default.html#invalid-reference-casting).
