### PR TITLE
Fix uses_atomic() duplication + missing type tests

### DIFF
--- a/include/luisa/ast/op.h
+++ b/include/luisa/ast/op.h
@@ -417,7 +417,7 @@ public:
                test(CallOp::ATOMIC_FETCH_AND) ||
                test(CallOp::ATOMIC_FETCH_OR) ||
                test(CallOp::ATOMIC_FETCH_XOR) ||
-               test(CallOp::ATOMIC_EXCHANGE) ||
+               test(CallOp::ATOMIC_FETCH_MAX) ||
                test(CallOp::ATOMIC_EXCHANGE) ||
                test(CallOp::ATOMIC_COMPARE_EXCHANGE);
     }


### PR DESCRIPTION
Fix CallOpTest::uses_atomic;  was checking AtomicExchange twice and missing AtomicMax.  Spotted this on a random warning scrolling past on the windows build, seems like it could cause mild to severe problems depending on what behavior this method changes elsewhere. 