### PR TITLE
DX-OIDN ext fix

### DIFF
--- a/src/backends/dx/DXApi/cuda_interop.cpp
+++ b/src/backends/dx/DXApi/cuda_interop.cpp
@@ -99,6 +99,7 @@ void DxCudaInteropImpl::cuda_buffer(uint64_t dx_buffer_handle, uint64_t *cuda_pt
         LUISA_ERROR("Failed to create shared handle");
     }
 
+
     CUDA_EXTERNAL_MEMORY_HANDLE_DESC externalMemoryHandleDesc{};
     externalMemoryHandleDesc.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE;
     externalMemoryHandleDesc.handle.win32.handle = sharedHandle;
@@ -207,5 +208,14 @@ ResourceCreationInfo DxCudaInteropImpl::create_interop_texture(
 DeviceInterface *DxCudaInteropImpl::device() {
     return &_device;
 }
+
+	CUcontext cuContext;
+	CUdevice cuDevice;
+	DxCudaInteropImpl::DxCudaInteropImpl(LCDevice& device) noexcept : _device{device}
+	{
+		cuInit(0);
+		cuDeviceGet(&cuDevice, 0); // Get handle to device 0
+		cuCtxCreate(&cuContext, 0, cuDevice); // Create context
+	}
 }// namespace lc::dx
 #endif

--- a/src/backends/dx/DXApi/ext.cpp
+++ b/src/backends/dx/DXApi/ext.cpp
@@ -423,7 +423,7 @@ luisa::shared_ptr<DenoiserExt::Denoiser> DXOidnDenoiserExt::create(uint64_t stre
     _device->nativeDevice.adapter->GetDesc1(&desc);
     auto device_id = desc.DeviceId;
     LUISA_ASSERT(device_id != -1, "device_id should not be -1.");
-    return luisa::make_shared<DXOidnDenoiser>(_device, oidn::newCUDADevice(device_id, 0), stream);
+    return luisa::make_shared<DXOidnDenoiser>(_device, oidn::newCUDADevice(-1, 0), stream);
 }
 luisa::shared_ptr<DenoiserExt::Denoiser> DXOidnDenoiserExt::create(Stream &stream) noexcept {
     return create(stream.handle());

--- a/src/backends/dx/DXApi/ext.h
+++ b/src/backends/dx/DXApi/ext.h
@@ -169,7 +169,7 @@ class DxCudaInteropImpl : public luisa::compute::DxCudaInterop {
     LCDevice &_device;
 
 public:
-    DxCudaInteropImpl(LCDevice &device) noexcept : _device{device} {}
+    DxCudaInteropImpl(LCDevice &device) noexcept;
     BufferCreationInfo create_interop_buffer(const Type *element, size_t elem_count) noexcept override;
     ResourceCreationInfo create_interop_texture(
         PixelFormat format, uint dimension,


### PR DESCRIPTION
Try to fix the DX-OIND extension by
1. fixing DxCudaInteropImpl by creating and maintaining an independent CUcontext
2. newCUDADevice uses deviceID = -1, as "negative value maps to the current device".