### PR TITLE
[Python frontend] Add support for default argument values

### DIFF
--- a/src/py/luisa/astbuilder.py
+++ b/src/py/luisa/astbuilder.py
@@ -263,11 +263,16 @@ class ASTVisitor:
             node.expr = varinfo.expr
             node.is_arg = varinfo.is_arg
             node.lr = 'l'
+        elif node.id in ctx().default_arg_values:
+            default_val = ctx().default_arg_values[node.id]
+            node.dtype = dtype_of(default_val)
+            node.expr = lcapi.builder().literal(to_lctype(node.dtype), default_val)
+            node.lr = 'r'
         else:
             val = ctx().closure_variable.get(node.id)
             if val is None:
                 if not allow_none:
-                    raise NameError(f"undeclared idenfitier '{node.id}'")
+                    raise NameError(f"undeclared identifier '{node.id}'")
                 node.dtype = None
                 return
             node.dtype, node.expr, node.lr = build.captured_expr(val)

--- a/src/py/luisa/func.py
+++ b/src/py/luisa/func.py
@@ -77,6 +77,7 @@ class FuncInstanceInfo:
             **_closure_vars.builtins
         }
         self.local_variable = {}  # dict: name -> VariableInfo(dtype, expr, is_arg)
+        self.default_arg_values = self._capture_default_arg_values(func.pyfunc)
         self.function = None
         self.shader_handle = None
 
@@ -86,6 +87,11 @@ class FuncInstanceInfo:
             if device is not None:
                 device.impl().destroy_shader(self.shader_handle)
 
+    def _capture_default_arg_values(self, pyfunc):
+        sig = inspect.signature(pyfunc)
+        return {param.name: param.default for param in sig.parameters.values()
+                if param.default is not inspect.Parameter.empty}
+    
     def build_arguments(self, allow_ref: bool, arg_info=None):
         if arg_info is None:
             for idx, name in enumerate(self.func.parameters):


### PR DESCRIPTION
When calling a function that has parameters with default values, if we don't specify those parameters, it will cause a `NameError: undeclared identifier`
This PR fixes this issue.

```
@func
def test(x: float=1):
    pass

v = test()
```

