### PR TITLE
fix bug: ld: Assertion failed: (slot < _sideTableBuffer.size()), function addAtom, file AtomFileConsolidator.cpp

### DIFF
--- a/.github/workflows/build-xmake.yml
+++ b/.github/workflows/build-xmake.yml
@@ -60,6 +60,11 @@ jobs:
           fi
           brew install molten-vk ninja cmake xmake
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          echo "Check the relevant software versions"
+          brew --version
+          xcodebuild -version
+          clang --version
+          echo "Check End"
       - name: "Configure and Build"
         run: |
           xmake lua setup.lua

--- a/.github/workflows/build-xmake.yml
+++ b/.github/workflows/build-xmake.yml
@@ -60,10 +60,17 @@ jobs:
           fi
           brew install molten-vk ninja cmake xmake
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          sudo xcode-select -switch /Applications/Xcode_15.1.app
           echo "Check the relevant software versions"
+          echo "check brew"
           brew --version
+          echo "check brew end"
+          echo "check xcode"
           xcodebuild -version
-          clang --version
+          echo "check xcode end"
+          echo "check clang++"
+          clang++ --version
+          echo "check clang++ end"
           echo "Check End"
       - name: "Configure and Build"
         run: |

--- a/.github/workflows/build-xmake.yml
+++ b/.github/workflows/build-xmake.yml
@@ -60,17 +60,11 @@ jobs:
           fi
           brew install molten-vk ninja cmake xmake
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          sudo xcode-select -switch /Applications/Xcode_15.1.app
+          sudo xcode-select -switch /Applications/Xcode_16.1.app
           echo "Check the relevant software versions"
-          echo "check brew"
           brew --version
-          echo "check brew end"
-          echo "check xcode"
           xcodebuild -version
-          echo "check xcode end"
-          echo "check clang++"
           clang++ --version
-          echo "check clang++ end"
           echo "Check End"
       - name: "Configure and Build"
         run: |


### PR DESCRIPTION
When running in macOS CI with debug mode, an error will be reported:
`ld: Assertion failed: (slot < _sideTableBuffer.size()), function addAtom, file AtomFileConsolidator.cpp, line 2278.`

After updating the XCode version from 15.4 to 16.1, the bug was resolved.

The bug should be caused by the linker, and the relevant references are as follows:

- [https://github.com/Homebrew/homebrew-core/issues/145991](https://github.com/Homebrew/homebrew-core/issues/145991)
- [https://forum.dlang.org/post/mailman.964.1708739532.3719.digitalmars-d-bugs@puremagic.com](https://forum.dlang.org/post/mailman.964.1708739532.3719.digitalmars-d-bugs@puremagic.com)
- [https://github.com/dlang/dmd/pull/16240](https://github.com/dlang/dmd/pull/16240)