### PR TITLE
Update build_wheels_linux.sh

### DIFF
--- a/build_wheels_linux.sh
+++ b/build_wheels_linux.sh
@@ -3,6 +3,7 @@
 export CIBW_ARCHS=auto64
 export CIBW_BUILD="*manylinux*"
 export CIBW_MANYLINUX_X86_64_IMAGE=manylinux_2_28
+export CIBW_MANYLINUX_AARCH_64_IMAGE=manylinux_2_28
 export CIBW_BEFORE_ALL="./scripts/cibw_install_deps.sh"
 export CIBW_BUILD_VERBOSITY=2
 export CIBW_REPAIR_WHEEL_COMMAND="auditwheel show {wheel} && auditwheel repair -w {dest_dir} {wheel} --exclude libcuda.so.1 --exclude libvulkan.so.1"


### PR DESCRIPTION
This pull request includes a small change to the `build_wheels_linux.sh` file. The change adds support for the `aarch64` architecture by setting the `CIBW_MANYLINUX_AARCH_64_IMAGE` environment variable to `manylinux_2_28`.
