### PR TITLE
remove typename for latest MSVC & add template before Type for latest…

### DIFF
--- a/include/luisa/vstl/functional.h
+++ b/include/luisa/vstl/functional.h
@@ -56,7 +56,7 @@ namespace detail {
 template<typename Ret, typename... Args>
 struct ObjType {
     template<template<typename...> typename Object>
-    using Type = typename Object<Ret(Args...)>;
+    using Type = Object<Ret(Args...)>;
 };
 template<typename T>
 struct member_func_meta;
@@ -76,7 +76,7 @@ struct member_func_meta<Ret (Class::*)(Args...) noexcept> : ObjType<Ret, Args...
 }// namespace detail
 template<typename Lambda>
 inline auto make_func_ref(Lambda &lambda) noexcept {
-    return typename detail::member_func_meta<decltype(&std::remove_reference_t<Lambda>::operator())>::Type<vstd::FuncRef>{lambda};
+    return typename detail::member_func_meta<decltype(&std::remove_reference_t<Lambda>::operator())>::template Type<vstd::FuncRef>{lambda};
 }
 
 }// namespace vstd


### PR DESCRIPTION

# 问题描述
在最新版的VS2022 17.13.4 的 19.43.34809 MSVC 
![image](https://github.com/user-attachments/assets/7ca5a964-aa18-47fa-90da-51b012e8f507)

使用xmake编译会出现：
![image](https://github.com/user-attachments/assets/71dec13a-e839-4b2a-987f-ba28c2ab5304)

# 修复
- include\luisa/vstl/functional.h(59) 中移除多余的typename
- include\luisa/vstl/functional.h(79) 添加template 给予编译器提示

# 结果
![image](https://github.com/user-attachments/assets/023eec2d-0657-4d2e-be21-951b8a933e06)

