### PR TITLE
import external image for fallback

### DIFF
--- a/include/luisa/runtime/device.h
+++ b/include/luisa/runtime/device.h
@@ -190,8 +190,8 @@ public:
     }
 
     template<typename T>
-    [[nodiscard]] auto import_external_image(PixelStorage pixel, uint2 size, void *external_native_handle, uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept {
-        return _create<Image<T>>(pixel, size, external_native_handle, mip_levels, simultaneous_access, allow_raster_target);
+    [[nodiscard]] auto import_external_image(PixelStorage pixel, void *external_native_handle, uint2 size, uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept {
+        return _create<Image<T>>(pixel, external_native_handle, size, mip_levels, simultaneous_access, allow_raster_target);
     }
 
     template<typename T>

--- a/include/luisa/runtime/device.h
+++ b/include/luisa/runtime/device.h
@@ -190,8 +190,8 @@ public:
     }
 
     template<typename T>
-    [[nodiscard]] auto import_external_image(PixelStorage pixel, uint2 size, byte* buffer, uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept {
-        return _create<Image<T>>(pixel, size, buffer, mip_levels, simultaneous_access, allow_raster_target);
+    [[nodiscard]] auto import_external_image(PixelStorage pixel, uint2 size, void *external_native_handle, uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept {
+        return _create<Image<T>>(pixel, size, external_native_handle, mip_levels, simultaneous_access, allow_raster_target);
     }
 
     template<typename T>

--- a/include/luisa/runtime/device.h
+++ b/include/luisa/runtime/device.h
@@ -190,6 +190,11 @@ public:
     }
 
     template<typename T>
+    [[nodiscard]] auto import_external_image(PixelStorage pixel, uint2 size, byte* buffer, uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept {
+        return _create<Image<T>>(pixel, size, buffer, mip_levels, simultaneous_access, allow_raster_target);
+    }
+
+    template<typename T>
     [[nodiscard]] auto create_sparse_image(PixelStorage pixel, uint width, uint height, uint mip_levels = 1u, bool simultaneous_access = true) noexcept {
         return _create<SparseImage<T>>(pixel, make_uint2(width, height), mip_levels, simultaneous_access);
     }

--- a/include/luisa/runtime/image.h
+++ b/include/luisa/runtime/image.h
@@ -73,8 +73,23 @@ private:
                         size.x, size.y, 1u,
                         detail::max_mip_levels(make_uint3(size, 1u), mip_levels),
                         simultaneous_access, allow_raster_target);
-                }(),
-                storage, size, mip_levels} {}
+        }(),
+        storage, size, mip_levels} {}
+
+    Image(DeviceInterface *device, PixelStorage storage, uint2 size, byte* data,
+          uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept
+        : Image{device,
+                [&] {
+                    if (size.x == 0 || size.y == 0) [[unlikely]] {
+                        detail::image_size_zero_error();
+                    }
+                    return device->create_texture(
+                        pixel_storage_to_format<T>(storage), 2u,
+                        size.x, size.y, 1u,
+                        detail::max_mip_levels(make_uint3(size, 1u), mip_levels),
+                        simultaneous_access, allow_raster_target, data);
+        }(),
+        storage, size, mip_levels} {}
 
 public:
     Image() noexcept = default;

--- a/include/luisa/runtime/image.h
+++ b/include/luisa/runtime/image.h
@@ -76,8 +76,8 @@ private:
         }(),
         storage, size, mip_levels} {}
 
-    Image(DeviceInterface *device, PixelStorage storage, uint2 size, byte* data,
-          uint mip_levels = 1u, bool simultaneous_access = false, bool allow_raster_target = false) noexcept
+    Image(DeviceInterface *device, PixelStorage storage, void* external_native_handle, uint2 size,
+          uint mip_levels, bool simultaneous_access = false, bool allow_raster_target = false) noexcept
         : Image{device,
                 [&] {
                     if (size.x == 0 || size.y == 0) [[unlikely]] {
@@ -87,7 +87,8 @@ private:
                         pixel_storage_to_format<T>(storage), 2u,
                         size.x, size.y, 1u,
                         detail::max_mip_levels(make_uint3(size, 1u), mip_levels),
-                        simultaneous_access, allow_raster_target, data);
+                        simultaneous_access, allow_raster_target,
+                        external_native_handle);
         }(),
         storage, size, mip_levels} {}
 

--- a/include/luisa/runtime/remote/client_interface.h
+++ b/include/luisa/runtime/remote/client_interface.h
@@ -46,7 +46,7 @@ public:
     [[nodiscard]] ResourceCreationInfo create_texture(
         PixelFormat format, uint dimension,
         uint width, uint height, uint depth,
-        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept override;
+        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
 
     // bindless array

--- a/include/luisa/runtime/remote/client_interface.h
+++ b/include/luisa/runtime/remote/client_interface.h
@@ -46,7 +46,8 @@ public:
     [[nodiscard]] ResourceCreationInfo create_texture(
         PixelFormat format, uint dimension,
         uint width, uint height, uint depth,
-        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
+        uint mipmap_levels, void* external_native_handle,
+        bool simultaneous_access, bool allow_raster_target) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
 
     // bindless array

--- a/include/luisa/runtime/rhi/device_interface.h
+++ b/include/luisa/runtime/rhi/device_interface.h
@@ -125,7 +125,8 @@ public:
     [[nodiscard]] virtual ResourceCreationInfo create_texture(
         PixelFormat format, uint dimension,
         uint width, uint height, uint depth,
-        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept = 0;
+        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target,
+        byte* external_buffer = nullptr) noexcept = 0;
     virtual void destroy_texture(uint64_t handle) noexcept = 0;
 
     // bindless array

--- a/src/backends/cuda/cuda_device.cpp
+++ b/src/backends/cuda/cuda_device.cpp
@@ -397,7 +397,7 @@ void CUDADevice::destroy_buffer(uint64_t handle) noexcept {
     });
 }
 
-ResourceCreationInfo CUDADevice::create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept {
+ResourceCreationInfo CUDADevice::create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept {
     auto p = with_handle([=] {
         auto array_format = cuda_array_format(format);
         auto channels = pixel_format_channel_count(format);

--- a/src/backends/cuda/cuda_device.h
+++ b/src/backends/cuda/cuda_device.h
@@ -148,7 +148,7 @@ public:
     BufferCreationInfo create_buffer(const Type *element, size_t elem_count, void *external_memory) noexcept override;
     BufferCreationInfo create_buffer(const ir::CArc<ir::Type> *element, size_t elem_count, void *external_memory) noexcept override;
     void destroy_buffer(uint64_t handle) noexcept override;
-    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept override;
+    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
     ResourceCreationInfo create_bindless_array(size_t size) noexcept override;
     void destroy_bindless_array(uint64_t handle) noexcept override;

--- a/src/backends/cuda/cuda_device.h
+++ b/src/backends/cuda/cuda_device.h
@@ -148,7 +148,8 @@ public:
     BufferCreationInfo create_buffer(const Type *element, size_t elem_count, void *external_memory) noexcept override;
     BufferCreationInfo create_buffer(const ir::CArc<ir::Type> *element, size_t elem_count, void *external_memory) noexcept override;
     void destroy_buffer(uint64_t handle) noexcept override;
-    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
+    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels,
+                                        void* external_native_handle, bool simultaneous_access, bool allow_raster_target) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
     ResourceCreationInfo create_bindless_array(size_t size) noexcept override;
     void destroy_bindless_array(uint64_t handle) noexcept override;

--- a/src/backends/dx/DXApi/LCDevice.cpp
+++ b/src/backends/dx/DXApi/LCDevice.cpp
@@ -225,7 +225,7 @@ ResourceCreationInfo LCDevice::create_texture(
     uint width,
     uint height,
     uint depth,
-    uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept {
+    uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, luisa::byte* external_buffer) noexcept {
     if (allow_raster_target) {
         if (simultaneous_access) {
             LUISA_INFO("DX do not allow simultaneous access texture as render target, set simultaneous_access = false");

--- a/src/backends/dx/DXApi/LCDevice.h
+++ b/src/backends/dx/DXApi/LCDevice.h
@@ -41,7 +41,7 @@ public:
     ResourceCreationInfo create_texture(
         PixelFormat format, uint dimension,
         uint width, uint height, uint depth,
-        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept override;
+        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, luisa::byte* external_buffer) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
 
     // bindless array

--- a/src/backends/fallback/fallback_device.cpp
+++ b/src/backends/fallback/fallback_device.cpp
@@ -162,14 +162,26 @@ BufferCreationInfo FallbackDevice::create_buffer(const ir::CArc<ir::Type> *eleme
 #endif
 }
 
-ResourceCreationInfo FallbackDevice::create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept {
-    auto texture = luisa::new_with_allocator<FallbackTexture>(
-        pixel_format_to_storage(format), dimension,
-        make_uint3(width, height, depth), mipmap_levels);
-    return {
-        .handle = reinterpret_cast<uint64_t>(texture),
-        .native_handle = texture->native_handle(),
-    };
+ResourceCreationInfo FallbackDevice::create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept {
+
+    if (external_buffer == nullptr) {
+        auto texture = luisa::new_with_allocator<FallbackTexture>(
+            pixel_format_to_storage(format), dimension,
+            make_uint3(width, height, depth), mipmap_levels);
+        return {
+            .handle = reinterpret_cast<uint64_t>(texture),
+            .native_handle = texture->native_handle(),
+        };
+    }
+    else {
+        auto texture = luisa::new_with_allocator<FallbackTexture>(
+            pixel_format_to_storage(format), dimension,
+            make_uint3(width, height, depth), mipmap_levels, reinterpret_cast<std::byte*>(external_buffer));
+        return {
+            .handle = reinterpret_cast<uint64_t>(texture),
+            .native_handle = texture->native_handle(),
+        };
+    }
 }
 
 ResourceCreationInfo FallbackDevice::create_stream(StreamTag stream_tag) noexcept {

--- a/src/backends/fallback/fallback_device.h
+++ b/src/backends/fallback/fallback_device.h
@@ -49,7 +49,7 @@ public:
     uint compute_warp_size() const noexcept override;
     BufferCreationInfo create_buffer(const Type *element, size_t elem_count, void *external_memory) noexcept override;
     BufferCreationInfo create_buffer(const ir::CArc<ir::Type> *element, size_t elem_count, void *external_memory) noexcept override;
-    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept override;
+    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
     ResourceCreationInfo create_stream(StreamTag stream_tag) noexcept override;
     void dispatch(uint64_t stream_handle, CommandList &&list) noexcept override;
     void set_stream_log_callback(uint64_t stream_handle, const StreamLogCallback &callback) noexcept override;

--- a/src/backends/fallback/fallback_texture.cpp
+++ b/src/backends/fallback/fallback_texture.cpp
@@ -124,8 +124,49 @@ FallbackTexture::FallbackTexture(PixelStorage storage, uint dim, uint3 size, uin
         _data = luisa::allocate_with_allocator<std::byte>(static_cast<size_t>(size_pixels) << _pixel_stride_shift);
     }
 }
+FallbackTexture::FallbackTexture(PixelStorage storage, uint dim, uint3 size, uint levels, std::byte *external_buffer)  noexcept
+    : _storage{storage}, _mip_levels{levels}, _dimension{dim} {
+    this->external = true;
+    if (_dimension == 2u) {
+        _pixel_stride_shift = std::bit_width(static_cast<uint>(pixel_storage_size(storage, make_uint3(1u)))) - 1u;
+        if (storage == PixelStorage::BC6 || storage == PixelStorage::BC7) {
+            _pixel_stride_shift = 0u;
+        }
+        _size[0] = size.x;
+        _size[1] = size.y;
+        _size[2] = 1u;
+        _mip_offsets[0] = 0u;
+        auto sz = make_uint2(size);
+        for (auto i = 1u; i < levels; i++) {
+            auto s = (sz + block_size - 1u) / block_size * block_size;
+            _mip_offsets[i] = _mip_offsets[i - 1u] + s.x * s.y;
+            sz = luisa::max(sz >> 1u, 1u);
+        }
+        auto s = (sz + block_size - 1u) / block_size * block_size;
+        auto size_pixels = _mip_offsets[levels - 1u] + s.x * s.y;
+        _data = external_buffer;
+    } else {
+        _pixel_stride_shift = std::bit_width(static_cast<uint>(pixel_storage_size(storage, make_uint3(1u)))) - 1u;
+        _size[0] = size.x;
+        _size[1] = size.y;
+        _size[2] = size.z;
+        _mip_offsets[0] = 0u;
+        for (auto i = 1u; i < levels; i++) {
+            auto s = (size + block_size - 1u) / block_size * block_size;
+            _mip_offsets[i] = _mip_offsets[i - 1u] + s.x * s.y * s.z;
+            size = luisa::max(size >> 1u, 1u);
+        }
+        auto s = (size + block_size - 1u) / block_size * block_size;
+        auto size_pixels = _mip_offsets[levels - 1u] + s.x * s.y * s.z;
+        _data = external_buffer;
+    }
+}
 
-FallbackTexture::~FallbackTexture() noexcept { luisa::deallocate_with_allocator(_data); }
+FallbackTexture::~FallbackTexture() noexcept {
+    if (!external) {
+        luisa::deallocate_with_allocator(_data);
+    }
+}
 
 FallbackTextureView FallbackTexture::view(uint level) const noexcept {
     auto size = luisa::max(make_uint3(_size[0], _size[1], _size[2]) >> level, 1u);

--- a/src/backends/fallback/fallback_texture.h
+++ b/src/backends/fallback/fallback_texture.h
@@ -301,9 +301,10 @@ private:
     uint _mip_levels : 8u;               // 19B
     uint _dimension : 8u;                // 20B
     std::array<uint, 15u> _mip_offsets{};// 80B
-
+    bool external{false};
 public:
     FallbackTexture(PixelStorage storage, uint dim, uint3 size, uint levels) noexcept;
+    FallbackTexture(PixelStorage storage, uint dim, uint3 size, uint levels, std::byte* external_buffer) noexcept;
     ~FallbackTexture() noexcept;
     FallbackTexture(FallbackTexture &&) noexcept = delete;
     FallbackTexture(const FallbackTexture &) noexcept = delete;

--- a/src/backends/metal/metal_device.cpp
+++ b/src/backends/metal/metal_device.cpp
@@ -311,7 +311,7 @@ void MetalDevice::destroy_buffer(uint64_t handle) noexcept {
 
 ResourceCreationInfo MetalDevice::create_texture(PixelFormat format, uint dimension,
                                                  uint width, uint height, uint depth, uint mipmap_levels,
-                                                 bool allow_simultaneous_access, bool allow_raster_target) noexcept {
+                                                 bool allow_simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept {
     return with_autorelease_pool([=, this] {
         auto texture = new_with_allocator<MetalTexture>(
             _handle, format, dimension, width, height, depth,

--- a/src/backends/metal/metal_device.h
+++ b/src/backends/metal/metal_device.h
@@ -60,7 +60,7 @@ public:
     BufferCreationInfo create_buffer(const Type *element, size_t elem_count, void *external_memory) noexcept override;
     BufferCreationInfo create_buffer(const ir::CArc<ir::Type> *element, size_t elem_count, void *external_memory) noexcept override;
     void destroy_buffer(uint64_t handle) noexcept override;
-    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept override;
+    ResourceCreationInfo create_texture(PixelFormat format, uint dimension, uint width, uint height, uint depth, uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
     ResourceCreationInfo create_bindless_array(size_t size) noexcept override;
     void destroy_bindless_array(uint64_t handle) noexcept override;

--- a/src/backends/validation/device.cpp
+++ b/src/backends/validation/device.cpp
@@ -120,7 +120,7 @@ void Device::destroy_buffer(uint64_t handle) noexcept {
 ResourceCreationInfo Device::create_texture(
     PixelFormat format, uint dimension,
     uint width, uint height, uint depth,
-    uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept {
+    uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept {
     auto tex = _native->create_texture(format, dimension, width, height, depth, mipmap_levels, simultaneous_access, allow_raster_target);
     new Texture{tex.handle, dimension, simultaneous_access, uint3(0, 0, 0), format};
     return tex;

--- a/src/backends/validation/device.h
+++ b/src/backends/validation/device.h
@@ -48,7 +48,7 @@ public:
     ResourceCreationInfo create_texture(
         PixelFormat format, uint dimension,
         uint width, uint height, uint depth,
-        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept override;
+        uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;
 
     // bindless array

--- a/src/runtime/remote/client_interface.cpp
+++ b/src/runtime/remote/client_interface.cpp
@@ -53,7 +53,7 @@ void ClientInterface::destroy_buffer(uint64_t handle) noexcept {
 ResourceCreationInfo ClientInterface::create_texture(
     PixelFormat format, uint dimension,
     uint width, uint height, uint depth,
-    uint mipmap_levels, bool simultaneous_access, bool allow_raster_target) noexcept {
+    uint mipmap_levels, bool simultaneous_access, bool allow_raster_target, byte* external_buffer) noexcept {
 
     ResourceCreationInfo r;
     r.handle = _flag++;


### PR DESCRIPTION
refactored create_texture with a pointer (default=nullptr) when trying to import the texture from an existing buffer.
this currently only applies to fallback backend.