### PR TITLE
Fix XIR DCE executable reachability

### DIFF
--- a/src/tests/unit/xir/test_xir_passes.cpp
+++ b/src/tests/unit/xir/test_xir_passes.cpp
@@ -1019,7 +1019,7 @@ void reg_dce() {
         expect(second.removed_block_count == 0u);
     };
 
-    "dce_structured_reachability_keeps_merge_and_loop_side_blocks"_test = [] {
+    "dce_exec_reachability_preserves_structured_cfg"_test = [] {
         Module m;
         BasicBlock *body;
         auto *k = make_kernel_with_body(m, body);
@@ -1060,8 +1060,196 @@ void reg_dce() {
         b.set_insertion_point(loop_merge);
         b.return_void();
         auto info = dce_pass_run_on_function(k);
-        expect(info.removed_block_count == 0u);
-        expect(count_reachable_blocks(k) == 11u);
+        expect(info.removed_block_count == 1u);
+        expect(count_reachable_blocks(k) == 10u);
+        expect(body->terminator()->isa<IfInst>());
+        expect(if_true->terminator()->isa<BranchInst>());
+        expect(if_false->terminator()->isa<UnreachableInst>());
+        expect(if_merge->terminator()->isa<SwitchInst>());
+        expect(sw_case->terminator()->isa<BranchInst>());
+        expect(sw_default->terminator()->isa<UnreachableInst>());
+        expect(sw_merge->terminator()->isa<LoopInst>());
+        auto *result_loop = static_cast<LoopInst *>(sw_merge->terminator());
+        expect(result_loop->prepare_block() == prepare);
+        expect(result_loop->body_block() == loop_body);
+        expect(result_loop->update_block() == update);
+        expect(result_loop->merge_block() == nullptr);
+    };
+
+    "dce_constant_cond_br_becomes_taken_branch"_test = [] {
+        Module m;
+        BasicBlock *entry;
+        auto *k = make_kernel_with_body(m, entry);
+        auto *taken = k->create_basic_block();
+        auto *dead = k->create_basic_block();
+        XIRBuilder b;
+        b.set_insertion_point(entry);
+        b.cond_br(m.create_constant_one(Type::of<bool>()), taken, dead);
+        b.set_insertion_point(taken);
+        b.return_void();
+        b.set_insertion_point(dead);
+        b.return_void();
+
+        auto info = dce_pass_run_on_function(k);
+        expect(info.removed_block_count == 1u);
+        expect(entry->terminator()->isa<BranchInst>());
+        expect(static_cast<BranchInst *>(entry->terminator())->target_block() == taken);
+        expect(count_reachable_blocks(k) == 2u);
+    };
+
+    "dce_constant_if_preserves_taken_break_in_loop_scope"_test = [] {
+        Module m;
+        BasicBlock *entry;
+        auto *k = make_kernel_with_body(m, entry);
+        XIRBuilder b;
+        b.set_insertion_point(entry);
+        auto *loop = b.loop();
+        auto *prepare = loop->create_prepare_block();
+        auto *loop_body = loop->create_body_block();
+        auto *update = loop->create_update_block();
+        auto *merge = loop->create_merge_block();
+
+        b.set_insertion_point(prepare);
+        b.br(loop_body);
+        b.set_insertion_point(loop_body);
+        auto *if_inst = b.if_(m.create_constant_one(Type::of<bool>()));
+        auto *if_true = if_inst->create_true_block();
+        auto *if_false = if_inst->create_false_block();
+        b.set_insertion_point(if_true);
+        b.break_(merge);
+        b.set_insertion_point(if_false);
+        b.continue_(update);
+        b.set_insertion_point(update);
+        b.br(prepare);
+        b.set_insertion_point(merge);
+        b.return_void();
+
+        (void)dce_pass_run_on_function(k);
+        expect(loop_body->terminator()->isa<IfInst>());
+        expect(if_true->terminator()->isa<BreakInst>());
+        expect(static_cast<BreakInst *>(if_true->terminator())->target_block() == merge);
+        expect(if_false->terminator()->isa<UnreachableInst>());
+        expect(loop->body_block() == loop_body);
+        expect(loop->update_block() == update);
+        expect(update->terminator()->isa<UnreachableInst>());
+        expect(loop->merge_block() == merge);
+    };
+
+    "dce_constant_switch_preserves_taken_continue_in_loop_scope"_test = [] {
+        Module m;
+        BasicBlock *entry;
+        auto *k = make_kernel_with_body(m, entry);
+        XIRBuilder b;
+        b.set_insertion_point(entry);
+        auto *loop = b.loop();
+        auto *prepare = loop->create_prepare_block();
+        auto *loop_body = loop->create_body_block();
+        auto *update = loop->create_update_block();
+        auto *merge = loop->create_merge_block();
+
+        b.set_insertion_point(prepare);
+        b.br(loop_body);
+        b.set_insertion_point(loop_body);
+        int32_t selector_value = 1;
+        auto *selector = m.create_constant(Type::of<int>(), &selector_value);
+        auto *switch_inst = b.switch_(selector);
+        auto *switch_case = switch_inst->create_case_block(1);
+        auto *switch_default = switch_inst->create_default_block();
+        b.set_insertion_point(switch_case);
+        b.continue_(update);
+        b.set_insertion_point(switch_default);
+        b.break_(merge);
+        b.set_insertion_point(update);
+        b.br(prepare);
+        b.set_insertion_point(merge);
+        b.return_void();
+
+        (void)dce_pass_run_on_function(k);
+        expect(loop_body->terminator()->isa<SwitchInst>());
+        expect(switch_case->terminator()->isa<ContinueInst>());
+        expect(static_cast<ContinueInst *>(switch_case->terminator())->target_block() == update);
+        expect(switch_default->terminator()->isa<UnreachableInst>());
+        expect(loop->body_block() == loop_body);
+        expect(loop->update_block() == update);
+        expect(loop->merge_block() == nullptr);
+    };
+
+    "dce_loop_preserves_dead_body_and_update_shells"_test = [] {
+        Module m;
+        BasicBlock *entry;
+        auto *k = make_kernel_with_body(m, entry);
+        XIRBuilder b;
+        b.set_insertion_point(entry);
+        auto *loop = b.loop();
+        auto *prepare = loop->create_prepare_block();
+        auto *loop_body = loop->create_body_block();
+        auto *update = loop->create_update_block();
+        auto *merge = loop->create_merge_block();
+        b.set_insertion_point(prepare);
+        b.cond_br(m.create_constant_zero(Type::of<bool>()), loop_body, merge);
+        b.set_insertion_point(loop_body);
+        b.br(update);
+        b.set_insertion_point(update);
+        b.br(prepare);
+        b.set_insertion_point(merge);
+        b.return_void();
+
+        (void)dce_pass_run_on_function(k);
+        expect(loop->prepare_block() == prepare);
+        expect(prepare->terminator()->isa<BranchInst>());
+        expect(static_cast<BranchInst *>(prepare->terminator())->target_block() == merge);
+        expect(loop->body_block() == loop_body);
+        expect(loop_body->terminator()->isa<UnreachableInst>());
+        expect(loop->update_block() == update);
+        expect(update->terminator()->isa<UnreachableInst>());
+        expect(loop->merge_block() == merge);
+        expect(count_reachable_blocks(k) == 3u);
+    };
+
+    "dce_clears_unreachable_if_merge_but_keeps_executable_unreachable"_test = [] {
+        Module m;
+        auto *k = m.create_kernel();
+        auto *condition = k->create_value_argument(Type::of<bool>());
+        auto *entry = k->create_body_block();
+        XIRBuilder b;
+        b.set_insertion_point(entry);
+        auto *if_inst = b.if_(condition);
+        auto *if_true = if_inst->create_true_block();
+        auto *if_false = if_inst->create_false_block();
+        auto *merge = if_inst->create_merge_block();
+        b.set_insertion_point(if_true);
+        b.unreachable_("executable unreachable");
+        b.set_insertion_point(if_false);
+        b.return_void();
+        b.set_insertion_point(merge);
+        b.return_void();
+
+        (void)dce_pass_run_on_function(k);
+        expect(if_inst->merge_block() == nullptr);
+        expect(if_true->terminator()->isa<UnreachableInst>());
+        expect(static_cast<UnreachableInst *>(if_true->terminator())->message() == "executable unreachable");
+        expect(count_reachable_blocks(k) == 3u);
+    };
+
+    "dce_keeps_reachable_self_loop_and_removes_disconnected_cycle"_test = [] {
+        Module m;
+        BasicBlock *entry;
+        auto *k = make_kernel_with_body(m, entry);
+        auto *dead_a = k->create_basic_block();
+        auto *dead_b = k->create_basic_block();
+        XIRBuilder b;
+        b.set_insertion_point(entry);
+        b.br(entry);
+        b.set_insertion_point(dead_a);
+        b.br(dead_b);
+        b.set_insertion_point(dead_b);
+        b.br(dead_a);
+
+        auto info = dce_pass_run_on_function(k);
+        expect(info.removed_block_count == 2u);
+        expect(entry->terminator()->isa<BranchInst>());
+        expect(static_cast<BranchInst *>(entry->terminator())->target_block() == entry);
+        expect(count_reachable_blocks(k) == 1u);
     };
 }
 

--- a/src/xir/passes/autodiff.cpp
+++ b/src/xir/passes/autodiff.cpp
@@ -1182,24 +1182,29 @@ struct TransformAdScope {
         }
         if (auto if_inst = block->terminator(); if_inst != nullptr && if_inst->isa<IfInst>()) {
             auto structured_if = static_cast<IfInst *>(if_inst);
+            auto structured_merge = structured_if->merge_block();
             LUISA_ASSERT(owns_block(structured_if->true_block()) &&
                              owns_block(structured_if->false_block()) &&
-                             owns_block(structured_if->merge_block()),
+                             (structured_merge == nullptr || owns_block(structured_merge)),
                          "Invalid XIR if region in autodiff scope.");
             snapshot_if_condition(structured_if);
             luisa::vector<Instruction *> true_emit;
             luisa::vector<Instruction *> false_emit;
-            auto found = collect_forward(structured_if->true_block(), structured_if->merge_block(), visited, true_emit);
-            found |= collect_forward(structured_if->false_block(), structured_if->merge_block(), visited, false_emit);
+            // A null structured merge means the arms do not rejoin. Bound their
+            // traversal by the enclosing region instead.
+            auto branch_merge = structured_merge == nullptr ? merge : structured_merge;
+            auto found = collect_forward(structured_if->true_block(), branch_merge, visited, true_emit);
+            found |= collect_forward(structured_if->false_block(), branch_merge, visited, false_emit);
             if_true_backward_emit_instructions[structured_if] = std::move(true_emit);
             if_false_backward_emit_instructions[structured_if] = std::move(false_emit);
-            if (found) { return true; }
-            return collect_forward(structured_if->merge_block(), merge, visited, emit_instructions);
+            if (found || structured_merge == nullptr) { return found; }
+            return collect_forward(structured_merge, merge, visited, emit_instructions);
         }
         if (auto switch_inst = block->terminator(); switch_inst != nullptr && switch_inst->isa<SwitchInst>()) {
             auto structured_switch = static_cast<SwitchInst *>(switch_inst);
+            auto structured_merge = structured_switch->merge_block();
             LUISA_ASSERT(owns_block(structured_switch->default_block()) &&
-                             owns_block(structured_switch->merge_block()),
+                             (structured_merge == nullptr || owns_block(structured_merge)),
                          "Invalid XIR switch region in autodiff scope.");
             for (auto i = 0u; i < structured_switch->case_count(); i++) {
                 LUISA_ASSERT(owns_block(structured_switch->case_block(i)),
@@ -1209,14 +1214,15 @@ struct TransformAdScope {
             luisa::vector<Instruction *> default_emit;
             luisa::vector<luisa::vector<Instruction *>> case_emits;
             case_emits.resize(structured_switch->case_count());
-            auto found = collect_forward(structured_switch->default_block(), structured_switch->merge_block(), visited, default_emit);
+            auto branch_merge = structured_merge == nullptr ? merge : structured_merge;
+            auto found = collect_forward(structured_switch->default_block(), branch_merge, visited, default_emit);
             for (auto i = 0u; i < structured_switch->case_count(); i++) {
-                found |= collect_forward(structured_switch->case_block(i), structured_switch->merge_block(), visited, case_emits[i]);
+                found |= collect_forward(structured_switch->case_block(i), branch_merge, visited, case_emits[i]);
             }
             switch_default_backward_emit_instructions[structured_switch] = std::move(default_emit);
             switch_case_backward_emit_instructions[structured_switch] = std::move(case_emits);
-            if (found) { return true; }
-            return collect_forward(structured_switch->merge_block(), merge, visited, emit_instructions);
+            if (found || structured_merge == nullptr) { return found; }
+            return collect_forward(structured_merge, merge, visited, emit_instructions);
         }
         if (auto loop_inst = block->terminator(); loop_inst != nullptr &&
                                                 (loop_inst->isa<LoopInst>() || loop_inst->isa<SimpleLoopInst>())) {

--- a/src/xir/passes/dce.cpp
+++ b/src/xir/passes/dce.cpp
@@ -106,62 +106,6 @@ static void eliminate_dead_alloca_in_function(Function *function, DCEInfo &info)
     }
 }
 
-[[nodiscard]] static bool is_block_terminated_by_unreachable(BasicBlock *block) noexcept {
-    if (!block->is_terminated()) { return false; }
-    return block->terminator()->isa<UnreachableInst>();
-}
-
-[[nodiscard]] static BasicBlock *find_owned_block(Value *value, const luisa::unordered_set<BasicBlock *> &owned) noexcept {
-    if (value == nullptr) { return nullptr; }
-    for (auto block : owned) {
-        if (static_cast<Value *>(block) == value) { return block; }
-    }
-    return nullptr;
-}
-
-template<typename Visit>
-void traverse_structural_successors(BasicBlock *block, const luisa::unordered_set<BasicBlock *> &owned,
-                                    Visit &&visit) noexcept {
-    if (block == nullptr || !block->is_terminated()) { return; }
-    auto *term = block->terminator();
-    // Break/Continue targets jump OUT of the current structured region
-    // (to loop merge/body blocks). They are not structural successors
-    // within the dead region being collected.
-    if (term->isa<BreakInst>() || term->isa<ContinueInst>()) { return; }
-    for (auto use : term->operand_uses()) {
-        if (auto *succ = find_owned_block(use->value(), owned)) { visit(succ); }
-    }
-    if (auto *merge = term->control_flow_merge(); merge != nullptr) {
-        if (auto *merge_block = merge->merge_block(); merge_block != nullptr && owned.contains(merge_block)) {
-            visit(merge_block);
-        }
-    }
-    if (term->isa<LoopInst>()) {
-        auto *loop = static_cast<LoopInst *>(term);
-        if (auto *body = loop->body_block(); body != nullptr && owned.contains(body)) { visit(body); }
-        if (auto *update = loop->update_block(); update != nullptr && owned.contains(update)) { visit(update); }
-    }
-}
-
-luisa::unordered_set<BasicBlock *> collect_structurally_reachable_blocks(FunctionDefinition *definition) noexcept {
-    luisa::unordered_set<BasicBlock *> reachable;
-    luisa::unordered_set<BasicBlock *> owned;
-    for (auto block : definition->basic_blocks()) { owned.emplace(block); }
-    luisa::vector<BasicBlock *> work_list;
-    auto add_to_work_list = [&](BasicBlock *block) noexcept {
-        if (block != nullptr && reachable.emplace(block).second) {
-            work_list.emplace_back(block);
-        }
-    };
-    add_to_work_list(definition->body_block());
-    while (!work_list.empty()) {
-        auto *block = work_list.back();
-        work_list.pop_back();
-        traverse_structural_successors(block, owned, add_to_work_list);
-    }
-    return reachable;
-}
-
 void eliminate_instructions_in_unreachable_blocks(const luisa::unordered_set<BasicBlock *> &blocks, DCEInfo &info) noexcept {
     luisa::vector<ManagedPtr<Instruction>> removed_instructions;
     for (auto b : blocks) {
@@ -188,50 +132,18 @@ void eliminate_instructions_in_unreachable_blocks(const luisa::unordered_set<Bas
 void remove_phi_incomings_from_blocks(FunctionDefinition *definition,
                                       const luisa::unordered_set<BasicBlock *> &blocks) noexcept {
     if (blocks.empty()) { return; }
-    definition->traverse_instructions([&](Instruction *inst) noexcept {
-        if (!inst->isa<PhiInst>()) { return; }
-        auto *phi = static_cast<PhiInst *>(inst);
-        for (size_t i = phi->incoming_count(); i-- > 0u;) {
-            if (blocks.contains(phi->incoming(i).block)) {
-                phi->remove_incoming(i);
-            }
-        }
-    });
-}
-
-void propagate_unreachable_marks_in_function(Function *function, DCEInfo &info) noexcept {
-    if (auto definition = function->definition()) {
-        luisa::vector<BasicBlock *> postorder;
-        definition->traverse_basic_blocks(BasicBlockTraversalOrder::POST_ORDER, [&](BasicBlock *block) noexcept {
-            postorder.emplace_back(block);
-        });
-        luisa::unordered_set<BasicBlock *> unreachable;
-        for (;;) {
-            auto prev_reachable_count = unreachable.size();
-            for (auto block : postorder) {
-                if (!unreachable.contains(block)) {
-                    if (is_block_terminated_by_unreachable(block)) {
-                        unreachable.emplace(block);
-                    } else {
-                        auto has_any_successor = false;
-                        auto all_successors_unreachable = true;
-                        block->traverse_successors(false, [&](BasicBlock *succ) noexcept {
-                            has_any_successor = true;
-                            if (succ != block && !unreachable.contains(succ) &&
-                                !is_block_terminated_by_unreachable(succ)) {
-                                all_successors_unreachable = false;
-                            }
-                        });
-                        if (has_any_successor && all_successors_unreachable) {
-                            unreachable.emplace(block);
-                        }
+    for (auto block : definition->basic_blocks()) {
+        if (!blocks.contains(block)) {
+            block->traverse_instructions([&](Instruction *inst) noexcept {
+                if (!inst->isa<PhiInst>()) { return; }
+                auto *phi = static_cast<PhiInst *>(inst);
+                for (size_t i = phi->incoming_count(); i-- > 0u;) {
+                    if (blocks.contains(phi->incoming(i).block)) {
+                        phi->remove_incoming(i);
                     }
                 }
-            }
-            if (unreachable.size() == prev_reachable_count) { break; }
+            });
         }
-        remove_phi_incomings_from_blocks(definition, unreachable);
-        eliminate_instructions_in_unreachable_blocks(unreachable, info);
     }
 }
 
@@ -263,88 +175,156 @@ void propagate_unreachable_marks_in_function(Function *function, DCEInfo &info) 
     }();
 }
 
-void collect_unreachable_region(BasicBlock *entry, BasicBlock *merge,
-                                const luisa::unordered_set<BasicBlock *> &owned,
-                                luisa::unordered_set<BasicBlock *> &unreachable) noexcept {
-    luisa::vector<BasicBlock *> work_list;
-    auto add_to_work_list = [&](BasicBlock *block) noexcept {
-        if (block != nullptr && block != merge && owned.contains(block) && unreachable.emplace(block).second) {
-            work_list.emplace_back(block);
+void canonicalize_static_unstructured_branches_in_function(
+    FunctionDefinition *definition, DCEInfo &info) noexcept {
+    // If/Switch/Loop terminators define lexical scopes for source codegen and must
+    // stay structured. Only a genuinely unstructured conditional branch can be
+    // replaced with an unconditional branch here.
+    luisa::vector<std::pair<ConditionalBranchInst *, BasicBlock *>> replacements;
+    for (auto block : definition->basic_blocks()) {
+        if (!block->is_terminated()) { continue; }
+        if (auto terminator = block->terminator(); terminator->isa<ConditionalBranchInst>()) {
+            auto cond_br = static_cast<ConditionalBranchInst *>(terminator);
+            if (auto static_cond = try_evaluate_static_branch_condition(cond_br->condition())) {
+                if (auto taken = *static_cond ? cond_br->true_block() : cond_br->false_block()) {
+                    replacements.emplace_back(cond_br, taken);
+                }
+            }
         }
-    };
-    add_to_work_list(entry);
-    while (!work_list.empty()) {
-        auto block = work_list.back();
-        work_list.pop_back();
-        traverse_structural_successors(block, owned, add_to_work_list);
+    }
+    for (auto [cond_br, taken] : replacements) {
+        auto block = cond_br->parent_block();
+        auto removed = cond_br->remove_self();
+        XIRBuilder builder;
+        builder.set_insertion_point(block);
+        auto branch = builder.br(taken);
+        for (auto metadata : removed->metadata_list()) {
+            branch->metadata_list().push_front(metadata->clone());
+        }
+        info.removed_inst_count++;
     }
 }
 
-void eliminate_unreachable_blocks_in_function(Function *function, DCEInfo &info, luisa::vector<ManagedPtr<BasicBlock>> &removed_blocks) noexcept {
-    if (auto definition = function->definition()) {
-        auto reachable = collect_structurally_reachable_blocks(definition);
-        luisa::unordered_set<BasicBlock *> owned;
-        for (auto *block : definition->basic_blocks()) { owned.emplace(block); }
-        luisa::unordered_set<BasicBlock *> unreachable;
-        for (auto *block : reachable) {
-            if (!block->is_terminated()) { continue; }
-            switch (auto terminator = block->terminator(); terminator->derived_instruction_tag()) {
-                case DerivedInstructionTag::IF: [[fallthrough]];
-                case DerivedInstructionTag::CONDITIONAL_BRANCH: {
-                    auto cond_br_inst = static_cast<ConditionalBranchTerminatorInstruction *>(terminator);
-                    if (auto static_cond = try_evaluate_static_branch_condition(cond_br_inst->condition())) {
-                        auto dead = *static_cond ? cond_br_inst->false_block() : cond_br_inst->true_block();
-                        auto merge = terminator->control_flow_merge();
-                        if (merge != nullptr && merge->merge_block() != nullptr) {
-                            collect_unreachable_region(dead, merge->merge_block(), owned, unreachable);
-                        } else if (dead != nullptr && owned.contains(dead)) {
-                            unreachable.emplace(dead);
-                        }
+template<typename Visit>
+void traverse_executable_successors(BasicBlock *block, Visit &&visit) noexcept {
+    auto terminator = block->terminator();
+    switch (terminator->derived_instruction_tag()) {
+        case DerivedInstructionTag::IF: [[fallthrough]];
+        case DerivedInstructionTag::CONDITIONAL_BRANCH: {
+            auto cond_br = static_cast<ConditionalBranchTerminatorInstruction *>(terminator);
+            if (auto static_cond = try_evaluate_static_branch_condition(cond_br->condition())) {
+                visit(*static_cond ? cond_br->true_block() : cond_br->false_block());
+            } else {
+                visit(cond_br->true_block());
+                visit(cond_br->false_block());
+            }
+            break;
+        }
+        case DerivedInstructionTag::SWITCH: {
+            auto switch_inst = static_cast<SwitchInst *>(terminator);
+            if (auto static_cond = try_evaluate_static_switch_condition(switch_inst->value())) {
+                auto taken = switch_inst->default_block();
+                for (size_t i = 0u; i < switch_inst->case_count(); i++) {
+                    if (switch_inst->case_value(i) == *static_cond) {
+                        taken = switch_inst->case_block(i);
+                        break;
                     }
-                    break;
                 }
-                case DerivedInstructionTag::SWITCH: {
-                    auto switch_inst = static_cast<SwitchInst *>(terminator);
-                    if (auto static_cond = try_evaluate_static_switch_condition(switch_inst->value())) {
-                        auto any_match = false;
-                        for (size_t i = 0; i < switch_inst->case_count(); i++) {
-                            if (switch_inst->case_value(i) == *static_cond) {
-                                any_match = true;
-                            } else {
-                                LUISA_DEBUG_ASSERT(switch_inst->case_block(i) != nullptr, "Switch case block must not be null.");
-                                collect_unreachable_region(switch_inst->case_block(i), switch_inst->merge_block(), owned, unreachable);
-                            }
-                        }
-                        if (any_match) {
-                            LUISA_DEBUG_ASSERT(switch_inst->default_block() != nullptr, "Switch default block must not be null.");
-                            collect_unreachable_region(switch_inst->default_block(), switch_inst->merge_block(), owned, unreachable);
-                        }
-                    }
-                    break;
-                }
-                default: break;
-            }
-        }
-        for (auto *block : definition->basic_blocks()) {
-            if (!reachable.contains(block)) {
-                unreachable.emplace(block);
-            }
-        }
-        remove_phi_incomings_from_blocks(definition, unreachable);
-        eliminate_instructions_in_unreachable_blocks(unreachable, info);
-        {
-            luisa::vector<BasicBlock *> work_list;
-            for (auto block : definition->basic_blocks()) {
-                if (block != definition->body_block() && block->use_list().empty() &&
-                    !reachable.contains(block)) {
-                    work_list.emplace_back(block);
+                visit(taken);
+            } else {
+                visit(switch_inst->default_block());
+                for (size_t i = 0u; i < switch_inst->case_count(); i++) {
+                    visit(switch_inst->case_block(i));
                 }
             }
-            for (auto block : work_list) {
-                removed_blocks.emplace_back(block->remove_self());
-                info.removed_block_count++;
+            break;
+        }
+        default: {
+            block->traverse_successors(false, [&](BasicBlock *successor) noexcept {
+                visit(successor);
+            });
+            break;
+        }
+    }
+}
+
+[[nodiscard]] luisa::unordered_set<BasicBlock *> collect_exec_reachable_blocks(
+    FunctionDefinition *definition) noexcept {
+    luisa::unordered_set<BasicBlock *> reachable;
+    luisa::unordered_set<BasicBlock *> owned;
+    for (auto block : definition->basic_blocks()) { owned.emplace(block); }
+    luisa::vector<BasicBlock *> work_list;
+    auto add_to_work_list = [&](BasicBlock *block) noexcept {
+        if (block != nullptr && owned.contains(block) && reachable.emplace(block).second) {
+            work_list.emplace_back(block);
+        }
+    };
+    add_to_work_list(definition->body_block());
+    while (!work_list.empty()) {
+        auto block = work_list.back();
+        work_list.pop_back();
+        if (block->is_terminated()) {
+            traverse_executable_successors(block, [&](BasicBlock *successor) noexcept {
+                add_to_work_list(successor);
+            });
+        }
+    }
+    return reachable;
+}
+
+void repair_dead_control_flow_merges(
+    FunctionDefinition *definition,
+    const luisa::unordered_set<BasicBlock *> &exec_reachable) noexcept {
+    for (auto block : definition->basic_blocks()) {
+        if (!exec_reachable.contains(block) || !block->is_terminated()) { continue; }
+        auto terminator = block->terminator();
+        if (auto merge = terminator->control_flow_merge()) {
+            if (auto merge_block = merge->merge_block();
+                merge_block != nullptr && !exec_reachable.contains(merge_block)) {
+                merge->set_merge_block(nullptr);
             }
         }
+    }
+}
+
+[[nodiscard]] luisa::unordered_set<BasicBlock *> collect_structural_shell_blocks(
+    FunctionDefinition *definition,
+    const luisa::unordered_set<BasicBlock *> &exec_reachable) noexcept {
+    // Loop body/update are structural raw pointers rather than CFG operands. Keep
+    // their blocks as unreachable shells when the loop itself is executable so
+    // source codegen retains the lexical loop frame.
+    luisa::unordered_set<BasicBlock *> shells;
+    for (auto block : definition->basic_blocks()) {
+        if (!exec_reachable.contains(block) || !block->is_terminated()) { continue; }
+        if (auto terminator = block->terminator(); terminator->isa<LoopInst>()) {
+            auto loop = static_cast<LoopInst *>(terminator);
+            if (auto body = loop->body_block()) { shells.emplace(body); }
+            if (auto update = loop->update_block()) { shells.emplace(update); }
+        }
+    }
+    return shells;
+}
+
+void eliminate_unreachable_blocks_in_function(
+    FunctionDefinition *definition, const luisa::unordered_set<BasicBlock *> &exec_reachable,
+    DCEInfo &info, luisa::vector<ManagedPtr<BasicBlock>> &removed_blocks) noexcept {
+    auto structural_shells = collect_structural_shell_blocks(definition, exec_reachable);
+    luisa::unordered_set<BasicBlock *> unreachable;
+    for (auto block : definition->basic_blocks()) {
+        if (!exec_reachable.contains(block)) { unreachable.emplace(block); }
+    }
+    remove_phi_incomings_from_blocks(definition, unreachable);
+    eliminate_instructions_in_unreachable_blocks(unreachable, info);
+    luisa::vector<BasicBlock *> to_remove;
+    for (auto block : definition->basic_blocks()) {
+        if (block != definition->body_block() && unreachable.contains(block) &&
+            !structural_shells.contains(block) && block->use_list().empty()) {
+            to_remove.emplace_back(block);
+        }
+    }
+    for (auto block : to_remove) {
+        removed_blocks.emplace_back(block->remove_self());
+        info.removed_block_count++;
     }
 }
 
@@ -370,21 +350,6 @@ void fix_phi_nodes_in_function(Function *function, luisa::vector<PhiInst *> &phi
     }
 }
 
-void fix_control_flow_merges_in_function(Function *function) noexcept {
-    if (auto definition = function->definition()) {
-        definition->traverse_basic_blocks([&](BasicBlock *block) noexcept {
-            auto term = block->terminator();
-            if (auto merge = term->control_flow_merge()) {
-                if (term->isa<LoopInst>() || term->isa<SimpleLoopInst>()) { return; }
-                if (auto merge_block = merge->merge_block();
-                    merge_block != nullptr && is_block_terminated_by_unreachable(merge_block)) {
-                    merge->set_merge_block(nullptr);
-                }
-            }
-        });
-    }
-}
-
 static void eliminate_redundant_phi_nodes(luisa::vector<PhiInst *> &phi_nodes, DCEInfo &info) noexcept {
     for (;;) {
         auto prev_size = phi_nodes.size();
@@ -399,24 +364,27 @@ static void eliminate_redundant_phi_nodes(luisa::vector<PhiInst *> &phi_nodes, D
 
 void run_dce_pass_on_function(Function *function, DCEInfo &info) noexcept {
     if (auto definition = function->definition()) {
-        definition->traverse_basic_blocks([&](BasicBlock *block) noexcept {
+        for (auto block : definition->basic_blocks()) {
             if (!block->is_terminated()) {
                 XIRBuilder builder;
                 builder.set_insertion_point(block);
                 builder.unreachable_();
             }
-        });
+        }
     }
     luisa::vector<ManagedPtr<BasicBlock>> removed_blocks;
     for (;;) {
         auto prev_count = info.removed_inst_count + info.removed_block_count;
-        propagate_unreachable_marks_in_function(function, info);
-        eliminate_unreachable_blocks_in_function(function, info, removed_blocks);
-        fix_control_flow_merges_in_function(function);
-        {
-            luisa::vector<PhiInst *> phi_nodes;
-            fix_phi_nodes_in_function(function, phi_nodes);
-            eliminate_redundant_phi_nodes(phi_nodes, info);
+        if (auto definition = function->definition()) {
+            canonicalize_static_unstructured_branches_in_function(definition, info);
+            auto exec_reachable = collect_exec_reachable_blocks(definition);
+            repair_dead_control_flow_merges(definition, exec_reachable);
+            eliminate_unreachable_blocks_in_function(definition, exec_reachable, info, removed_blocks);
+            {
+                luisa::vector<PhiInst *> phi_nodes;
+                fix_phi_nodes_in_function(function, phi_nodes);
+                eliminate_redundant_phi_nodes(phi_nodes, info);
+            }
         }
         eliminate_dead_code_in_function(function, info);
         eliminate_dead_alloca_in_function(function, info);


### PR DESCRIPTION
## Summary

- compute DCE reachability from executable CFG edges, with constant-aware handling for conditional branches, structured `IfInst`, and `SwitchInst`
- fold only constant unstructured `ConditionalBranchInst` into `BranchInst`; preserve structured `IfInst`, `SwitchInst`, `LoopInst`, break, and continue semantics
- clear unreachable merge annotations, keep required loop body/update structural shells, repair PHIs, and remove disconnected dead regions
- make reverse-mode autodiff traversal accept structured control flow whose unreachable merge was cleared by DCE

## Tests

- built `test_xir_passes` and its XIR dependencies
- ran all 12 DCE tests individually: 12/12 passed
- ran all 30 autodiff tests individually: 30/30 passed
- full `test_xir_passes` run completes without a DCE/autodiff crash; 163/164 tests pass, with the unrelated `loop_unroll_trip_count_exceeds_max_not_unrolled` assertion still failing
