### PR TITLE
Fix DX shader cache cleanup on adapter mismatch

### DIFF
--- a/src/backends/dx/DXRuntime/Device.cpp
+++ b/src/backends/dx/DXRuntime/Device.cpp
@@ -317,11 +317,13 @@ Device::Device(Context &&ctx, DeviceConfig const *settings)
             if (adapter == nullptr) { LUISA_ERROR_WITH_LOCATION("Failed to create DirectX device at index {}.", index); }
         }
         {
-            auto adapter_id_stream = file_io->read_shader_cache("dx_adapterid");
             bool same_adaptor = false;
-            if (adapter_id_stream) {
-                auto blob = adapter_id_stream->read(~0ull);
-                same_adaptor = blob.size() == sizeof(vstd::MD5) && std::memcmp(blob.data(), &adapter_id, sizeof(vstd::MD5)) == 0;
+            {
+                auto adapter_id_stream = file_io->read_shader_cache("dx_adapterid");
+                if (adapter_id_stream) {
+                    auto blob = adapter_id_stream->read(~0ull);
+                    same_adaptor = blob.size() == sizeof(vstd::MD5) && std::memcmp(blob.data(), &adapter_id, sizeof(vstd::MD5)) == 0;
+                }
             }
             if (!same_adaptor) {
                 LUISA_INFO("Adapter mismatch, shader cache cleared.");


### PR DESCRIPTION
## Summary

- release the cached DirectX adapter ID stream before clearing the shader cache
- prevent a Windows sharing violation when the selected adapter differs from the cached adapter ID

## Root cause

`read_shader_cache("dx_adapterid")` returns a `LockedBinaryFileStream` that owns an open `FILE *`. On an adapter mismatch, `clear_shader_cache()` was called while that stream was still alive in the same scope. Windows therefore refused to remove `.cache/dx_adapterid`, and the fatal cache removal error aborted device creation.

## Fix

Limit the adapter ID stream to an inner scope so its file handle is closed before `clear_shader_cache()` removes the cache entries.

## Verification

- built `lc-backend-dx` successfully on Windows
- started with an existing mismatched 16-byte `dx_adapterid`; the cache was cleared and the application completed one frame with exit code 0
- started again with the rewritten adapter ID; the warm-cache path completed one frame with exit code 0 and did not report another mismatch

Command used for both startup checks:

```text
xmake run lcp_examples_dfsph --scene dam-break --frames 1
```
