### PR TITLE
Fix/dx adapter cache file lock

### DIFF
--- a/src/backends/dx/DXRuntime/Device.cpp
+++ b/src/backends/dx/DXRuntime/Device.cpp
@@ -318,12 +318,13 @@ Device::Device(Context &&ctx, DeviceConfig const *settings)
         }
         {
             auto adapter_id_stream = file_io->read_shader_cache("dx_adapterid");
-            bool same_adaptor = false;
+            bool same_adapter = false;
             if (adapter_id_stream) {
                 auto blob = adapter_id_stream->read(~0ull);
-                same_adaptor = blob.size() == sizeof(vstd::MD5) && std::memcmp(blob.data(), &adapter_id, sizeof(vstd::MD5)) == 0;
+                same_adapter = blob.size() == sizeof(vstd::MD5) && std::memcmp(blob.data(), &adapter_id, sizeof(vstd::MD5)) == 0;
             }
-            if (!same_adaptor) {
+            adapter_id_stream.reset();
+            if (!same_adapter) {
                 LUISA_INFO("Adapter mismatch, shader cache cleared.");
                 file_io->clear_shader_cache();
             }

--- a/src/backends/dx/DXRuntime/Device.cpp
+++ b/src/backends/dx/DXRuntime/Device.cpp
@@ -323,7 +323,6 @@ Device::Device(Context &&ctx, DeviceConfig const *settings)
                 auto blob = adapter_id_stream->read(~0ull);
                 same_adaptor = blob.size() == sizeof(vstd::MD5) && std::memcmp(blob.data(), &adapter_id, sizeof(vstd::MD5)) == 0;
             }
-            adapter_id_stream.reset();
             if (!same_adaptor) {
                 LUISA_INFO("Adapter mismatch, shader cache cleared.");
                 file_io->clear_shader_cache();

--- a/src/backends/dx/DXRuntime/Device.cpp
+++ b/src/backends/dx/DXRuntime/Device.cpp
@@ -323,6 +323,7 @@ Device::Device(Context &&ctx, DeviceConfig const *settings)
                 auto blob = adapter_id_stream->read(~0ull);
                 same_adaptor = blob.size() == sizeof(vstd::MD5) && std::memcmp(blob.data(), &adapter_id, sizeof(vstd::MD5)) == 0;
             }
+            adapter_id_stream.reset();
             if (!same_adaptor) {
                 LUISA_INFO("Adapter mismatch, shader cache cleared.");
                 file_io->clear_shader_cache();


### PR DESCRIPTION
## Summary

- close the cached DirectX adapter ID stream before invalidating the shader cache
- allow the shader cache to be regenerated after the selected adapter changes

## Root cause

The DirectX backend stores a 16-byte adapter ID in `.cache/dx_adapterid` and invalidates the shader cache when the selected adapter no longer matches it.

This issue was observed after switching from an NVIDIA discrete GPU to an AMD integrated GPU while retaining the existing runtime cache.

The adapter mismatch was detected correctly, but `adapter_id_stream` still owned an open `FILE *` when `clear_shader_cache()` attempted to remove the cache entries. Windows rejected removal of the open `dx_adapterid` file, causing a fatal error before the current adapter ID could be written. Subsequent launches therefore encountered the same stale adapter ID again.

## Fix

Explicitly reset `adapter_id_stream` before clearing the shader cache. This closes the file handle before `remove_all()` processes `dx_adapterid`.

The local comparison variable is also renamed from `same_adaptor` to `same_adapter`.

## Verification

Tested on Windows x64 with a D3D12-capable adapter using LuisaCompute's `example_helloworld` target. All commands below were run after applying this change.

```powershell
xmake build example_helloworld

# Seed the cache with the current adapter ID.
& .\bin\release\example_helloworld.exe dx

$adapter_id_path = (Resolve-Path ".\bin\release\.cache\dx_adapterid").Path
$expected_adapter_id = [IO.File]::ReadAllBytes($adapter_id_path)

# Preserve the valid 16-byte format while simulating an ID from another adapter.
$stale_adapter_id = [byte[]]$expected_adapter_id.Clone()
$stale_adapter_id[0] = [byte]($stale_adapter_id[0] -bxor 1)
[IO.File]::WriteAllBytes($adapter_id_path, $stale_adapter_id)

# Exercise the mismatch path with the patched binary.
# Expected: cache cleanup succeeds and the process exits normally.
& .\bin\release\example_helloworld.exe dx

# After applying this fix, run again to verify that the updated adapter ID is reused.
# Expected: no adapter mismatch is reported.
& .\bin\release\example_helloworld.exe dx
```
