### PR TITLE
fix(cuda): signal callback semaphore via cuLaunchHostFunc to fix cros…

### DIFF
--- a/src/backends/cuda/cuda_stream.cpp
+++ b/src/backends/cuda/cuda_stream.cpp
@@ -145,19 +145,15 @@ void CUDAStream::callback(CUDAStream::CallbackContainer &&callbacks) noexcept {
     if (!callbacks.empty()) {
         // signal that the stream has been dispatched
         auto ticket = 1u + _current_ticket.fetch_add(1u, std::memory_order_relaxed);
-        if (_callback_semaphore_device) {
-            LUISA_CHECK_CUDA(cuStreamWriteValue64(_stream, _callback_semaphore_device,
-                                                  ticket, CU_STREAM_WRITE_VALUE_DEFAULT));
-        } else {
-            auto update = StreamCallbackSemaphoreUpdate::create(_callback_semaphore, ticket);
-            LUISA_CHECK_CUDA(cuLaunchHostFunc(
-                _stream,
-                [](void *data) noexcept {
-                    auto update = static_cast<StreamCallbackSemaphoreUpdate *>(data);
-                    update->recycle();
-                },
-                update));
-        }
+        // signal via cuLaunchHostFunc so the driver orders the host write after the stream's prior DMAs
+        auto update = StreamCallbackSemaphoreUpdate::create(_callback_semaphore, ticket);
+        LUISA_CHECK_CUDA(cuLaunchHostFunc(
+            _stream,
+            [](void *data) noexcept {
+                auto update = static_cast<StreamCallbackSemaphoreUpdate *>(data);
+                update->recycle();
+            },
+            update));
         // enqueue callbacks
         {
             CallbackPackage package{


### PR DESCRIPTION
## Summary
The race is triggered by uploads split across **multiple dispatches** — each `stream << buf.copy_from(...);` statement is its own dispatch with no intermediate `synchronize`:

```cpp
// cross-dispatch uploads: each line is a separate dispatch, no sync between
stream << buffer_A.copy_from(vector_A.data());
stream << buffer_B.copy_from(vector_B.data());
stream << buffer_C.copy_from(vector_C.data());
stream << synchronize();
// With many small buffers this intermittently corrupts B/C with A's staging data.
```
`CUDAStream::callback()` signaled its recycling-ticket semaphore with `cuStreamWriteValue64` on the fast path. That write is a GPU-side write to device-mapped host memory; the callback thread polls it from the host with only cache-coherence visibility, so it can recycle an upload staging region before the region's `cuMemcpyHtoDAsync` completes. A later dispatch then reuses that staging and the wrong buffer's data lands in the wrong device buffer. This PR signals unconditionally via `cuLaunchHostFunc`, whose host callback the driver invokes only after the stream's prior DMAs finish, giving a driver-guaranteed happens-before. The fast/fallback path split is removed.

## Motivation
The upload path (`CUDACommandEncoder::visit(BufferUploadCommand)`) copies host data into a sub-range of a 64 MiB pinned staging pool (`CUDAHostBufferPool`, FirstFit-allocated) and issues `cuMemcpyHtoDAsync(staging → device)`. At each `dispatch`, `CUDAStream::callback()`:
1. assigns a monotonic `ticket`,
2. signals it on the stream,
3. enqueues the staging `View`s into a callback package,
4. a callback thread recycles them once it observes `*_callback_semaphore >= ticket`.

The bug is in step 2. `cuStreamWriteValue64` enqueues a **GPU-side** write to `_callback_semaphore` (device-mapped host memory); a host thread reading it sees the write through ordinary cache coherence, with **no driver guarantee** that it is visible only after the preceding `cuMemcpyHtoDAsync`s. The callback thread spins on `*_callback_semaphore >= ticket` and recycles staging on success. Under cross-dispatch uploads, dispatch N+1's `allocate` can obtain a sub-range that dispatch N's callback thread recycled too early — before dispatch N's DMA read it. The new upload `memcpy`s over the stale staging, but the still-in-flight DMA may read a mix of old/new data, or the new DMA may read the stale data entirely.
`cuLaunchHostFunc` schedules a host function the driver invokes only after all prior stream work completes. Signaling the semaphore from inside it gives a driver-guaranteed happens-before between uploads and recycle. It was already used on the fallback path; this PR uses it unconditionally.

## Change
In `src/backends/cuda/cuda_stream.cpp`, `CUDAStream::callback()` now signals the recycling-ticket semaphore unconditionally via `cuLaunchHostFunc` instead of `cuStreamWriteValue64` (removing the fast/fallback path split); `_callback_semaphore_device` allocation is left untouched since it still backs the host-polled `_callback_semaphore`.

## Reproducer
```cpp
#include <luisa/luisa-compute.h>

using namespace luisa;
using namespace luisa::compute;

// N small buffers, each uploaded in its own `stream << ...;` dispatch with no
// intermediate sync; each carries a per-buffer sentinel uint3(b,0,b).
// On unpatched LuisaCompute (cuStreamWriteValue64 signal) this intermittently
// corrupts buffers; with the cuLaunchHostFunc fix it is clean.
int main(int argc, char** argv) {
    Context ctx{std::string{argv[0]}};
    Device device = ctx.create_device("cuda", nullptr, true);
    Stream stream = device.create_stream(StreamTag::COMPUTE);

    constexpr uint N = 500u;   // many small buffers stress the staging pool
    constexpr uint M = 4u;     // tiny each -> dense staging-reuse window

    std::vector<Buffer<uint3>> buf;
    std::vector<std::vector<uint3>> ref;
    buf.reserve(N);
    ref.reserve(N);
    for (uint b = 0; b < N; b++) {
        ref.emplace_back(M, make_uint3(b, 0, b));   // per-buffer sentinel
        buf.emplace_back(device.create_buffer<uint3>(M));
    }
    // cross-dispatch: one statement per buffer -> one dispatch each, no sync between
    for (uint b = 0; b < N; b++)
        stream << buf[b].copy_from(ref[b].data());
    stream << synchronize();

    uint bad = 0;
    std::vector<uint3> tmp(M);
    for (uint b = 0; b < N; b++) {
        stream << buf[b].copy_to(tmp.data()) << synchronize();
        for (uint i = 0; i < M; i++)
            if (tmp[i].x != b) { bad++; break; }
    }
    LUISA_INFO("corrupt = {} / {}", bad, N);
    return bad ? 1 : 0;
}
```
You need to run the application in a loop, since the race is probabilistic:

```powershell
1..50 | ForEach-Object { .\build\bin\example_upload_race_min.exe 2>&1 | Select-String "corrupt =" }
```

### Results (RTX 5070, driver 12090, 50 consecutive runs)

| Build | runs with `corrupt > 0` |
|---|---|
| unpatched (`cuStreamWriteValue64`) | **4 / 50** |
| this PR (`cuLaunchHostFunc`) | **0 / 50** |

Each run uploads 500 buffers (4 uint3 each) across 500 separate dispatches with no intermediate sync. Unpatched intermittently reports `corrupt = 1 / 500` (one buffer's element 0 holds another buffer's sentinel); with this fix every run reports `corrupt = 0 / 500`.

## Performance note
`cuLaunchHostFunc` is heavier than `cuStreamWriteValue64` (host callback dispatch) but is called **once per dispatch** (not per upload), amortized over every command in that dispatch. The reproducer's wall-clock was unchanged. A benchmark on a dispatch-heavy workload (many small shader dispatches) would be welcome to confirm no regression.