### PR TITLE
fallback: add persistent native shader object cache

### DIFF
--- a/src/backends/fallback/CMakeLists.txt
+++ b/src/backends/fallback/CMakeLists.txt
@@ -50,6 +50,7 @@ if (LLVM_FOUND AND embree_FOUND)
             fallback_buffer.cpp
             fallback_swapchain.cpp
             fallback_tex_compress.cpp
+            ../common/default_binary_io.cpp
     )
 
     luisa_compute_add_backend(fallback SOURCES ${LUISA_FALLBACK_BACKEND_SOURCES})

--- a/src/backends/fallback/fallback_device.cpp
+++ b/src/backends/fallback/fallback_device.cpp
@@ -44,8 +44,19 @@
 
 namespace luisa::compute::fallback {
 
-FallbackDevice::FallbackDevice(Context &&ctx) noexcept
+FallbackDevice::FallbackDevice(Context &&ctx, const DeviceConfig *config) noexcept
     : DeviceInterface{std::move(ctx)} {
+
+    if (config == nullptr || config->binary_io == nullptr) {
+        auto use_lmdb =
+            config != nullptr && config->use_lmdb;
+        _default_io =
+            luisa::make_unique<DefaultBinaryIO>(
+                context(), false, use_lmdb);
+        _io = _default_io.get();
+    } else {
+        _io = config->binary_io;
+    }
 
 #if defined(LUISA_ARCH_X86_64)
     _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
@@ -404,8 +415,10 @@ ResourceCreationInfo FallbackDevice::create_event() noexcept {
 }// namespace luisa::compute::fallback
 
 LUISA_EXPORT_API luisa::compute::DeviceInterface *create(luisa::compute::Context &&ctx,
-                                                         const luisa::compute::DeviceConfig *) noexcept {
-    return luisa::new_with_allocator<luisa::compute::fallback::FallbackDevice>(std::move(ctx));
+                                                         const luisa::compute::DeviceConfig *config) noexcept {
+    return luisa::new_with_allocator<
+        luisa::compute::fallback::FallbackDevice>(
+        std::move(ctx), config);
 }
 
 LUISA_EXPORT_API void destroy(luisa::compute::DeviceInterface *device) noexcept {

--- a/src/backends/fallback/fallback_device.h
+++ b/src/backends/fallback/fallback_device.h
@@ -7,6 +7,7 @@
 #include <luisa/runtime/device.h>
 #include <luisa/core/spin_mutex.h>
 
+#include "../common/default_binary_io.h"
 #include "fallback_embree.h"
 
 namespace llvm {
@@ -25,14 +26,17 @@ class FallbackDevice : public DeviceInterface {
 
 private:
     RTCDevice _rtc_device{nullptr};
+    luisa::unique_ptr<DefaultBinaryIO> _default_io{};
+    const BinaryIO *_io{};
 
 private:
     luisa::spin_mutex _ext_mutex;
     luisa::unique_ptr<FallbackTexCompressInterface> _tex_compress_ext{};
 
 public:
-    explicit FallbackDevice(Context &&ctx) noexcept;
+    explicit FallbackDevice(Context &&ctx, const DeviceConfig *config) noexcept;
     ~FallbackDevice() noexcept override;
+    [[nodiscard]] auto binary_io() const noexcept { return _io; }
     void *native_handle() const noexcept override;
     void destroy_buffer(uint64_t handle) noexcept override;
     void destroy_texture(uint64_t handle) noexcept override;

--- a/src/backends/fallback/fallback_shader.cpp
+++ b/src/backends/fallback/fallback_shader.cpp
@@ -4,9 +4,14 @@
 
 #include <fstream>
 
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Config/llvm-config.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
 #include <llvm/MC/TargetRegistry.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/Target/TargetMachine.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/IRReader/IRReader.h>
 #include <llvm/Analysis/AliasAnalysis.h>
@@ -97,6 +102,10 @@ namespace luisa::compute::fallback {
 
 namespace {
 
+// Increment whenever the persisted object or its external symbol contract
+// changes in a way that makes an older cache artifact unsafe to load.
+static constexpr auto fallback_shader_cache_abi = 1u;
+
 void verify_xir_or_error(const xir::Module *module,
                          luisa::string_view stage) noexcept {
     auto verification = xir::xir_verify_module(module);
@@ -105,6 +114,132 @@ void verify_xir_or_error(const xir::Module *module,
             "Invalid XIR at fallback {}: {} ({} error(s) total).",
             stage, verification.errors.front().message, verification.errors.size());
     }
+}
+
+[[nodiscard]] bool function_contains_debug_break(
+    Function function,
+    luisa::unordered_set<uint64_t> &visited) noexcept {
+    if (!visited.emplace(function.hash()).second) { return false; }
+    auto contains_debug_break = false;
+    traverse_expressions<false>(
+        function.body(),
+        [](auto) noexcept {},
+        [&](auto statement) noexcept {
+            contains_debug_break |=
+                statement->tag() == Statement::Tag::DEBUG_BREAK;
+        },
+        [](auto) noexcept {});
+    if (contains_debug_break) { return true; }
+    for (auto &&callable : function.custom_callables()) {
+        if (function_contains_debug_break(
+                callable->function(), visited)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] bool function_contains_debug_break(
+    Function function) noexcept {
+    luisa::unordered_set<uint64_t> visited;
+    return function_contains_debug_break(function, visited);
+}
+
+struct FallbackShaderCacheMetadata {
+    uint64_t checksum;
+    luisa::string object_name;
+    luisa::string metadata_name;
+    luisa::string serialized;
+};
+
+[[nodiscard]] FallbackShaderCacheMetadata make_shader_cache_metadata(
+    Function kernel, const ShaderOption &option,
+    const llvm::TargetMachine &target_machine) noexcept {
+    auto copy_string = [](llvm::StringRef value) noexcept {
+        return luisa::string{value.data(), value.size()};
+    };
+    auto builtin_module = fallback_backend_device_builtin_module();
+    auto builtin_hash = luisa::hash64(
+        builtin_module.data(), builtin_module.size(),
+        luisa::hash64_default_seed);
+    auto native_include_hash = luisa::hash64(
+        option.native_include.data(), option.native_include.size(),
+        luisa::hash64_default_seed);
+    auto argument_hash = luisa::hash64_default_seed;
+    for (auto argument : kernel.arguments()) {
+        argument_hash = luisa::hash_value(
+            argument.type()->description(), argument_hash);
+        argument_hash = luisa::hash_value(
+            luisa::to_underlying(argument.tag()), argument_hash);
+        argument_hash = luisa::hash_value(
+            luisa::to_underlying(
+                kernel.variable_usage(argument.uid())),
+            argument_hash);
+    }
+    auto data_layout =
+        target_machine.createDataLayout().getStringRepresentation();
+    auto target_triple =
+        copy_string(target_machine.getTargetTriple().str());
+    auto target_cpu =
+        copy_string(target_machine.getTargetCPU());
+    auto target_features =
+        copy_string(target_machine.getTargetFeatureString());
+#ifdef NDEBUG
+    static constexpr auto release_build = true;
+#else
+    static constexpr auto release_build = false;
+#endif
+    auto body = luisa::format(
+        "FALLBACK_CACHE_ABI {}\n"
+        "KERNEL_HASH {:016x}\n"
+        "ARGUMENT_HASH {:016x}\n"
+        "ARGUMENT_COUNT {}\n"
+        "BLOCK_SIZE {} {} {}\n"
+        "LLVM_VERSION {}.{}.{}\n"
+        "TARGET_TRIPLE {}\n"
+        "TARGET_CPU {}\n"
+        "TARGET_FEATURES {}\n"
+        "DATA_LAYOUT {}\n"
+        "BUILTIN_HASH {:016x}\n"
+        "NATIVE_INCLUDE_HASH {:016x}\n"
+        "FAST_MATH {}\n"
+        "DEBUG_INFO {}\n"
+        "RELEASE_BUILD {}\n"
+        "XIR_NORMALIZE_CFG {}\n"
+        "XIR_RESTRUCTURE_CFG {}\n"
+        "XIR_ELIMINATE_EARLY_RETURN {}\n",
+        fallback_shader_cache_abi,
+        kernel.hash(),
+        argument_hash,
+        kernel.arguments().size(),
+        kernel.block_size().x,
+        kernel.block_size().y,
+        kernel.block_size().z,
+        LLVM_VERSION_MAJOR,
+        LLVM_VERSION_MINOR,
+        LLVM_VERSION_PATCH,
+        target_triple,
+        target_cpu,
+        target_features,
+        data_layout,
+        builtin_hash,
+        native_include_hash,
+        option.enable_fast_math,
+        option.enable_debug_info,
+        release_build,
+        LUISA_XIR_NORMALIZE_CFG,
+        LUISA_XIR_RESTRUCTURE_CFG,
+        LUISA_XIR_ELIMINATE_EARLY_RETURN);
+    auto checksum = luisa::hash64(
+        body.data(), body.size(), luisa::hash64_default_seed);
+    auto object_name = luisa::format(
+        "kernel_{:016x}.fallback.obj", checksum);
+    return {
+        .checksum = checksum,
+        .object_name = object_name,
+        .metadata_name = luisa::format("{}.metadata", object_name),
+        .serialized = luisa::format(
+            "CHECKSUM {:016x}\n{}", checksum, body)};
 }
 
 }// namespace
@@ -177,13 +312,246 @@ struct FallbackShaderLaunchConfig {
 
 FallbackShader::FallbackShader(FallbackDevice *device, const ShaderOption &option, Function kernel) noexcept {
 
-    _initialize_target_machine_jit(
-        option);
-
-    LUISA_VERBOSE("======= Fallback Backend JIT Shader Compilation =======");
+    _initialize_target_machine_jit(option);
 
     _block_size = kernel.block_size();
     _build_bound_arguments(kernel.bound_arguments());
+
+    // Compute the dispatch argument layout before trying the cache. Bound
+    // resource handles and uniform values are intentionally absent from the
+    // cache key: they are encoded into this buffer for each dispatch.
+    _argument_buffer_size = 0u;
+    static constexpr auto argument_alignment = 16u;
+    for (auto arg : kernel.arguments()) {
+        switch (arg.tag()) {
+            case Variable::Tag::LOCAL: {
+                _argument_buffer_size += arg.type()->size();
+                _argument_buffer_size = luisa::align(
+                    _argument_buffer_size, argument_alignment);
+                break;
+            }
+            case Variable::Tag::BUFFER: {
+                _argument_buffer_size += sizeof(FallbackBufferView);
+                _argument_buffer_size = luisa::align(
+                    _argument_buffer_size, argument_alignment);
+                break;
+            }
+            case Variable::Tag::TEXTURE: {
+                _argument_buffer_size += sizeof(FallbackTextureView);
+                _argument_buffer_size = luisa::align(
+                    _argument_buffer_size, argument_alignment);
+                break;
+            }
+            case Variable::Tag::BINDLESS_ARRAY: {
+                _argument_buffer_size += sizeof(FallbackBindlessArray *);
+                _argument_buffer_size = luisa::align(
+                    _argument_buffer_size, argument_alignment);
+                break;
+            }
+            case Variable::Tag::ACCEL: {
+                _argument_buffer_size += sizeof(FallbackAccel *);
+                _argument_buffer_size = luisa::align(
+                    _argument_buffer_size, argument_alignment);
+                break;
+            }
+            default: LUISA_ERROR_WITH_LOCATION("Unsupported argument type.");
+        }
+    }
+
+    auto define_common_symbols = [&]() noexcept {
+        llvm::orc::SymbolMap symbol_map{};
+        auto map_symbol = [
+                              jit = _jit.get(),
+                              &symbol_map]<typename T>(
+                              const char *name, T *function) noexcept {
+            auto address = llvm::orc::ExecutorAddr::fromPtr(function);
+            auto symbol = llvm::orc::ExecutorSymbolDef{
+                address, llvm::JITSymbolFlags::Callable};
+            symbol_map.try_emplace(
+                jit->mangleAndIntern(name), symbol);
+        };
+
+#include "fallback_device_api_map_symbols.inl.h"
+
+        map_symbol("luisa.asin.f16", &luisa_fallback_asin_f16);
+        map_symbol("luisa.asin.f32", &luisa_fallback_asin_f32);
+        map_symbol("luisa.asin.f64", &luisa_fallback_asin_f64);
+        map_symbol("luisa.acos.f16", &luisa_fallback_acos_f16);
+        map_symbol("luisa.acos.f32", &luisa_fallback_acos_f32);
+        map_symbol("luisa.acos.f64", &luisa_fallback_acos_f64);
+        map_symbol("luisa.atan.f16", &luisa_fallback_atan_f16);
+        map_symbol("luisa.atan.f32", &luisa_fallback_atan_f32);
+        map_symbol("luisa.atan.f64", &luisa_fallback_atan_f64);
+        map_symbol("luisa.atan2.f16", &luisa_fallback_atan2_f16);
+        map_symbol("luisa.atan2.f32", &luisa_fallback_atan2_f32);
+        map_symbol("luisa.atan2.f64", &luisa_fallback_atan2_f64);
+        map_symbol("luisa.coro.alloc", &luisa_coro_alloc);
+        map_symbol("luisa.coro.free", &luisa_coro_free);
+        map_symbol("luisa.shared.memory", &luisa_shared_memory);
+        map_symbol("luisa.assert", &luisa_fallback_assert);
+
+        if (auto error = _jit->getMainJITDylib().define(
+                llvm::orc::absoluteSymbols(std::move(symbol_map)))) {
+            auto message = llvm::toString(std::move(error));
+            LUISA_ERROR_WITH_LOCATION(
+                "Failed to define fallback JIT symbols: {}.",
+                message);
+        }
+    };
+    define_common_symbols();
+
+    auto define_codegen_symbols =
+        [&](const FallbackCodeGenFeedback &feedback) noexcept {
+            llvm::orc::SymbolMap symbol_map{};
+            auto map_symbol = [
+                                  jit = _jit.get(),
+                                  &symbol_map]<typename T>(
+                                  const char *name, T *function) noexcept {
+                auto address =
+                    llvm::orc::ExecutorAddr::fromPtr(function);
+                auto symbol = llvm::orc::ExecutorSymbolDef{
+                    address, llvm::JITSymbolFlags::Callable};
+                symbol_map.try_emplace(
+                    jit->mangleAndIntern(name), symbol);
+            };
+
+            if (!feedback.print_inst_map.empty()) {
+                map_symbol("luisa.print.context", this);
+                _print_formatters.reserve(
+                    feedback.print_inst_map.size());
+                for (auto format_id = 0u;
+                     format_id < feedback.print_inst_map.size();
+                     format_id++) {
+                    auto &&[print_inst, llvm_symbol] =
+                        feedback.print_inst_map[format_id];
+                    map_symbol(
+                        llvm_symbol.c_str(),
+                        &luisa_fallback_print);
+                    LUISA_INFO(
+                        "Mapping print instruction #{}: \"{}\" -> {}",
+                        format_id, print_inst->format(), llvm_symbol);
+                    llvm::SmallVector<const Type *, 8u> argument_types;
+                    for (auto operand : print_inst->operand_uses()) {
+                        argument_types.emplace_back(
+                            operand->value()->type());
+                    }
+                    auto argument_pack_type =
+                        Type::structure(16u, argument_types);
+                    _print_formatters.emplace_back(
+                        luisa::make_unique<ShaderPrintFormatter>(
+                            print_inst->format(),
+                            argument_pack_type, false));
+                }
+            }
+            for (auto &&[callback, llvm_symbol] :
+                 feedback.debug_callback_map) {
+                map_symbol(llvm_symbol.c_str(), callback);
+                LUISA_INFO(
+                    "Mapping debug callback: {} -> {}",
+                    reinterpret_cast<void *>(callback), llvm_symbol);
+            }
+            if (!symbol_map.empty()) {
+                if (auto error =
+                        _jit->getMainJITDylib().define(
+                            llvm::orc::absoluteSymbols(
+                                std::move(symbol_map)))) {
+                    auto message = llvm::toString(std::move(error));
+                    LUISA_ERROR_WITH_LOCATION(
+                        "Failed to define fallback shader-specific "
+                        "JIT symbols: {}.",
+                        message);
+                }
+            }
+        };
+
+    auto has_debug_break = function_contains_debug_break(kernel);
+    auto cache_enabled =
+        option.enable_cache &&
+        option.name.empty() &&
+        !kernel.requires_printing() &&
+        !has_debug_break &&
+        !LUISA_SHOULD_DUMP_XIR &&
+        !LUISA_SHOULD_DUMP_LLVM_IR &&
+        !LUISA_SHOULD_DUMP_ASM &&
+        device->binary_io() != nullptr;
+    auto cache_metadata = make_shader_cache_metadata(
+        kernel, option, *_target_machine);
+
+    auto lookup_kernel_entry = [&]() noexcept {
+        auto address = _jit->lookup("kernel.main");
+        if (!address) {
+            auto message = llvm::toString(address.takeError());
+            LUISA_WARNING_WITH_LOCATION(
+                "Fallback JIT kernel lookup failed: {}.", message);
+            return false;
+        }
+        _kernel_entry = address->toPtr<kernel_entry_t>();
+        return true;
+    };
+
+    if (cache_enabled) {
+        Clock cache_clock;
+        auto metadata_stream = device->binary_io()->read_shader_cache(
+            cache_metadata.metadata_name);
+        auto object_stream = device->binary_io()->read_shader_cache(
+            cache_metadata.object_name);
+        auto metadata_matches = false;
+        if (metadata_stream != nullptr &&
+            metadata_stream->length() ==
+                cache_metadata.serialized.size()) {
+            luisa::string serialized;
+            serialized.resize(metadata_stream->length());
+            metadata_stream->read(luisa::span{
+                reinterpret_cast<std::byte *>(serialized.data()),
+                serialized.size()});
+            metadata_matches =
+                serialized == cache_metadata.serialized;
+        }
+        if (metadata_matches &&
+            object_stream != nullptr &&
+            object_stream->length() != 0u) {
+            auto object = object_stream->read(
+                object_stream->length());
+            auto object_buffer =
+                llvm::MemoryBuffer::getMemBufferCopy(
+                    llvm::StringRef{
+                        reinterpret_cast<const char *>(object.data()),
+                        object.size()},
+                    cache_metadata.object_name.c_str());
+            if (auto error =
+                    _jit->addObjectFile(std::move(object_buffer))) {
+                auto message = llvm::toString(std::move(error));
+                LUISA_WARNING_WITH_LOCATION(
+                    "Fallback shader cache object '{}' is invalid: {}. "
+                    "The shader will be recompiled.",
+                    cache_metadata.object_name, message);
+            } else if (lookup_kernel_entry()) {
+                LUISA_VERBOSE(
+                    "Fallback shader cache hit '{}' in {} ms.",
+                    cache_metadata.object_name,
+                    cache_clock.toc());
+                return;
+            }
+            _initialize_target_machine_jit(option);
+            define_common_symbols();
+        } else {
+            LUISA_VERBOSE(
+                "Fallback shader cache miss '{}'.",
+                cache_metadata.object_name);
+        }
+    } else if (option.enable_cache) {
+        LUISA_VERBOSE(
+            "Fallback shader cache disabled for kernel {:016x} "
+            "(named={}, printing={}, debug_break={}, dumping={}).",
+            kernel.hash(), !option.name.empty(),
+            kernel.requires_printing(), has_debug_break,
+            LUISA_SHOULD_DUMP_XIR ||
+                LUISA_SHOULD_DUMP_LLVM_IR ||
+                LUISA_SHOULD_DUMP_ASM);
+    }
+
+    LUISA_VERBOSE(
+        "======= Fallback Backend JIT Shader Compilation =======");
 
     Clock translate_clk;
     auto xir_module = xir::ast_to_xir_translate(kernel, {});
@@ -318,72 +686,7 @@ FallbackShader::FallbackShader(FallbackDevice *device, const ShaderOption &optio
         LUISA_ERROR_WITH_LOCATION("LLVM module verification failed. IR dumped to '{}'.", filename);
     }
 
-    // map symbols
-    llvm::orc::SymbolMap symbol_map{};
-    auto map_symbol = [jit = _jit.get(), &symbol_map]<typename T>(const char *name, T *f) noexcept {
-        auto addr = llvm::orc::ExecutorAddr::fromPtr(f);
-        auto symbol = llvm::orc::ExecutorSymbolDef{addr, llvm::JITSymbolFlags::Callable};
-        symbol_map.try_emplace(jit->mangleAndIntern(name), symbol);
-    };
-
-#include "fallback_device_api_map_symbols.inl.h"
-
-    // asin, acos, atan, atan2
-    map_symbol("luisa.asin.f16", &luisa_fallback_asin_f16);
-    map_symbol("luisa.asin.f32", &luisa_fallback_asin_f32);
-    map_symbol("luisa.asin.f64", &luisa_fallback_asin_f64);
-    map_symbol("luisa.acos.f16", &luisa_fallback_acos_f16);
-    map_symbol("luisa.acos.f32", &luisa_fallback_acos_f32);
-    map_symbol("luisa.acos.f64", &luisa_fallback_acos_f64);
-    map_symbol("luisa.atan.f16", &luisa_fallback_atan_f16);
-    map_symbol("luisa.atan.f32", &luisa_fallback_atan_f32);
-    map_symbol("luisa.atan.f64", &luisa_fallback_atan_f64);
-    map_symbol("luisa.atan2.f16", &luisa_fallback_atan2_f16);
-    map_symbol("luisa.atan2.f32", &luisa_fallback_atan2_f32);
-    map_symbol("luisa.atan2.f64", &luisa_fallback_atan2_f64);
-
-    // luisa.coro.alloc and luisa.coro.free
-    map_symbol("luisa.coro.alloc", &luisa_coro_alloc);
-    map_symbol("luisa.coro.free", &luisa_coro_free);
-
-    // emulated shared memory
-    map_symbol("luisa.shared.memory", &luisa_shared_memory);
-
-    // assert
-    map_symbol("luisa.assert", &luisa_fallback_assert);
-
-    // bind print instructions
-    if (!codegen_feedback.print_inst_map.empty()) {
-        map_symbol("luisa.print.context", this);
-        _print_formatters.reserve(codegen_feedback.print_inst_map.size());
-        for (auto fmt_id = 0u; fmt_id < codegen_feedback.print_inst_map.size(); fmt_id++) {
-            auto &&[print_inst, llvm_symbol] = codegen_feedback.print_inst_map[fmt_id];
-            map_symbol(llvm_symbol.c_str(), &luisa_fallback_print);
-            LUISA_INFO("Mapping print instruction #{}: \"{}\" -> {}", fmt_id, print_inst->format(), llvm_symbol);
-            llvm::SmallVector<const Type *, 8u> arg_types;
-            for (auto o : print_inst->operand_uses()) {
-                arg_types.emplace_back(o->value()->type());
-            }
-            auto arg_pack_type = Type::structure(16u, arg_types);
-            _print_formatters.emplace_back(luisa::make_unique<ShaderPrintFormatter>(
-                print_inst->format(), arg_pack_type, false));
-        }
-    }
-
-    // bind debug callback functions
-    for (auto &&[callback, llvm_symbol] : codegen_feedback.debug_callback_map) {
-        map_symbol(llvm_symbol.c_str(), callback);
-        LUISA_INFO("Mapping debug callback: {} -> {}", reinterpret_cast<void *>(callback), llvm_symbol);
-    }
-
-    // define symbols
-    if (auto error = _jit->getMainJITDylib().define(
-            ::llvm::orc::absoluteSymbols(std::move(symbol_map)))) {
-        ::llvm::handleAllErrors(std::move(error), [](const ::llvm::ErrorInfoBase &err) {
-            LUISA_WARNING_WITH_LOCATION("LLJIT::define(): {}", err.message());
-        });
-        LUISA_ERROR_WITH_LOCATION("Failed to define symbols.");
-    }
+    define_codegen_symbols(codegen_feedback);
 
     llvm_module->setDataLayout(_target_machine->createDataLayout());
 #if LLVM_VERSION_MAJOR >= 21
@@ -475,55 +778,63 @@ FallbackShader::FallbackShader(FallbackDevice *device, const ShaderOption &optio
         }
     }
 
-    // compile to machine code
-    auto m = llvm::orc::ThreadSafeModule(std::move(llvm_module), std::move(llvm_ctx));
-    if (auto error = _jit->addIRModule(std::move(m))) {
-        ::llvm::handleAllErrors(std::move(error), [](const ::llvm::ErrorInfoBase &err) {
-            LUISA_WARNING_WITH_LOCATION("LLJIT::addIRModule(): {}", err.message());
-        });
-    }
-    auto addr = _jit->lookup("kernel.main");
-    if (!addr) {
-        ::llvm::handleAllErrors(addr.takeError(), [](const ::llvm::ErrorInfoBase &err) {
-            LUISA_WARNING_WITH_LOCATION("LLJIT::lookup(): {}", err.message());
-        });
-    }
-    LUISA_ASSERT(addr, "JIT compilation failed.");
-    _kernel_entry = addr->toPtr<kernel_entry_t>();
-
-    // compute argument buffer size
-    _argument_buffer_size = 0u;
-    static constexpr auto argument_alignment = 16u;
-    for (auto arg : kernel.arguments()) {
-        switch (arg.tag()) {
-            case Variable::Tag::LOCAL: {
-                _argument_buffer_size += arg.type()->size();
-                _argument_buffer_size = luisa::align(_argument_buffer_size, argument_alignment);
-                break;
-            }
-            case Variable::Tag::BUFFER: {
-                _argument_buffer_size += sizeof(FallbackBufferView);
-                _argument_buffer_size = luisa::align(_argument_buffer_size, argument_alignment);
-                break;
-            }
-            case Variable::Tag::TEXTURE: {
-                _argument_buffer_size += sizeof(FallbackTextureView);
-                _argument_buffer_size = luisa::align(_argument_buffer_size, argument_alignment);
-                break;
-            }
-            case Variable::Tag::BINDLESS_ARRAY: {
-                _argument_buffer_size += sizeof(FallbackBindlessArray *);
-                _argument_buffer_size = luisa::align(_argument_buffer_size, argument_alignment);
-                break;
-            }
-            case Variable::Tag::ACCEL: {
-                _argument_buffer_size += sizeof(FallbackAccel *);
-                _argument_buffer_size = luisa::align(_argument_buffer_size, argument_alignment);
-                break;
-            }
-            default: LUISA_ERROR_WITH_LOCATION("Unsupported argument type.");
+    // Persist the fully optimized, host-specific relocatable object. This is
+    // the first representation that skips all expensive work on a cache hit:
+    // AST-to-XIR, XIR passes, LLVM IR generation, O3, and machine codegen.
+    if (cache_enabled) {
+        Clock object_clock;
+        llvm::SmallVector<char, 0u> object_code;
+        llvm::raw_svector_ostream object_stream{object_code};
+        llvm::legacy::PassManager object_pass;
+        if (_target_machine->addPassesToEmitFile(
+                object_pass, object_stream, nullptr,
+                llvm::CodeGenFileType::ObjectFile)) {
+            LUISA_ERROR_WITH_LOCATION(
+                "Fallback target machine cannot emit object files.");
+        }
+        object_pass.run(*llvm_module);
+        LUISA_VERBOSE(
+            "Fallback machine object generated in {} ms ({} bytes).",
+            object_clock.toc(), object_code.size());
+        luisa::span<const std::byte> object_bytes{
+            reinterpret_cast<const std::byte *>(object_code.data()),
+            object_code.size()};
+        static_cast<void>(
+            device->binary_io()->write_shader_cache(
+                cache_metadata.object_name, object_bytes));
+        luisa::span<const std::byte> metadata_bytes{
+            reinterpret_cast<const std::byte *>(
+                cache_metadata.serialized.data()),
+            cache_metadata.serialized.size()};
+        // Metadata is written last. A partial object write therefore cannot
+        // become a valid cache hit.
+        static_cast<void>(
+            device->binary_io()->write_shader_cache(
+                cache_metadata.metadata_name, metadata_bytes));
+        auto object_buffer =
+            llvm::MemoryBuffer::getMemBufferCopy(
+                llvm::StringRef{
+                    object_code.data(), object_code.size()},
+                cache_metadata.object_name.c_str());
+        if (auto error =
+                _jit->addObjectFile(std::move(object_buffer))) {
+            auto message = llvm::toString(std::move(error));
+            LUISA_ERROR_WITH_LOCATION(
+                "Failed to add fallback machine object '{}': {}.",
+                cache_metadata.object_name, message);
+        }
+    } else {
+        auto module = llvm::orc::ThreadSafeModule(
+            std::move(llvm_module), std::move(llvm_ctx));
+        if (auto error = _jit->addIRModule(std::move(module))) {
+            auto message = llvm::toString(std::move(error));
+            LUISA_ERROR_WITH_LOCATION(
+                "Failed to add fallback LLVM IR module: {}.",
+                message);
         }
     }
+    LUISA_ASSERT(
+        lookup_kernel_entry(), "Fallback JIT compilation failed.");
 }
 
 class FallbackShaderDispatchBuffer {

--- a/src/backends/fallback/xmake.lua
+++ b/src/backends/fallback/xmake.lua
@@ -53,5 +53,6 @@ after_build(function(target)
     ::END::
 end)
 add_files("*.cpp")
+add_files("../common/default_binary_io.cpp")
 add_deps("lc-runtime")
 target_end()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -227,6 +227,13 @@ luisa_compute_add_test(test_copy                unit/runtime/test_copy.cpp)
 luisa_compute_add_test(test_cpu_callable        unit/runtime/test_cpu_callable.cpp)
 luisa_compute_add_test(test_decoupled_look_back unit/runtime/test_decoupled_look_back.cpp)
 luisa_compute_add_test(test_complex_kernel      unit/runtime/test_complex_kernel.cpp)
+if (TARGET luisa-compute-backend-fallback)
+    # Uses two independent fallback Device instances and a shared in-memory
+    # BinaryIO to verify cold compilation, object-cache reuse, and dynamic
+    # uniform arguments. Kept out of unattended CTest because it requires the
+    # optional LLVM/Embree fallback backend at runtime.
+    luisa_compute_add_test(test_fallback_shader_cache unit/runtime/test_fallback_shader_cache.cpp)
+endif ()
 luisa_compute_add_test(test_bindless_mip        unit/runtime/test_bindless_mip.cpp)
 luisa_compute_add_test(test_direct_texture_sampling unit/runtime/test_direct_texture_sampling.cpp)
 luisa_compute_add_test(test_mipmap              unit/runtime/test_mipmap.cpp)

--- a/src/tests/unit/runtime/test_fallback_shader_cache.cpp
+++ b/src/tests/unit/runtime/test_fallback_shader_cache.cpp
@@ -1,0 +1,178 @@
+#include "ut/ut.hpp"
+
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <luisa/core/binary_io.h>
+#include <luisa/dsl/sugar.h>
+#include <luisa/runtime/buffer.h>
+#include <luisa/runtime/context.h>
+#include <luisa/runtime/device.h>
+#include <luisa/runtime/stream.h>
+
+using namespace boost::ut;
+using namespace luisa;
+using namespace luisa::compute;
+
+namespace {
+
+class MemoryBinaryStream final : public BinaryStream {
+
+private:
+    luisa::vector<std::byte> _data;
+    size_t _position{};
+
+public:
+    explicit MemoryBinaryStream(
+        luisa::span<const std::byte> data) noexcept
+        : _data{data.begin(), data.end()} {}
+
+    [[nodiscard]] size_t length() const noexcept override {
+        return _data.size();
+    }
+
+    [[nodiscard]] size_t pos() const noexcept override {
+        return _position;
+    }
+
+    void read(luisa::span<std::byte> destination) noexcept override {
+        if (_position > _data.size() ||
+            destination.size() > _data.size() - _position) {
+            std::memset(
+                destination.data(), 0, destination.size());
+            _position = _data.size();
+            return;
+        }
+        std::memcpy(
+            destination.data(), _data.data() + _position,
+            destination.size());
+        _position += destination.size();
+    }
+};
+
+class MemoryBinaryIO final : public BinaryIO {
+
+private:
+    mutable std::unordered_map<
+        std::string, std::vector<std::byte>>
+        _cache;
+
+public:
+    mutable size_t cache_read_count{};
+    mutable size_t cache_write_count{};
+
+    void clear_shader_cache() const noexcept override {
+        _cache.clear();
+    }
+
+    [[nodiscard]] luisa::unique_ptr<BinaryStream>
+    read_shader_bytecode(
+        luisa::string_view) const noexcept override {
+        return nullptr;
+    }
+
+    [[nodiscard]] luisa::unique_ptr<BinaryStream>
+    read_shader_cache(
+        luisa::string_view name) const noexcept override {
+        cache_read_count++;
+        auto iterator = _cache.find(std::string{name});
+        if (iterator == _cache.end()) { return nullptr; }
+        auto &&data = iterator->second;
+        return luisa::make_unique<MemoryBinaryStream>(
+            luisa::span<const std::byte>{
+                data.data(), data.size()});
+    }
+
+    [[nodiscard]] luisa::unique_ptr<BinaryStream>
+    read_internal_shader(
+        luisa::string_view) const noexcept override {
+        return nullptr;
+    }
+
+    luisa::filesystem::path write_shader_bytecode(
+        luisa::string_view,
+        luisa::span<const std::byte>) const noexcept override {
+        return {};
+    }
+
+    luisa::filesystem::path write_shader_cache(
+        luisa::string_view name,
+        luisa::span<const std::byte> data) const noexcept override {
+        cache_write_count++;
+        _cache[std::string{name}] = {
+            data.begin(), data.end()};
+        return {};
+    }
+
+    luisa::filesystem::path write_internal_shader(
+        luisa::string_view,
+        luisa::span<const std::byte>) const noexcept override {
+        return {};
+    }
+};
+
+[[nodiscard]] int run_cached_kernel(
+    const char *program_path, const BinaryIO *binary_io,
+    int value, bool enable_cache) noexcept {
+    Context context{program_path};
+    DeviceConfig config{.binary_io = binary_io};
+    auto device = context.create_device("fallback", &config);
+    auto output = device.create_buffer<int>(1u);
+    Kernel1D kernel = [](
+                          BufferVar<int> result,
+                          Int parameter) noexcept {
+        result->write(0u, parameter * 3 + 1);
+    };
+    auto shader = device.compile(
+        kernel, ShaderOption{.enable_cache = enable_cache});
+    auto stream = device.create_stream();
+    auto result = 0;
+    stream << shader(output, value).dispatch(1u)
+           << output.copy_to(&result)
+           << synchronize();
+    return result;
+}
+
+}// namespace
+
+int main(int argc, char *argv[]) {
+    auto program_path =
+        argc > 0 && argv != nullptr ? argv[0] : "";
+    MemoryBinaryIO binary_io;
+
+    "fallback object cache reuses code across devices and keeps uniforms dynamic"_test =
+        [&] {
+            auto cold_result = run_cached_kernel(
+                program_path, &binary_io, 7, true);
+            expect(cold_result == 22);
+            expect(binary_io.cache_write_count == 2u);
+            auto cold_read_count = binary_io.cache_read_count;
+            auto cold_write_count = binary_io.cache_write_count;
+
+            auto hot_result = run_cached_kernel(
+                program_path, &binary_io, 11, true);
+            expect(hot_result == 34);
+            expect(
+                binary_io.cache_read_count ==
+                cold_read_count + 2u);
+            expect(
+                binary_io.cache_write_count ==
+                cold_write_count);
+
+            auto reads_before_disabled =
+                binary_io.cache_read_count;
+            auto writes_before_disabled =
+                binary_io.cache_write_count;
+            auto uncached_result = run_cached_kernel(
+                program_path, &binary_io, 13, false);
+            expect(uncached_result == 40);
+            expect(
+                binary_io.cache_read_count ==
+                reads_before_disabled);
+            expect(
+                binary_io.cache_write_count ==
+                writes_before_disabled);
+        };
+}

--- a/src/tests/xmake.lua
+++ b/src/tests/xmake.lua
@@ -270,6 +270,9 @@ test_proj("test_mha_warp_reduction", "unit/runtime/test_mha_warp_reduction.cpp")
 test_proj("test_ray_query_world_ray", "unit/runtime/test_ray_query_world_ray.cpp")
 test_proj("test_buffer_io", "unit/runtime/test_buffer_io.cpp")
 test_proj("test_buffer", "unit/runtime/test_buffer.cpp")
+if has_config("lc_fallback_backend") then
+    test_proj("test_fallback_shader_cache", "unit/runtime/test_fallback_shader_cache.cpp")
+end
 test_proj("test_out_of_range", "unit/runtime/test_out_of_range.cpp")
 test_proj("test_buffer_view", "unit/runtime/test_buffer_view.cpp")
 test_proj("test_device_test", "unit/runtime/test_device.cpp")


### PR DESCRIPTION
## Summary

- wire the fallback device to Luisa's default or application-provided `BinaryIO`
- derive an exact cache identity from the kernel ABI, LLVM/target-machine identity, builtins/native includes, and code-generation options
- persist a host-specific relocatable object plus metadata, with metadata written last
- load valid objects directly into ORC JIT so a hit skips AST-to-XIR, XIR passes, LLVM IR generation, O3, and object generation
- keep uniform values, resource handles, and dispatch values dynamic rather than incorporating them into the cache key
- bypass caching for named, printing, debug-break, and dump-mode shaders

The key/metadata split and exact validation follow the existing CUDA AST-codegen cache model, adapted for LLVM host objects.

## Validation

Built from a clean CMake fallback configuration with LLVM 18.1.3 and Embree 4.4.0. `test_fallback_shader_cache` passes 8/8 assertions across independent Device instances:

- cold run: cache miss, object + metadata written, result `22` for uniform `7`
- hot run: object hit in `0.12 ms`, shader creation in `1.65 ms`, no write, result `34` for changed uniform `11`
- cache disabled: no cache I/O, result `40`

### Psycles full-scene cross-process benchmark

[Psycles `ad360032`](https://github.com/LuisaGroup/Psycles/commit/ad360032f064c98837dcfa06300a3839c54d3817) pins this PR head and validates a 1,275-geometry / 7,543-instance / 37-material Lone Monk scene with a frozen runtime and isolated cache:

- cold main AST-to-XIR: `183.578 s`
- cold shader JIT: `327.574 s`; process wall time: `331.110 s`
- hot main-object load: `1.8655 ms`
- hot shader JIT: `0.682609 s` (**479.9×** faster); process wall time: `4.506 s`
- all 13 emitted linear passes are byte-identical between cold and hot processes
- changing runtime arguments from 64×48/1 spp to 640×480/64 spp retains the same main key (`kernel_bb7a6886f6f75b90`) and loads the object in `1.9202 ms`; shader setup is `0.789711 s`
- the main object is 1,195,232 bytes; total two-kernel cache footprint is 1,220,590 bytes

This validates both persistent cross-process reuse and the intended boundary: dispatch extent, sample count, and other runtime values do not invalidate the structural shader artifact.