### PR TITLE
fix(vk): enable portability enumeration on Apple platforms

### DIFF
--- a/src/backends/vk/device.cpp
+++ b/src/backends/vk/device.cpp
@@ -407,11 +407,11 @@ void create_instance(bool enable_validation, bool &enable_surface, VkInstance &i
             }
         }
 
-#if (defined(VK_USE_PLATFORM_IOS_MVK) || defined(VK_USE_PLATFORM_MACOS_MVK)) && defined(VK_KHR_portability_enumeration)
-        // SRS - When running on iOS/macOS with MoltenVK and VK_KHR_portability_enumeration is defined and supported by the instance, enable the extension and the flag
-        if (supported_instance_exts.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) == supported_instance_exts.end()) {
+#if defined(LUISA_PLATFORM_APPLE) && defined(VK_KHR_portability_enumeration)
+        // MoltenVK requires portability enumeration to expose all conformant physical devices.
+        if (supported_instance_exts.find(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME) != supported_instance_exts.end()) {
             emplace_instance_ext(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-            instance_create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            instance_create_info.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
         }
 #endif
         if (settings.validation) {
@@ -843,6 +843,31 @@ void Device::_init_device(VkPhysicalDevice external_physical_device, VkDevice ex
         // Defaults to the first device unless specified by command line
         VkPhysicalDeviceProperties device_properties;
         if (selected_device == -1) {
+#if defined(LUISA_PLATFORM_APPLE)
+            selected_device = 0;
+            for (uint32_t i = 0u; i < gpu_count; i++) {
+                uint32_t queue_family_count = 0u;
+                vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &queue_family_count, nullptr);
+                vstd::vector<VkQueueFamilyProperties> queue_families;
+                luisa::enlarge_by(queue_families, queue_family_count);
+                vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &queue_family_count, queue_families.data());
+                auto supports_graphics_compute = std::any_of(
+                    queue_families.begin(), queue_families.end(),
+                    [](auto &&queue_family) noexcept {
+                        constexpr auto required = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
+                        return queue_family.queueCount > 0u &&
+                               (queue_family.queueFlags & required) == required;
+                    });
+                if (supports_graphics_compute) {
+                    selected_device = i;
+                    vkGetPhysicalDeviceProperties(physical_devices[i], &device_properties);
+                    LUISA_INFO("Select device: {} (device ID: {:#010x})",
+                               device_properties.deviceName,
+                               device_properties.deviceID);
+                    break;
+                }
+            }
+#else
             selected_device = 0;
             for (auto &&i : physical_devices) {
                 vkGetPhysicalDeviceProperties(i, &device_properties);
@@ -855,6 +880,7 @@ void Device::_init_device(VkPhysicalDevice external_physical_device, VkDevice ex
                 }
                 selected_device++;
             }
+#endif
         }
         physical_device = physical_devices[std::min<uint32_t>(selected_device, physical_devices.size() - 1)];
     }


### PR DESCRIPTION
The Vulkan backend never enables VK_KHR_portability_enumeration on Apple
platforms. The portability branch in create_instance()
(src/backends/vk/device.cpp:410-415) is gated on VK_USE_PLATFORM_MACOS_MVK and
VK_USE_PLATFORM_IOS_MVK, which are not defined by the Apple build
configurations, and its supported-extension check is inverted
(`find(...) == end` instead of `!= end`). MoltenVK exposes the physical device
only when the extension and VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
are both enabled
(https://github.com/KhronosGroup/MoltenVK#using-moltenvk-as-a-vulkan-portability-implementation).
Without them, a single reduced device (0x00000064) is enumerated and the
default selection in _init_device() (src/backends/vk/device.cpp:845-858) falls
through to it. On the test machine, rendering the Cornell box scene with the
same kernel on that device took 56.3 s, versus 31.2 s when 0x1a05020a is
selected explicitly.

Changes:
- Replace the platform gate with LUISA_PLATFORM_APPLE, which both the CMake
  and xmake builds define.
- Enable the extension and the instance flag only when the loader reports
  support.
- When DeviceConfig.device_index is unspecified, select the first device
  exposing a graphics+compute queue family on Apple
  (src/backends/vk/device.cpp:846-881).
- Keep explicit indices, out-of-range clamping, zero-device failure handling,
  and the non-Apple selection path unchanged.

Validation:
- Default selection now logs `Select device: Apple M5 (device ID: 0x1a05020a)`.
- Cornell box render time (median of three; nine runs total, all passing):
  56.342 s -> 31.193 s.
- XIR-to-SPIR-V compute smoke test passes.
- The Metal backend and other backends are unaffected; the change is confined
  to src/backends/vk/device.cpp.
