### PR TITLE
fix(vk): negotiate bindless descriptor layout capacity

### DIFF
--- a/src/backends/vk/device.cpp
+++ b/src/backends/vk/device.cpp
@@ -76,6 +76,53 @@ namespace {
     return false;
 }
 
+[[nodiscard]] uint32_t query_bindless_heap_capacity(
+    VkPhysicalDevice physical_device) noexcept {
+    VkPhysicalDeviceVulkan12Features features{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES};
+    VkPhysicalDeviceFeatures2 features2{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+        .pNext = &features};
+    vkGetPhysicalDeviceFeatures2(physical_device, &features2);
+    if (features.descriptorIndexing != VK_TRUE ||
+        features.shaderSampledImageArrayNonUniformIndexing != VK_TRUE ||
+        features.shaderStorageBufferArrayNonUniformIndexing != VK_TRUE ||
+        features.descriptorBindingSampledImageUpdateAfterBind != VK_TRUE ||
+        features.descriptorBindingStorageBufferUpdateAfterBind != VK_TRUE ||
+        features.descriptorBindingPartiallyBound != VK_TRUE ||
+        features.runtimeDescriptorArray != VK_TRUE) {
+        return 0u;
+    }
+    VkPhysicalDeviceMaintenance3Properties maintenance3_properties{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES};
+    VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_properties{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES,
+        .pNext = &maintenance3_properties};
+    VkPhysicalDeviceProperties2 properties2{
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
+        .pNext = &descriptor_indexing_properties};
+    vkGetPhysicalDeviceProperties2(physical_device, &properties2);
+    return detail::plan_bindless_heap_capacity(
+        {.max_per_set_descriptors =
+             maintenance3_properties.maxPerSetDescriptors,
+         .max_per_stage_update_after_bind_samplers =
+             descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSamplers,
+         .max_descriptor_set_update_after_bind_samplers =
+             descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSamplers,
+         .max_per_stage_update_after_bind_storage_buffers =
+             descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageBuffers,
+         .max_descriptor_set_update_after_bind_storage_buffers =
+             descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindStorageBuffers,
+         .max_per_stage_update_after_bind_sampled_images =
+             descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSampledImages,
+         .max_descriptor_set_update_after_bind_sampled_images =
+             descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSampledImages,
+         .max_per_stage_update_after_bind_resources =
+             descriptor_indexing_properties.maxPerStageUpdateAfterBindResources,
+         .max_update_after_bind_descriptors_in_all_pools =
+             descriptor_indexing_properties.maxUpdateAfterBindDescriptorsInAllPools});
+}
+
 #ifdef LUISA_XIR_TO_SPIRV
 [[nodiscard]] luisa::string describe_hlsl_fallback_reasons(
     detail::UserComputeCodegenRoute route) noexcept {
@@ -845,6 +892,7 @@ void Device::_init_device(VkPhysicalDevice external_physical_device, VkDevice ex
         if (selected_device == -1) {
 #if defined(LUISA_PLATFORM_APPLE)
             selected_device = 0;
+            detail::DefaultDeviceCandidate selected_candidate{};
             for (uint32_t i = 0u; i < gpu_count; i++) {
                 uint32_t queue_family_count = 0u;
                 vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[i], &queue_family_count, nullptr);
@@ -858,15 +906,24 @@ void Device::_init_device(VkPhysicalDevice external_physical_device, VkDevice ex
                         return queue_family.queueCount > 0u &&
                                (queue_family.queueFlags & required) == required;
                     });
-                if (supports_graphics_compute) {
+                auto candidate = detail::DefaultDeviceCandidate{
+                    .supports_graphics_compute = supports_graphics_compute,
+                    .bindless_heap_capacity =
+                        bindless_enabled ?
+                            query_bindless_heap_capacity(physical_devices[i]) :
+                            0u};
+                if (detail::prefer_default_device_candidate(
+                        candidate, selected_candidate, bindless_enabled)) {
                     selected_device = i;
-                    vkGetPhysicalDeviceProperties(physical_devices[i], &device_properties);
-                    LUISA_INFO("Select device: {} (device ID: {:#010x})",
-                               device_properties.deviceName,
-                               device_properties.deviceID);
-                    break;
+                    selected_candidate = candidate;
                 }
             }
+            vkGetPhysicalDeviceProperties(
+                physical_devices[selected_device], &device_properties);
+            LUISA_INFO(
+                "Select device: {} (device ID: {:#010x}, bindless capacity: {})",
+                device_properties.deviceName, device_properties.deviceID,
+                selected_candidate.bindless_heap_capacity);
 #else
             selected_device = 0;
             for (auto &&i : physical_devices) {
@@ -1415,9 +1472,15 @@ void Device::_init_device(VkPhysicalDevice external_physical_device, VkDevice ex
             VkPhysicalDeviceProperties2 properties2{
                 .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
                 .pNext = &_descriptor_indexing_properties};
+            VkPhysicalDeviceMaintenance3Properties maintenance3_properties{
+                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES};
+            _descriptor_indexing_properties.pNext = &maintenance3_properties;
             vkGetPhysicalDeviceProperties2(physical_device, &properties2);
+            _descriptor_indexing_properties.pNext = nullptr;
             _bindless_heap_capacity =
-                detail::plan_bindless_heap_capacity({.max_per_stage_update_after_bind_samplers =
+                detail::plan_bindless_heap_capacity({.max_per_set_descriptors =
+                                                         maintenance3_properties.maxPerSetDescriptors,
+                                                     .max_per_stage_update_after_bind_samplers =
                                                          _descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSamplers,
                                                      .max_descriptor_set_update_after_bind_samplers =
                                                          _descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSamplers,
@@ -2077,19 +2140,36 @@ void Device::_init_device(VkPhysicalDevice external_physical_device, VkDevice ex
                 .bindingCount = 1u,
                 .pBindings = &global_bindless_bindings[i]};
         }
-        // Query every persistent global layout before creating the first pool
-        // or layout. This keeps device initialization atomic with respect to
-        // implementation-specific update-after-bind layout restrictions.
-        for (auto i = 0u; i < global_bindless_layouts.size(); ++i) {
-            VkDescriptorSetLayoutSupport support{
-                .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT};
-            vkGetDescriptorSetLayoutSupport(
-                logic_device(), &global_bindless_layouts[i], &support);
-            LUISA_ASSERT(
-                support.supported == VK_TRUE,
-                "Vulkan device rejected global bindless descriptor layout {} "
-                "at capacity {}.",
-                i, _bindless_heap_capacity);
+        // Some implementations apply additional per-layout restrictions not
+        // reflected by descriptor-indexing properties. Negotiate one capacity
+        // accepted by all three persistent global layouts before creating any
+        // descriptor pool or layout.
+        auto planned_capacity = _bindless_heap_capacity;
+        _bindless_heap_capacity = detail::negotiate_bindless_heap_capacity(
+            planned_capacity, [&](uint32_t capacity) noexcept {
+                for (auto i = 0u; i < global_bindless_layouts.size(); ++i) {
+                    global_bindless_bindings[i].descriptorCount = capacity;
+                    VkDescriptorSetLayoutSupport support{
+                        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT};
+                    vkGetDescriptorSetLayoutSupport(
+                        logic_device(), &global_bindless_layouts[i], &support);
+                    if (support.supported != VK_TRUE) { return false; }
+                }
+                return true;
+            });
+        LUISA_ASSERT(
+            _bindless_heap_capacity != 0u,
+            "Vulkan device does not support any usable global bindless "
+            "descriptor layout capacity (planned upper bound: {}).",
+            planned_capacity);
+        for (auto &binding : global_bindless_bindings) {
+            binding.descriptorCount = _bindless_heap_capacity;
+        }
+        if (_bindless_heap_capacity < planned_capacity) {
+            LUISA_INFO(
+                "Vulkan bindless heap capacity negotiated from {} to {} by "
+                "descriptor-set layout support.",
+                planned_capacity, _bindless_heap_capacity);
         }
     }
     // bindless buffer desc_pool

--- a/src/backends/vk/device_feature_plan.h
+++ b/src/backends/vk/device_feature_plan.h
@@ -23,6 +23,7 @@ inline constexpr uint32_t local_per_stage_descriptor_budget = 256u;
 inline constexpr uint32_t fixed_sampler_descriptor_count = 16u;
 
 struct BindlessHeapLimits {
+    uint32_t max_per_set_descriptors{};
     uint32_t max_per_stage_update_after_bind_samplers{};
     uint32_t max_descriptor_set_update_after_bind_samplers{};
     uint32_t max_per_stage_update_after_bind_storage_buffers{};
@@ -54,6 +55,7 @@ struct BindlessHeapLimits {
     // local storage + C, local sampled + 2C, and local resources + 3C. The
     // all-pools limit covers only the three persistent update-after-bind pools.
     return std::min({requested_capacity,
+                     limits.max_per_set_descriptors,
                      reserve_local_descriptors(
                          limits.max_per_stage_update_after_bind_storage_buffers),
                      reserve_local_descriptors(
@@ -68,6 +70,36 @@ struct BindlessHeapLimits {
                          limits.max_per_stage_update_after_bind_resources) /
                          3u,
                      limits.max_update_after_bind_descriptors_in_all_pools / 3u});
+}
+
+template<typename F>
+[[nodiscard]] uint32_t negotiate_bindless_heap_capacity(
+    uint32_t upper_bound, F &&supports_capacity) noexcept {
+    auto lower = 0u;
+    while (lower < upper_bound) {
+        auto capacity = lower + (upper_bound - lower + 1u) / 2u;
+        if (supports_capacity(capacity)) {
+            lower = capacity;
+        } else {
+            upper_bound = capacity - 1u;
+        }
+    }
+    return lower;
+}
+
+struct DefaultDeviceCandidate {
+    bool supports_graphics_compute{false};
+    uint32_t bindless_heap_capacity{};
+};
+
+[[nodiscard]] constexpr bool prefer_default_device_candidate(
+    DefaultDeviceCandidate candidate, DefaultDeviceCandidate current,
+    bool require_bindless) noexcept {
+    auto usable = [require_bindless](DefaultDeviceCandidate value) noexcept {
+        return value.supports_graphics_compute &&
+               (!require_bindless || value.bindless_heap_capacity != 0u);
+    };
+    return usable(candidate) && !usable(current);
 }
 
 // robustBufferAccess and storage-buffer update-after-bind can only be enabled

--- a/src/tests/unit/ext/test_vk_device_feature_plan.cpp
+++ b/src/tests/unit/ext/test_vk_device_feature_plan.cpp
@@ -2319,6 +2319,7 @@ int main(int argc, char *argv[]) {
     "vk_bindless_heap_capacity_reserves_local_budget_before_per_stage_clamps"_test = [] {
         using namespace lc::vk::detail;
         constexpr BindlessHeapLimits generous{
+            .max_per_set_descriptors = 1'000'000u,
             .max_per_stage_update_after_bind_samplers = 1'000'000u,
             .max_descriptor_set_update_after_bind_samplers = 1'000'000u,
             .max_per_stage_update_after_bind_storage_buffers = 1'000'000u,
@@ -2366,6 +2367,7 @@ int main(int argc, char *argv[]) {
     "vk_bindless_heap_capacity_applies_set_pool_and_request_limits_exactly"_test = [] {
         using namespace lc::vk::detail;
         constexpr BindlessHeapLimits generous{
+            .max_per_set_descriptors = 1'000'000u,
             .max_per_stage_update_after_bind_samplers = 1'000'000u,
             .max_descriptor_set_update_after_bind_samplers = 1'000'000u,
             .max_per_stage_update_after_bind_storage_buffers = 1'000'000u,
@@ -2376,6 +2378,13 @@ int main(int argc, char *argv[]) {
             .max_update_after_bind_descriptors_in_all_pools = 1'000'000u};
         expect(eq(plan_bindless_heap_capacity(generous),
                   requested_bindless_heap_capacity));
+
+        constexpr auto per_set_limited = [=] {
+            auto limits = generous;
+            limits.max_per_set_descriptors = 1212u;
+            return plan_bindless_heap_capacity(limits);
+        }();
+        expect(eq(per_set_limited, 1212u));
 
         constexpr auto sampled_set_limited = [=] {
             auto limits = generous;
@@ -2410,6 +2419,43 @@ int main(int argc, char *argv[]) {
         }();
         expect(eq(sampler_limited, 0u))
             << "the fixed ordinary sampler set participates in UAB aggregates";
+    };
+
+    "vk_bindless_heap_capacity_negotiates_layout_support"_test = [] {
+        using namespace lc::vk::detail;
+        auto queries = 0u;
+        auto capacity = negotiate_bindless_heap_capacity(
+            requested_bindless_heap_capacity,
+            [&queries](uint32_t value) noexcept {
+                ++queries;
+                return value <= 1211u;
+            });
+        expect(eq(capacity, 1211u));
+        expect(queries < 20u);
+        expect(eq(negotiate_bindless_heap_capacity(
+                      16u, [](uint32_t) noexcept { return false; }),
+                  0u));
+    };
+
+    "vk_default_device_selection_requires_usable_bindless_when_enabled"_test = [] {
+        using namespace lc::vk::detail;
+        constexpr DefaultDeviceCandidate no_bindless{
+            .supports_graphics_compute = true,
+            .bindless_heap_capacity = 0u};
+        constexpr DefaultDeviceCandidate molten_vk{
+            .supports_graphics_compute = true,
+            .bindless_heap_capacity = 1212u};
+        constexpr DefaultDeviceCandidate large_heap{
+            .supports_graphics_compute = true,
+            .bindless_heap_capacity = requested_bindless_heap_capacity};
+        static_assert(prefer_default_device_candidate(
+            molten_vk, no_bindless, true));
+        static_assert(!prefer_default_device_candidate(
+            large_heap, molten_vk, true));
+        static_assert(!prefer_default_device_candidate(
+            no_bindless, molten_vk, true));
+        static_assert(prefer_default_device_candidate(
+            no_bindless, {}, false));
     };
 
     "vk_required_features_use_core_without_redundant_extensions"_test = [] {


### PR DESCRIPTION
## Summary

- include `VkPhysicalDeviceMaintenance3Properties::maxPerSetDescriptors` in Vulkan bindless heap planning
- negotiate the largest common capacity accepted by all three global bindless layouts with `vkGetDescriptorSetLayoutSupport`
- require a usable graphics+compute bindless candidate during implicit Apple device selection while preserving explicit `device_index` behavior

## Background

MoltenVK can advertise update-after-bind storage-buffer and sampled-image limits of 1,000,000 while separately reporting `maxPerSetDescriptors = 1212`. The existing planner therefore selected the requested capacity of 262,144. MoltenVK's layout-support query rejects 1,212 and accepts 1,211, so device initialization stopped at the defensive layout assertion even though a smaller heap was usable.

The updated planner applies the maintenance-3 upper bound first. After logical-device creation, a binary search queries the exact storage-buffer and sampled-image layouts and chooses the largest capacity supported by all three. A zero result remains a clear initialization error.

On Apple platforms, implicit selection now skips graphics+compute candidates that cannot provide any planned bindless capacity. Equally usable candidates retain enumeration order, and explicit indices still bypass this preference. Non-Apple selection is unchanged.

## Validation

- Vulkan backend and `test_vk_device_feature_plan` build successfully with Apple Clang 21
- `test_vk_device_feature_plan`: passed
- `test_buffer_io vk`: default Apple M5 device `0x1a05020a`; capacity planned at 1,212, negotiated to 1,211; all 52 assertions passed
- downstream Vulkan/XIR parity suite: 23/23 tests passed on the same device

Devices that support 262,144 descriptors retain the existing capacity. The change is confined to the Vulkan backend; Metal, CUDA, HIP, and other backends are unaffected.
