### PR TITLE
fix(vk): preserve logical types for UBO-loaded constants

### DIFF
--- a/src/backends/common/spirv/spirv_codegen/emit.cpp
+++ b/src/backends/common/spirv/spirv_codegen/emit.cpp
@@ -423,7 +423,12 @@ spv::Id SpirvCodegenEntry::_emit_constant(const xir::Constant *c) noexcept {
         auto ptr = _create_access_chain(
             spv::StorageClass::Uniform, _constant_ubo_var,
             std::vector<spv::Id>{_builder.makeUintConstant(ubo_it->second)});
-        return _builder.createLoad(ptr, spv::NoPrecision);
+        auto loaded = _builder.createLoad(ptr, spv::NoPrecision);
+        auto logical_type = _convert_type(c->type(), Usage::READ);
+        return _builder.getTypeId(loaded) == logical_type ?
+                   loaded :
+                   _builder.createUnaryOp(
+                       spv::Op::OpCopyLogical, logical_type, loaded);
     }
     auto id = _emit_literal(c->type(), c->data());
     LUISA_ASSERT(id != spv::NoResult, "Failed to emit constant.");

--- a/src/tests/unit/runtime/test_vk_spirv_codegen_path.cpp
+++ b/src/tests/unit/runtime/test_vk_spirv_codegen_path.cpp
@@ -2236,6 +2236,43 @@ OpName %8 "Fma"
             << "autodiff scope should be lowered before SPIR-V emission";
     };
 
+    "vk_user_compute_autodiff_array_store_uses_logical_type"_test = [&] {
+        ScopedEnvironmentVariable disable_spirv_optimization{
+            "LUISA_SPIRV_OPT_LEVEL", "0"};
+        ScopedEnvironmentVariable clear_spirv_pass_override{
+            "LUISA_SPIRV_OPT_PASSES", nullptr};
+        auto dc = luisa::test::create_device(argc, argv);
+        auto input = dc.device.create_buffer<std::array<float, 1u>>(1u);
+        auto output = dc.device.create_buffer<float>(1u);
+        auto stream = dc.device.create_stream();
+        Kernel1D kernel = [](BufferVar<std::array<float, 1u>> in,
+                             BufferFloat out) noexcept {
+            auto i = dispatch_x();
+            auto p = in.read(i);
+            $autodiff {
+                requires_grad(p);
+                ArrayFloat<1> scratch;
+                scratch = p;
+                auto used = scratch[0];
+                auto loss = used * used;
+                scratch[0] = p[0] * 7.0f;
+                backward(loss);
+                out.write(i, grad(p)[0]);
+            };
+        };
+        auto shader = dc.device.compile(
+            kernel, ShaderOption{.enable_cache = false,
+                                 .enable_fast_math = false});
+        constexpr std::array source{std::array<float, 1u>{3.0f}};
+        std::array<float, 1u> result{};
+        stream << input.copy_from(luisa::span{source})
+               << shader(input, output).dispatch(1u)
+               << output.copy_to(luisa::span{result})
+               << synchronize();
+        expect(result[0] == 6.0f)
+            << "aggregate autodiff stores should preserve the logical array type";
+    };
+
     "vk_user_compute_aot_uses_spirv_not_hlsl"_test = [&] {
         constexpr std::string_view hlsl_dump = "hlsl_output_vk_spirv_codegen_path_aot.hlsl";
         constexpr std::string_view spv_dump = "spv_code_vk_spirv_codegen_path_aot.spvasm";


### PR DESCRIPTION
## Summary

- Preserve the logical XIR type of constants loaded from the std140 constant UBO.
- Add a Vulkan runtime regression for an autodiff aggregate scratch value that is overwritten after use.

## Root cause

The native Vulkan XIR-to-SPIR-V path lowers eligible array constants into a Uniform block whose SPIR-V array types carry explicit layout decorations. `_emit_constant` returned that physical load result directly, even when its type ID differed from the logical XIR array type used by later aggregate operations.

Reverse-mode autodiff exposed the mismatch through an aggregate insert/store sequence. On the current `next` baseline the reproducer aborted with:

```text
Assertion 'pointee_type == val_type' failed:
SPIR-V store type mismatch escaped XIR dialect validation.
pointee_type = 35
val_type = 5
```

With the assertion bypassed for diagnosis, SPIRV-Tools reported:

```text
The Result Type must be the same as Composite type in OpCompositeInsert
%127 = OpCompositeInsert %_arr_float_uint_1_1 %float_0 %118 0
```

Metal and HLSL go through logical AST assignment and do not expose the Uniform layout-qualified type ID to aggregate operations.

## Fix

After loading a constant UBO member, compare its physical SPIR-V type ID with the logical type produced by `_convert_type`. Emit `OpCopyLogical` only when they differ; existing loads whose IDs already match are unchanged. The UBO planner already excludes logical booleans, structures, and nested arrays, and separately gates narrow Uniform storage features.

## Verification

- Full CMake build: `cmake --build /tmp/lc-vk-build --parallel 4` (exit 0).
- Strict native-XIR regression: `vk_user_compute_autodiff_array_store_uses_logical_type` passed; `SPIR-V compilation successful, binary size: 992 words, properties: 6 binds`; `Suite 'global': all tests passed (1 asserts in 87 tests)`.
- Related autodiff callable test passed; `binary size: 839 words`; `all tests passed (4 asserts in 87 tests)`.
- Constant UBO boundary tests passed under the strict native guard:
  - `vk_user_compute_mat2_constant_array_uses_std140_matrix_stride`: 35 assertions.
  - `vk_user_compute_nested_constant_dynamic_index_uses_non_ubo_fallback`: 123 assertions.

The complete runtime executable was also attempted. It progressed beyond the tests above but is currently aborted later on this MoltenVK device by an unrelated existing `bool4`/`short4` shader-library compilation failure.

## Downstream workaround

Feather currently sets a non-empty `ShaderOption::native_include` for Vulkan autodiff kernels specifically to select LuisaCompute's HLSL compatibility route and avoid this native SPIR-V type-ID failure. Once this fix is available in the pinned LuisaCompute revision, that compatibility workaround can be removed.
