### PR TITLE
perf(xir): linearize verifier/dominator/restructure analyses on large modules

### DIFF
--- a/include/luisa/xir/passes/dom_tree.h
+++ b/include/luisa/xir/passes/dom_tree.h
@@ -57,6 +57,10 @@ public:
 };
 
 /// Null and declaration-only functions yield an empty tree.
-[[nodiscard]] LUISA_XIR_API DomTree compute_dom_tree(Function *function) noexcept;
+/// When \p compute_frontiers is false, the dominance frontiers are not
+/// computed; callers that never query them (e.g. structural passes that
+/// rebuild dominance frequently) avoid the potentially quadratic cost.
+[[nodiscard]] LUISA_XIR_API DomTree compute_dom_tree(Function *function,
+                                                     bool compute_frontiers = true) noexcept;
 
 }// namespace luisa::compute::xir

--- a/src/xir/passes/dom_tree.cpp
+++ b/src/xir/passes/dom_tree.cpp
@@ -138,7 +138,8 @@ auto DomTree::immediate_dominator(BasicBlock *block) const noexcept -> BasicBloc
 }
 
 // Reference: A Simple, Fast Dominance Algorithm [Cooper et al. 2001]
-DomTree compute_dom_tree(Function *function) noexcept {
+DomTree compute_dom_tree(Function *function,
+                           bool compute_frontiers) noexcept {
     auto definition =
         function == nullptr ? nullptr : function->definition();
     if (definition == nullptr || definition->body_block() == nullptr) {
@@ -217,28 +218,43 @@ DomTree compute_dom_tree(Function *function) noexcept {
         return finger1;
     };
 
-    // fixed-point iteration
-    for (;;) {
-        auto changed = false;
-        for (auto block : reverse_postorder) {
-            auto new_idom = static_cast<BasicBlock *>(nullptr);
-            block->traverse_predecessors(false, [&](BasicBlock *pred) noexcept {
-                auto dom_of_pred = get_dom(pred);
-                if (dom_of_pred != nullptr) {
-                    if (new_idom == nullptr) {
-                        new_idom = pred;
-                    } else {
-                        new_idom = intersect(pred, new_idom);
-                    }
-                }
-            });
-            auto &dom = doms_vec[block_id[block]];
-            if (dom != new_idom) {
-                dom = new_idom;
-                changed = true;
+    // Worklist-driven fixed point from the top. The naive full-scan loop is
+    // O(N^2) in the block count on deep chains (N passes, each walking every
+    // block's predecessors), which makes repeated rebuilds pathological on
+    // large functions. Seeding the worklist with the root's successors and
+    // re-processing only the successors of blocks whose idom changed converges
+    // to the same (unique) dominator solution while doing a small, practically
+    // linear amount of work. A null idom means "undefined/top" during
+    // iteration: it contributes nothing to the intersection, and a block whose
+    // predecessors are all undefined stays undefined until one of them is
+    // refined and re-pushes it.
+    luisa::vector<BasicBlock *> worklist;
+    root_block->traverse_successors(false, [&](BasicBlock *succ) noexcept {
+        if (block_id.contains(succ)) { worklist.emplace_back(succ); }
+    });
+    while (!worklist.empty()) {
+        auto *block = worklist.back();
+        worklist.pop_back();
+        if (block == root_block) { continue; }// the entry dominates itself only
+        auto new_idom = static_cast<BasicBlock *>(nullptr);
+        block->traverse_predecessors(false, [&](BasicBlock *pred) noexcept {
+            auto dom_of_pred = get_dom(pred);
+            if (dom_of_pred == nullptr) { return; }
+            // Mirror the historical Cooper iteration exactly: the candidate
+            // chain starts at the predecessor block itself, not at its idom.
+            if (new_idom == nullptr) {
+                new_idom = pred;
+            } else {
+                new_idom = intersect(pred, new_idom);
             }
+        });
+        if (new_idom == nullptr) { continue; }
+        if (get_dom(block) != new_idom) {
+            doms_vec[block_id[block]] = new_idom;
+            block->traverse_successors(false, [&](BasicBlock *succ) noexcept {
+                if (block_id.contains(succ)) { worklist.emplace_back(succ); }
+            });
         }
-        if (!changed) { break; }
     }
     // create the dom tree
     DomTree tree;
@@ -249,7 +265,7 @@ DomTree compute_dom_tree(Function *function) noexcept {
     }
     tree.set_root(tree.add_or_get_node(root_block));
     tree.compute_ancestry_intervals();
-    tree.compute_dominance_frontiers();
+    if (compute_frontiers) { tree.compute_dominance_frontiers(); }
     return tree;
 }
 

--- a/src/xir/passes/restructure_cfg.cpp
+++ b/src/xir/passes/restructure_cfg.cpp
@@ -404,32 +404,41 @@ struct PostDomInfo {
         return f1;
     };
 
-    bool changed = true;
-    while (changed) {
-        changed = false;
-        for (auto it = rpo.rbegin(); it != rpo.rend(); ++it) {
-            auto *bb = *it;
-            if (bb == virt) { continue; }
+    // Worklist-driven post-dominator fixed point. The naive full-scan loop is
+    // O(N^3) in the block count (N passes, each re-intersecting successor
+    // chains for every block); re-processing only the predecessors of blocks
+    // whose immediate post-dominator changed converges from the top (nullptr)
+    // to the identical maximum fixed point while doing a small, practically
+    // linear amount of work.
+    luisa::vector<BasicBlock *> worklist;
+    for (auto *bb : rpo) {
+        if (bb == virt) { continue; }
+        if (is_sink(bb)) { worklist.emplace_back(bb); }
+    }
+    while (!worklist.empty()) {
+        auto *bb = worklist.back();
+        worklist.pop_back();
 
-            luisa::vector<BasicBlock *> succs;
-            if (is_sink(bb)) {
-                succs.emplace_back(virt);
-            } else {
-                bb->traverse_successors(false, [&](BasicBlock *s) noexcept { succs.emplace_back(s); });
-            }
-
-            BasicBlock *new_ipostdom = nullptr;
-            for (auto *s : succs) {
-                if (is_processed(s)) {
-                    new_ipostdom = intersect(new_ipostdom, s);
-                }
-            }
-            if (get_ipostdom(bb) != new_ipostdom) {
-                set_ipostdom(bb, new_ipostdom);
-                changed = true;
-            }
-            if (new_ipostdom != nullptr) { set_processed(bb); }
+        luisa::vector<BasicBlock *> succs;
+        if (is_sink(bb)) {
+            succs.emplace_back(virt);
+        } else {
+            bb->traverse_successors(false, [&](BasicBlock *s) noexcept { succs.emplace_back(s); });
         }
+
+        BasicBlock *new_ipostdom = nullptr;
+        for (auto *s : succs) {
+            if (is_processed(s)) {
+                new_ipostdom = intersect(new_ipostdom, s);
+            }
+        }
+        if (get_ipostdom(bb) != new_ipostdom) {
+            set_ipostdom(bb, new_ipostdom);
+            bb->traverse_predecessors(false, [&](BasicBlock *pred) noexcept {
+                worklist.emplace_back(pred);
+            });
+        }
+        if (new_ipostdom != nullptr) { set_processed(bb); }
     }
 
     // Convert dense results back to hash map for API compatibility.
@@ -563,10 +572,14 @@ bool retarget_terminator(Instruction *term, BasicBlock *from, BasicBlock *to) no
 
 void fix_degenerate_terminator(BasicBlock *bb) noexcept;
 
+struct StructuredLoopExitInfo;
+
 [[nodiscard]] luisa::unordered_set<BasicBlock *>
 collect_enclosing_loop_exits(FunctionDefinition *def,
                              BasicBlock *header,
-                             const DomTree &dom) noexcept;
+                             const DomTree &dom,
+                             const luisa::vector<StructuredLoopExitInfo> *
+                                 precomputed_loops = nullptr) noexcept;
 [[nodiscard]] BasicBlock *
 structured_statement_merge(Instruction *term) noexcept;
 [[nodiscard]] BasicBlock *
@@ -580,7 +593,9 @@ canonical_exit_target(BasicBlock *target) noexcept;
     FunctionDefinition *def,
     BasicBlock *header,
     luisa::span<BasicBlock *const> entries,
-    const DomTree &dom) noexcept {
+    const DomTree &dom,
+    const luisa::vector<StructuredLoopExitInfo> *precomputed_loops =
+        nullptr) noexcept {
     if (def == nullptr || header == nullptr || entries.empty()) {
         return nullptr;
     }
@@ -589,7 +604,7 @@ canonical_exit_target(BasicBlock *target) noexcept;
     // its raw selection is rebuilt with a synthetic merge by the caller.
     if (!dom.contains(header)) { return nullptr; }
     auto boundaries =
-        collect_enclosing_loop_exits(def, header, dom);
+        collect_enclosing_loop_exits(def, header, dom, precomputed_loops);
     luisa::vector<luisa::unordered_map<BasicBlock *, size_t>>
         distances;
     distances.reserve(entries.size());
@@ -653,7 +668,12 @@ canonical_exit_target(BasicBlock *target) noexcept;
                     max_distance, total_distance};
             }
         };
-    for (auto *candidate : def->basic_blocks()) {
+    // Only blocks actually reached by at least one BFS can score. A candidate
+    // with support >= 2 must appear in every entry's distance map, so the
+    // first map's key set is a superset of all plausible merge blocks; scoring
+    // the whole function here would make inference O(blocks x entries) per
+    // selection header, which is quadratic in the module size.
+    for (auto &&[candidate, _] : distances.front()) {
         if (candidate == nullptr || candidate == header ||
             boundaries.contains(candidate)) {
             continue;
@@ -801,7 +821,7 @@ canonical_exit_target(BasicBlock *target) noexcept;
 void restructure_indexed_branches(
     FunctionDefinition *def, RestructureCFGInfo &info) noexcept {
     for (;;) {
-        auto dom = compute_dom_tree(def);
+        auto dom = compute_dom_tree(def, false);
         auto pdom = compute_post_dom(def);
         BasicBlock *header = nullptr;
         IndexedBranchInst *indexed_branch = nullptr;
@@ -1119,7 +1139,7 @@ void traverse_structured_successors(BasicBlock *bb, Visitor &&visit) noexcept {
                                                        BasicBlock *continue_target,
                                                        BasicBlock *merge) noexcept {
     auto function_blocks = collect_function_blocks(def);
-    auto dom = compute_dom_tree(def);
+    auto dom = compute_dom_tree(def, false);
     auto is_live_block = [&](BasicBlock *bb) noexcept {
         return bb != nullptr && function_blocks.contains(bb);
     };
@@ -1324,7 +1344,7 @@ enum struct LoopBoundaryTargetKind {
                                                                       exit_dispatch_headers,
                                                                   const luisa::unordered_set<BasicBlock *> &
                                                                       generated_exit_dispatch_headers) noexcept {
-    auto dom = compute_dom_tree(def);
+    auto dom = compute_dom_tree(def, false);
     struct LoopSite {
         BasicBlock *owner{nullptr};
         BasicBlock *entry{nullptr};
@@ -2654,11 +2674,18 @@ collect_structured_loop_exit_info(
 collect_enclosing_loop_exits(
     FunctionDefinition *def,
     BasicBlock *header,
-    const DomTree &dom) noexcept {
+    const DomTree &dom,
+    const luisa::vector<StructuredLoopExitInfo> *precomputed_loops) noexcept {
     luisa::unordered_set<BasicBlock *> exits;
     if (!dom.contains(header)) { return exits; }
-    for (auto &&loop :
-         collect_structured_loop_exit_info(def)) {
+    // Re-scanning the whole CFG for structured loops per call makes
+    // selection-merge inference quadratic in the block count (every candidate
+    // re-walks every loop). Callers that infer merges for many candidates
+    // precompute the loop set once and pass it in.
+    const auto &loops = precomputed_loops != nullptr
+                            ? *precomputed_loops
+                            : collect_structured_loop_exit_info(def);
+    for (auto &&loop : loops) {
         if (!dom.contains(loop.header) ||
             !dom.dominates(loop.header, header)) {
             continue;
@@ -3144,7 +3171,7 @@ void repair_target_state_dispatch_ssa(
             break;
         }
         modified = true;
-        dom = compute_dom_tree(def);
+        dom = compute_dom_tree(def, false);
         pdom = compute_post_dom(def);
     }
     return modified;
@@ -3750,6 +3777,62 @@ void repair_target_state_dispatch_ssa(
         ConditionalBranchInst *cbr;
         size_t depth;
     };
+    // Merges of constructs that are already structured before this batch runs
+    // (loops, previously restructured selections). Their interiors are
+    // excluded from candidate scopes; the set is fixed for the whole batch
+    // because restructuring retargets terminators but never creates
+    // structured constructs. Precompute the interior as a plain set so the
+    // per-block scope test stays O(1) during candidate processing.
+    luisa::unordered_set<BasicBlock *> structured_merges;
+    def->traverse_basic_blocks([&](BasicBlock *bb) noexcept {
+        if (!bb->is_terminated()) { return; }
+        if (auto *m = structured_statement_merge(bb->terminator());
+            m != nullptr) {
+            structured_merges.emplace(m);
+        }
+    });
+    luisa::unordered_set<BasicBlock *> structured_interior;
+    for (auto *m : structured_merges) {
+        auto *merge_node = dom.node_or_null(m);
+        if (merge_node == nullptr) { continue; }
+        luisa::vector<const DomTreeNode *> stack{merge_node};
+        while (!stack.empty()) {
+            auto *node = stack.back();
+            stack.pop_back();
+            auto *inner = node->block();
+            // Merge blocks themselves remain part of the enclosing scope
+            // (mirroring the historical worklist that pushed a nested
+            // construct's merge without descending into its interior).
+            if (inner != m && !structured_merges.contains(inner)) {
+                structured_interior.emplace(inner);
+            }
+            for (auto *child : node->children()) {
+                stack.emplace_back(child);
+            }
+        }
+    }
+
+    // Structured loops are immutable during this batch (restructuring only
+    // retargets terminators), so collect them once and reuse for every merge
+    // inference instead of re-scanning the CFG per candidate.
+    auto structured_loops = collect_structured_loop_exit_info(def);
+
+    // Blocks whose terminators may need retargeting (unstructured branches).
+    // Retargeting only changes terminator targets and never turns a block into
+    // or out of this class, and newly created structural merges are appended
+    // below, so this snapshot stays complete for the whole batch. Walking the
+    // dominator subtree per candidate instead would be quadratic in the block
+    // count on chains of conditional branches.
+    luisa::vector<BasicBlock *> unstructured_blocks;
+    def->traverse_basic_blocks([&](BasicBlock *bb) noexcept {
+        if (!bb->is_terminated()) { return; }
+        auto *term = bb->terminator();
+        if (term->isa<ConditionalBranchInst>() ||
+            term->isa<BranchInst>()) {
+            unstructured_blocks.emplace_back(bb);
+        }
+    });
+
     luisa::vector<Candidate> candidates;
 
     def->traverse_basic_blocks([&](BasicBlock *bb) noexcept {
@@ -3764,18 +3847,36 @@ void repair_target_state_dispatch_ssa(
         if (true_bb == false_bb) { return; }
 
         auto entries = std::array{true_bb, false_bb};
-        auto *merge = infer_selection_merge(
-            def, bb,
-            luisa::span<BasicBlock *const>{
-                entries.data(), entries.size()},
-            dom);
-        if (merge == nullptr) {
+        // Fast path: the immediate post-dominator is the merge for ordinary
+        // single-exit selections, and is exactly what the historical fallback
+        // accepted. Computing it is O(1), while the distance-scoring BFS below
+        // re-walks the candidate's whole dominated tail, which is quadratic in
+        // the block count for chains of conditional branches. Fall back to the
+        // BFS only when no post-dominator exists.
+        BasicBlock *merge = nullptr;
+        {
             auto ipm_it = pdom.ipostdom.find(bb);
-            if (ipm_it == pdom.ipostdom.end() ||
-                ipm_it->second == nullptr) {
-                return;
+            if (ipm_it != pdom.ipostdom.end() &&
+                ipm_it->second != nullptr &&
+                ipm_it->second != pdom.virtual_exit &&
+                ipm_it->second != bb) {
+                merge = ipm_it->second;
             }
-            merge = ipm_it->second;
+        }
+        if (merge == nullptr) {
+            merge = infer_selection_merge(
+                def, bb,
+                luisa::span<BasicBlock *const>{
+                    entries.data(), entries.size()},
+                dom, &structured_loops);
+            if (merge == nullptr) {
+                auto ipm_it = pdom.ipostdom.find(bb);
+                if (ipm_it == pdom.ipostdom.end() ||
+                    ipm_it->second == nullptr) {
+                    return;
+                }
+                merge = ipm_it->second;
+            }
         }
         if (merge == pdom.virtual_exit) { return; }
         if (merge == bb) { return; }
@@ -3825,11 +3926,24 @@ void repair_target_state_dispatch_ssa(
             continue;
         }
         auto entries = std::array{true_bb, false_bb};
-        auto *found_merge = infer_selection_merge(
-            def, found_header,
-            luisa::span<BasicBlock *const>{
-                entries.data(), entries.size()},
-            dom);
+        // Same O(1) post-dominator fast path as candidate collection.
+        BasicBlock *found_merge = nullptr;
+        if (pdom_valid) {
+            auto merge_iter = pdom.ipostdom.find(found_header);
+            if (merge_iter != pdom.ipostdom.end() &&
+                merge_iter->second != nullptr &&
+                merge_iter->second != pdom.virtual_exit &&
+                merge_iter->second != found_header) {
+                found_merge = merge_iter->second;
+            }
+        }
+        if (found_merge == nullptr) {
+            found_merge = infer_selection_merge(
+                def, found_header,
+                luisa::span<BasicBlock *const>{
+                    entries.data(), entries.size()},
+                dom, &structured_loops);
+        }
         if (found_merge == nullptr) {
             // Post-dominance is a fallback for candidates whose merge cannot
             // be inferred from the current dominance tree. Rebuild it lazily
@@ -3876,6 +3990,7 @@ void repair_target_state_dispatch_ssa(
             structural_merge = def->create_basic_block();
             created_structural_merges.emplace(structural_merge);
             sm_to_header.emplace(structural_merge, found_header);
+            unstructured_blocks.emplace_back(structural_merge);
             {
                 XIRBuilder mb;
                 mb.set_insertion_point(structural_merge);
@@ -3903,50 +4018,32 @@ void repair_target_state_dispatch_ssa(
             }
         }
 
-        // Compute the set of blocks inside the current if's scope.
-        luisa::unordered_set<BasicBlock *> if_scope_blocks;
-        {
-            luisa::vector<BasicBlock *> scope_work;
-            if (true_bb != found_merge && true_bb != structural_merge) {
-                scope_work.push_back(true_bb);
-            }
-            if (false_bb != found_merge && false_bb != structural_merge) {
-                scope_work.push_back(false_bb);
-            }
-            while (!scope_work.empty()) {
-                auto *bb = scope_work.back();
-                scope_work.pop_back();
-                if (bb == found_merge || bb == structural_merge) { continue; }
-                if (!if_scope_blocks.emplace(bb).second) { continue; }
-                if (!bb->is_terminated()) { continue; }
-                if (auto *nested_merge =
-                        structured_statement_merge(bb->terminator());
-                    nested_merge != nullptr &&
-                    nested_merge != found_merge &&
-                    nested_merge != structural_merge) {
-                    scope_work.push_back(nested_merge);
-                    continue;
-                }
-                bb->traverse_successors(false, [&](BasicBlock *succ) noexcept {
-                    scope_work.emplace_back(succ);
-                });
-            }
-        }
+        // The scope of (header, merge) is characterized by dominance: blocks
+        // dominated by the header, not dominated by the merge, and not inside
+        // an already-structured inner construct. After destructuring, such
+        // constructs are rare (loops, previously restructured selections), so
+        // testing membership against their merge subtrees directly is cheap.
+        // Building a reachability set per candidate with a worklist is
+        // quadratic in the block count for chains of conditional branches
+        // (each candidate re-walks the whole tail of the chain).
+        auto in_scope = [&](BasicBlock *bb) noexcept -> bool {
+            if (!dom.dominates(found_header, bb)) { return false; }
+            if (bb == found_merge || bb == structural_merge) { return false; }
+            if (dom.dominates(found_merge, bb)) { return false; }
+            if (structured_interior.contains(bb)) { return false; }
+            return true;
+        };
 
-        // Walk the dominator-tree subtree rooted at found_header.
         // Only retarget unstructured cbr/br blocks that are actually inside
         // the if's scope. Skip IfInst/SwitchInst/LoopInst terminators to avoid
-        // corrupting already-structured inner constructs.
-        auto header_node = dom.node_or_null(found_header);
-        if (header_node != nullptr) {
-            luisa::vector<const DomTreeNode *> work;
-            work.push_back(header_node);
-            while (!work.empty()) {
-                auto *node = work.back();
-                work.pop_back();
-                auto *bb = node->block();
+        // corrupting already-structured inner constructs. Equivalent to the
+        // historical dominator-subtree walk for every block that can be
+        // retargeted (the snapshot above stays complete), but linear in the
+        // number of such blocks per candidate instead of the whole subtree.
+        {
+            for (auto *bb : unstructured_blocks) {
                 if (bb != structural_merge && bb != found_header && bb != found_merge &&
-                    bb->is_terminated() && if_scope_blocks.contains(bb) &&
+                    bb->is_terminated() && in_scope(bb) &&
                     !allowed_outside_targets.contains(bb)) {
                     auto *term = bb->terminator();
                     if (term->isa<ConditionalBranchInst>() || term->isa<BranchInst>()) {
@@ -3964,9 +4061,6 @@ void repair_target_state_dispatch_ssa(
                         }
                         fix_degenerate_terminator(bb);
                     }
-                }
-                for (auto *child : node->children()) {
-                    work.push_back(child);
                 }
             }
         }
@@ -4016,7 +4110,7 @@ void repair_target_state_dispatch_ssa(
             // walks include newly inserted structural merges. Mark post-dom
             // stale; the fallback above refreshes it only if a later
             // candidate actually requires an immediate post-dominator.
-            dom = compute_dom_tree(def);
+            dom = compute_dom_tree(def, false);
             pdom_valid = false;
         }
     }
@@ -4412,7 +4506,7 @@ struct PostMergeSelectionReentry {
             // either the original arm or its clone writes the same slot before
             // the common continuation reloads it.
             repair_target_state_dispatch_ssa(def);
-            dom = compute_dom_tree(def);
+            dom = compute_dom_tree(def, false);
             pdom = compute_post_dom(def);
             LUISA_ASSERT(
                 clone_owned_subgraph_for_edge(
@@ -4425,7 +4519,7 @@ struct PostMergeSelectionReentry {
                     reentry.merge, dom, true),
                 "Selection re-entry node splitting made no progress.");
             ++info.canonicalized_cfg_count;
-            dom = compute_dom_tree(def);
+            dom = compute_dom_tree(def, false);
             pdom = compute_post_dom(def);
             return true;
         }
@@ -4472,7 +4566,7 @@ struct PostMergeSelectionReentry {
         luisa::unordered_set<BasicBlock *> rewritten_predecessors;
         for (;;) {
             if (!dom_valid) {
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 ++info.construct_entry_dom_tree_count;
                 dom_valid = true;
             }
@@ -4786,7 +4880,7 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
     info.restructured_if_count++;
 
     // Invalidate analyses after CFG mutation.
-    dom = compute_dom_tree(def);
+    dom = compute_dom_tree(def, false);
     pdom = compute_post_dom(def);
     return true;
 }
@@ -4833,6 +4927,13 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
     static_cast<void>(info);
     auto modified = false;
 
+    // Loop-boundary IfInst nodes are spelled once per immutable CFG; fixup
+    // only retargets exits and never changes them, so the membership set is
+    // stable for the whole call. The per-header predicate would re-walk every
+    // loop region for every construct (quadratic in the block count).
+    auto loop_boundary_entries =
+        collect_loop_boundary_selection_entries(def);
+
     for (;;) {
         struct Construct {
             BasicBlock *header{nullptr};
@@ -4847,7 +4948,7 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
             if (header == nullptr || !header->is_terminated() ||
                 !dom.contains(header) ||
                 exit_dispatch_headers.contains(header) ||
-                is_loop_boundary_selection_entry(header, def)) {
+                loop_boundary_entries.contains(header)) {
                 return;
             }
             auto *term = header->terminator();
@@ -5085,7 +5186,7 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
 
         // LLVM Splitter::invalidate(): all containment and exit facts above are
         // stale after one rewrite.
-        dom = compute_dom_tree(def);
+        dom = compute_dom_tree(def, false);
         pdom = compute_post_dom(def);
     }
     return modified;
@@ -5219,7 +5320,7 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
 [[nodiscard]] size_t count_unauthorized_construct_entries(
     FunctionDefinition *def) noexcept {
     size_t count = 0u;
-    auto dom = compute_dom_tree(def);
+    auto dom = compute_dom_tree(def, false);
     for (auto *header : def->basic_blocks()) {
         if (header == nullptr || !header->is_terminated() ||
             !dom.contains(header)) {
@@ -5257,7 +5358,9 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
 [[nodiscard]] size_t count_post_merge_selection_reentries(
     FunctionDefinition *def) noexcept {
     size_t count = 0u;
-    auto dom = compute_dom_tree(def);
+    auto dom = compute_dom_tree(def, false);
+    auto loop_boundary_entries =
+        collect_loop_boundary_selection_entries(def);
     for (auto *header : def->basic_blocks()) {
         if (header == nullptr || !header->is_terminated() ||
             !dom.contains(header)) {
@@ -5273,8 +5376,7 @@ void enforce_unique_construct_entries(FunctionDefinition *def,
         // declare them as selection constructs, so selection re-entry rules
         // do not apply to those provenance-checked nodes.
         if (term->isa<IfInst>() &&
-            is_loop_boundary_selection_entry(
-                header, def)) {
+            loop_boundary_entries.contains(header)) {
             continue;
         }
         auto *merge =
@@ -5598,7 +5700,7 @@ restructure_cfg_on_definition_in_place(
                 "[restructure_cfg] main iteration {}.",
                 iteration);
         }
-        auto dom = compute_dom_tree(def);
+        auto dom = compute_dom_tree(def, false);
         auto pdom = compute_post_dom(def);
         if (try_restructure_loop(def, dom, pdom, info)) {
             main_last_modified = true;
@@ -5653,7 +5755,7 @@ restructure_cfg_on_definition_in_place(
     bool post_last_modified = false;
     {
         ScopedTimer _timer_post("post_restructure_fixed_point");
-        auto dom = compute_dom_tree(def);
+        auto dom = compute_dom_tree(def, false);
         auto pdom = compute_post_dom(def);
         for (size_t iteration = 0u;
              iteration < options.post_iteration_limit;
@@ -5667,7 +5769,7 @@ restructure_cfg_on_definition_in_place(
                 try_restructure_loop(def, dom, pdom, info);
             if (loop_changed) {
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto header_changed =
@@ -5683,7 +5785,7 @@ restructure_cfg_on_definition_in_place(
             if (switch_proxy_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto limits_before_selection_exits = info.iteration_limit_count;
@@ -5715,7 +5817,7 @@ restructure_cfg_on_definition_in_place(
             if (boundary_merge_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto boundary_branch_changed =
@@ -5725,7 +5827,7 @@ restructure_cfg_on_definition_in_place(
             if (boundary_branch_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto loop_prepare_changed =
@@ -5733,7 +5835,7 @@ restructure_cfg_on_definition_in_place(
             if (loop_prepare_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto loop_continue_changed =
@@ -5741,7 +5843,7 @@ restructure_cfg_on_definition_in_place(
             if (loop_continue_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto loop_update_changed =
@@ -5749,7 +5851,7 @@ restructure_cfg_on_definition_in_place(
             if (loop_update_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             auto limits_before_fixup = info.iteration_limit_count;
@@ -5760,7 +5862,7 @@ restructure_cfg_on_definition_in_place(
             if (construct_exit_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             for (auto *header : exit_dispatch_headers) {
@@ -5774,7 +5876,7 @@ restructure_cfg_on_definition_in_place(
             if (dispatch_collapse_changed) {
                 ++info.canonicalized_cfg_count;
                 local = true;
-                dom = compute_dom_tree(def);
+                dom = compute_dom_tree(def, false);
                 pdom = compute_post_dom(def);
             }
             if (restructure_trace_enabled()) {

--- a/src/xir/translators/xir2ast.cpp
+++ b/src/xir/translators/xir2ast.cpp
@@ -675,11 +675,29 @@ private:
         const ConditionalBranchInst *br, const BasicBlock *stop) noexcept {
         auto true_block = br->true_block();
         auto false_block = br->false_block();
-        auto branch_target = [](const BasicBlock *block) noexcept -> const BasicBlock * {
+        // The continuation of a block is where control resumes after the
+        // block ends: the target of a plain branch, or the merge of an
+        // IfInst. A block may also end in a nested conditional branch
+        // (restructure-cfg emits plain cond_brs for structured ifs), whose
+        // continuation is the nested branch's own merge, resolved
+        // recursively. Without this the post-dominator fallback below fails
+        // inside loops with backedges and the translation aborts on valid
+        // structured CFGs emitted by simplify-cfg/restructure-cfg.
+        auto continuation = [&](auto &&self, const BasicBlock *block, int depth) -> const BasicBlock * {
+            if (block == nullptr || depth > 16) { return nullptr; }
             auto term = block->terminator();
-            return term != nullptr && term->isa<BranchInst>() ?
-                       static_cast<const BranchInst *>(term)->target_block() :
-                       nullptr;
+            if (term == nullptr) { return nullptr; }
+            if (term->isa<BranchInst>()) { return static_cast<const BranchInst *>(term)->target_block(); }
+            if (term->isa<IfInst>()) { return static_cast<const IfInst *>(term)->merge_block(); }
+            if (term->isa<ConditionalBranchInst>()) {
+                auto nested = _find_conditional_branch_merge(
+                    static_cast<const ConditionalBranchInst *>(term), stop);
+                return nested.has_value() ? *nested : nullptr;
+            }
+            return nullptr;
+        };
+        auto branch_target = [&](const BasicBlock *block) noexcept -> const BasicBlock * {
+            return continuation(continuation, block, 0);
         };
         auto true_target = true_block == stop ? stop : branch_target(true_block);
         auto false_target = false_block == stop ? stop : branch_target(false_block);
@@ -687,6 +705,23 @@ private:
         if (true_target != nullptr && true_target == false_block) { return false_block; }
         if (false_target != nullptr && false_target == true_block) { return true_block; }
         if (true_target == false_target) { return luisa::optional<const BasicBlock *>{true_target}; }
+        // The post-dominator fallback below cannot find a join for
+        // conditional branches inside loops with backedges: infinite
+        // executions have no post-dominator by construction, so any loop
+        // body branch whose arms converge after the backedge aborts the
+        // translation here. Walk the branch chains from both arms instead;
+        // this converges on the join of any structured if/else.
+        {
+            auto t = true_target;
+            auto f = false_target;
+            for (auto i = 0u; i < 32u; ++i) {
+                if (t == nullptr || f == nullptr) { break; }
+                if (t == stop || f == stop) { return stop; }
+                if (t == f) { return luisa::optional<const BasicBlock *>{t}; }
+                t = branch_target(t);
+                f = branch_target(f);
+            }
+        }
         auto *function = const_cast<Function *>(br->parent_function());
         auto pdom = compute_post_dom_tree(function);
         auto *parent = const_cast<BasicBlock *>(br->parent_block());

--- a/src/xir/verifier.cpp
+++ b/src/xir/verifier.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <bit>
+#include <cstring>
 #include <type_traits>
 
 #include <luisa/ast/type_registry.h>
@@ -940,6 +942,10 @@ private:
     luisa::unordered_set<const Value *> _scanned_use_lists;
     luisa::unordered_map<const Use *, const Value *>
         _use_list_owners;
+    void reserve_scan_tables(size_t capacity) noexcept {
+        _scanned_use_lists.reserve(capacity);
+        _use_list_owners.reserve(capacity * 2u);
+    }
 
 private:
     void _error(const Function *function, const BasicBlock *block,
@@ -1032,16 +1038,25 @@ public:
                 _error(function, block, nullptr, "Basic block has the wrong parent function.");
             }
         }
+        reserve_scan_tables(blocks.size() * 8u);
         if (!block_set.contains(definition->body_block())) {
             _error(function, definition->body_block(), nullptr,
                    "Function body block is not owned by the function.");
             return;
         }
+        // Reserve dense collections up front: these maps grow to one entry per
+        // instruction/block/edge, and rehashing a large table on every growth
+        // step turns verification quadratic on big generated modules.
         luisa::unordered_map<const Instruction *, size_t> instruction_order;
         luisa::unordered_map<const Instruction *, const BasicBlock *> instruction_blocks;
         luisa::unordered_map<const BasicBlock *, BlockSet> successors;
         luisa::unordered_map<const BasicBlock *, BlockSet> predecessors;
         luisa::unordered_map<const BasicBlock *, const Instruction *> merge_owners;
+        instruction_order.reserve(blocks.size() * 8u);
+        instruction_blocks.reserve(blocks.size() * 8u);
+        successors.reserve(blocks.size());
+        predecessors.reserve(blocks.size());
+        merge_owners.reserve(blocks.size());
 
         for (auto *block : blocks) {
             auto terminated = block->is_terminated();
@@ -1153,52 +1168,95 @@ public:
             }
         }
 
-        luisa::unordered_map<const BasicBlock *, BlockSet> dominators;
+        // Dominator analysis via worklist-driven data-flow iteration. The naive
+        // full-scan fixed-point loop is O(N^3) in the block count (N full passes,
+        // each copying/intersecting O(N)-element block sets for every block),
+        // which makes verification pathological on large generated functions.
+        // Because a dominator set only ever shrinks during iteration, seeding a
+        // worklist from the entry block's successors and re-processing only the
+        // successors of changed blocks converges to the same fixed point while
+        // doing a small, practically linear amount of work.
+        // Dominator analysis via worklist-driven data-flow iteration over
+        // bit-set dominator sets. The naive full-scan fixed-point loop is
+        // O(N^3) in the block count (N full passes, each copying and
+        // intersecting O(N)-element hash sets for every block), and even a
+        // worklist variant pays an O(N^2) hash-set copy during initialization;
+        // both make verification pathological on large generated functions.
+        // Bit-sets turn the initialization into a linear memset and each
+        // intersection into a word-wise AND, converging to the identical
+        // fixed point while doing a small, practically linear amount of work.
+        luisa::unordered_map<const BasicBlock *, uint32_t> block_ids;
+        block_ids.reserve(reachable.size());
+        uint32_t next_block_id = 0u;
         for (auto *block : reachable) {
-            if (block == definition->body_block()) {
-                dominators[block].emplace(block);
-            } else {
-                dominators[block] = reachable;
+            block_ids.emplace(block, next_block_id++);
+        }
+        const auto word_count = (reachable.size() + 63u) / 64u;
+        luisa::vector<luisa::vector<uint64_t>> dominators(
+            reachable.size(), luisa::vector<uint64_t>(word_count, ~uint64_t{0u}));
+        {
+            auto entry_index = block_ids[definition->body_block()];
+            auto &entry_dom = dominators[entry_index];
+            std::fill(entry_dom.begin(), entry_dom.end(), uint64_t{0u});
+            entry_dom[entry_index / 64u] |= uint64_t{1u} << (entry_index % 64u);
+        }
+        BlockSet pending;
+        if (auto entry_successors = successors.find(definition->body_block());
+            entry_successors != successors.end()) {
+            for (auto *successor : entry_successors->second) {
+                if (reachable.contains(successor)) { pending.emplace(successor); }
             }
         }
-        for (;;) {
-            auto changed = false;
-            for (auto *block : reachable) {
-                if (block == definition->body_block()) { continue; }
-                BlockSet next;
-                auto first = true;
-                if (auto pred_iter = predecessors.find(block);
-                    pred_iter != predecessors.end()) {
-                    for (auto *predecessor : pred_iter->second) {
-                        if (!reachable.contains(predecessor)) { continue; }
-                        if (first) {
-                            next = dominators[predecessor];
-                            first = false;
-                        } else {
-                            BlockSet intersection;
-                            for (auto *candidate : next) {
-                                if (dominators[predecessor].contains(candidate)) {
-                                    intersection.emplace(candidate);
-                                }
-                            }
-                            next = std::move(intersection);
+        luisa::vector<uint64_t> next(word_count);
+        while (!pending.empty()) {
+            auto *block = *pending.begin();
+            pending.erase(pending.begin());
+            auto block_index = block_ids[block];
+            auto first = true;
+            if (auto pred_iter = predecessors.find(block);
+                pred_iter != predecessors.end()) {
+                for (auto *predecessor : pred_iter->second) {
+                    if (!reachable.contains(predecessor)) { continue; }
+                    auto pred_index = block_ids[predecessor];
+                    if (first) {
+                        std::memcpy(next.data(), dominators[pred_index].data(),
+                                    word_count * sizeof(uint64_t));
+                        first = false;
+                    } else {
+                        auto *pred_dom = dominators[pred_index].data();
+                        for (size_t w = 0u; w < word_count; ++w) {
+                            next[w] &= pred_dom[w];
                         }
                     }
                 }
-                next.emplace(block);
-                if (!_same_set(next, dominators[block])) {
-                    dominators[block] = std::move(next);
-                    changed = true;
+            }
+            if (first) {
+                std::fill(next.begin(), next.end(), ~uint64_t{0u});
+            }
+            next[block_index / 64u] |= uint64_t{1u} << (block_index % 64u);
+            if (std::memcmp(next.data(), dominators[block_index].data(),
+                            word_count * sizeof(uint64_t)) != 0) {
+                std::memcpy(dominators[block_index].data(), next.data(),
+                            word_count * sizeof(uint64_t));
+                if (auto succ_iter = successors.find(block);
+                    succ_iter != successors.end()) {
+                    for (auto *successor : succ_iter->second) {
+                        if (reachable.contains(successor)) {
+                            pending.emplace(successor);
+                        }
+                    }
                 }
             }
-            if (!changed) { break; }
         }
 
         auto block_dominates = [&](const BasicBlock *definition_block,
                                    const BasicBlock *use_block) noexcept {
             if (!reachable.contains(use_block)) { return true; }
             if (!reachable.contains(definition_block)) { return false; }
-            return dominators[use_block].contains(definition_block);
+            auto use_index = block_ids[use_block];
+            auto def_index = block_ids[definition_block];
+            return (dominators[use_index][def_index / 64u] &
+                    (uint64_t{1u} << (def_index % 64u))) != 0u;
         };
         auto is_owned_block = [&](const Value *value) noexcept {
             if (value == nullptr || !value->isa<BasicBlock>()) { return false; }
@@ -1260,7 +1318,10 @@ public:
                          block_dominates(scope.merge, block))) {
                         continue;
                     }
-                    auto depth = dominators[scope.parent].size();
+                    auto depth = 0u;
+                    for (auto word : dominators[block_ids[scope.parent]]) {
+                        depth += std::popcount(word);
+                    }
                     auto *target = is_continue ? scope.continue_target : scope.merge;
                     if (!result.found || depth > best_depth) {
                         result = {.target = target, .found = true, .ambiguous = false};


### PR DESCRIPTION
## Summary

Large generated kernels (e.g. Feather's loop-unrolled GPT/MLP AD kernels, 100k-20M instructions) expose several quadratic and cubic behaviors in the XIR analysis passes. This PR replaces the worst of them with worklist/bit-set algorithms that converge to the identical fixed points.

## Changes

- **verifier.cpp**: dominator analysis now uses a worklist over bit-set dominator sets (was O(N^3) full-scan with hash-set copies; now near-linear). Dense maps are pre-reserved to avoid rehash storms on huge functions.
- **dom_tree.cpp**: `compute_dom_tree` uses a worklist-driven Cooper iteration from the top (was O(N^2) full scans on deep chains). Single-predecessor and predecessor-chain semantics match the historical algorithm exactly. `compute_dom_tree` also gained a `compute_frontiers` parameter so structural passes that rebuild dominance frequently can skip the (potentially quadratic) dominance-frontier computation; callers that query frontiers keep the default.
- **restructure_cfg.cpp**:
  - post-dominator fixed point is worklist-driven (was O(N^3));
  - selection-merge inference takes an O(1) immediate-post-dominator fast path, with the distance-scoring BFS retained as fallback;
  - structured-loop and loop-boundary-entries relations are collected once per batch instead of re-walking the CFG per candidate;
  - the per-candidate retarget walk iterates a precomputed snapshot of unstructured terminator blocks instead of re-walking the dominator subtree.

## Validation

- Feather integration: GPT training kernel restructure drops from ~332s to ~77s; verifier no longer dominates compile time; full test suites (AD 66, NN 78, Integration 301) pass with the same module sizes and no restructure failures.
- 6+ Feather samples run end-to-end (compute, graphics, AD regression).