### PR TITLE
DX: skip indirect dispatch bounds checks for root UAVs

### DIFF
--- a/src/backends/common/hlsl/builtin/indirect.bytes
+++ b/src/backends/common/hlsl/builtin/indirect.bytes
@@ -7,11 +7,13 @@ if(block_size==0){return 0;}
 return size/block_size+(size%block_size==0?0u:1u);
 }
 void _SetDispInd(RWStructuredBuffer<uint> buffer,uint idx,uint3 blk,uint3 size,uint kid){
+#ifdef LUISA_INDIRECT_DISPATCH_BOUNDS_CHECK
 uint word_count,word_stride;
 buffer.GetDimensions(word_count,word_stride);
 if(word_stride!=4||word_count<_LC_INDIRECT_HEADER_WORDS){return;}
 uint capacity=(word_count-_LC_INDIRECT_HEADER_WORDS)/_LC_INDIRECT_RECORD_WORDS;
 if(idx>=capacity){return;}
+#endif
 bool valid_block=all(blk!=0);
 uint3 dispSize=uint3(
 _LC_IndirectGroupCount(size.x,blk.x),
@@ -28,9 +30,13 @@ buffer[idx+5]=dispSize.y;
 buffer[idx+6]=dispSize.z;
 }
 void _SetDispCount(RWStructuredBuffer<uint> buffer,uint cnt){
+#ifdef LUISA_INDIRECT_DISPATCH_BOUNDS_CHECK
 uint word_count,word_stride;
 buffer.GetDimensions(word_count,word_stride);
 if(word_stride!=4||word_count<_LC_INDIRECT_HEADER_WORDS){return;}
 uint capacity=(word_count-_LC_INDIRECT_HEADER_WORDS)/_LC_INDIRECT_RECORD_WORDS;
 buffer[0]=min(cnt,capacity);
+#else
+buffer[0]=cnt;
+#endif
 }

--- a/src/backends/common/hlsl/codegen_utils/entry_points.cpp
+++ b/src/backends/common/hlsl/codegen_utils/entry_points.cpp
@@ -101,6 +101,8 @@ size_t AddHeader(CallOpSet const &ops, vstd::StringBuilder &builder, bool isRast
         // Vulkan versions typed bindless descriptors per slot. DXIL keeps its
         // established contiguous base+slot ABI.
         builder << "#define LUISA_SPIRV_TYPED_BINDLESS_INDIRECT 1\n";
+        // DX root UAVs do not carry a view size for capacity queries.
+        builder << "#define LUISA_INDIRECT_DISPATCH_BOUNDS_CHECK 1\n";
         builder << CodegenUtility::ReadInternalHLSLFile("spv_alias");
     }
     if (is_spirv && ops.test(CallOp::ASYNC_COPY)) {


### PR DESCRIPTION
## Summary

- Gate indirect-dispatch buffer capacity checks behind
  `LUISA_INDIRECT_DISPATCH_BOUNDS_CHECK`.
- Enable the checks only for SPIR-V code generation.
- Preserve the previous direct-write behavior for DXIL.

## Context

The indirect-dispatch HLSL helpers use
`RWStructuredBuffer::GetDimensions` to determine the command-buffer capacity.

On DX, these buffers are bound as root UAVs. A root UAV carries a GPU virtual
address but does not carry the UAV view size needed to recover the actual
element count reliably. As a result, the capacity checks can reject valid
record writes or incorrectly clamp the dispatch count.

SPIR-V storage-buffer descriptors retain the required range information, so
the existing bounds checks remain enabled there.

## Scope

This is intentionally a small compatibility fix. It does not change the
indirect-dispatch buffer layout or ABI.

The DX path returns to the previous unchecked behavior and therefore continues
to rely on the caller to provide valid record indices and dispatch counts.

## Follow-up

The complete fix requires addressing DX UAV handling rather than simply
disabling the checks. Possible approaches include binding the indirect buffer
through a UAV descriptor that carries an explicit view size, or passing the
capacity to the shader separately.

Once the DX shader can reliably obtain the capacity, the same bounds checks
should be enabled for DX again.
