### PR TITLE
metal4: gate ray query pipelines by payload

### DIFF
--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -27,12 +27,14 @@ Launching without additional arguments retains the normal interactive
 Window/Swapchain behavior.
 
 `example_ios_path_tracing_cutout` additionally accepts
-`--trace-mode direct|opaque-query|accept-query|cutout-query`. The `direct` and
-`opaque-query` modes use an all-opaque acceleration structure and produce the
-same image, making them a matched direct-intersector versus stateful-query
-measurement. They must not be described as an intersection-function pipeline
-measurement until the Metal4 backend binds a non-null intersection function
-table for `RayQueryPipelineInst`.
+`--trace-mode direct|opaque-query|accept-query|cutout-query`,
+`--ray-query-lowering pipeline|loop`, and `--capture-float4s N`. Omitting the
+lowering option exercises Metal4's automatic device/payload policy; `pipeline`
+forces every semantically eligible triangle query through a non-null
+intersection-function table, while `loop` forces the native stateful query.
+The direct and opaque-query modes remain useful as an all-opaque direct-
+intersector versus stateful-query pair, but they are separate from the matched
+cutout IFT/loop comparison documented in the AIR report.
 
 ## Reproducible build scripts
 
@@ -66,7 +68,8 @@ scripts/build_ios_metal4.sh \
   --mode all --unsigned
 
 scripts/audit_ios_bundles.sh \
-  --bin-dir cmake-build-ios-metal4-device-air-xcode/bin/Release
+  --bin-dir cmake-build-ios-metal4-device-air-xcode/bin/Release \
+  --expected-count 21
 ~~~
 
 The LLVM script also accepts `--source <llvm-project>` to use an existing
@@ -181,6 +184,15 @@ the Metal4 benchmark, and the separate device-test mirror. All 21 executables
 were arm64 and
 `otool -L` found only Apple system frameworks/libraries: LLVM,
 `llvm-downgrade`, Luisa, and the Metal4 backend were all inside each Mach-O.
+
+The 2026-09-01 follow-up also completed an examples-only generated Xcode
+project's unsigned Release `ALL_BUILD` with `CODE_SIGNING_ALLOWED=NO`: all 49
+targets built and linked, including the 19 rendering-example bundles. Its
+bundle audit passes with `--expected-count 19`. The cutout bundle was then
+separately signed and installed on the physical iPhone 17 Pro Max. Automatic
+ray-query lowering completed finite renders at zero, four, and sixteen mutable
+`float4` captures; device logs proved the 128-byte Apple10 gate selected IFT at
+zero and four, and retained the stateful loop at sixteen (512 bytes).
 
 The physical iPhone 17 Pro Max run separately executed four representative
 signed apps rather than inferring runtime support from that link audit:

--- a/examples/rendering/path_tracing_cutout.cpp
+++ b/examples/rendering/path_tracing_cutout.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
 
     Context context{argv[0]};
     if (argc <= 1) {
-        LUISA_INFO("Usage: {} <backend> [--offline] [--spp N] [--iterations N] [--max-registers N] [--max-spp-per-dispatch N] [--trace-mode cutout-query|accept-query|opaque-query|direct] [--ray-query-lowering pipeline|loop]. <backend>: cuda, dx, metal, metal4, vk, hip, fallback, simd", argv[0]);
+        LUISA_INFO("Usage: {} <backend> [--offline] [--spp N] [--iterations N] [--max-registers N] [--max-spp-per-dispatch N] [--trace-mode cutout-query|accept-query|opaque-query|direct] [--ray-query-lowering pipeline|loop] [--capture-float4s N]. <backend>: cuda, dx, metal, metal4, vk, hip, fallback, simd", argv[0]);
         exit(1);
     }
 
@@ -90,8 +90,10 @@ int main(int argc, char *argv[]) {
     // traversal occupancy policy; this override remains available for explicit
     // resource-sensitivity experiments.
     auto max_registers = 0u;
+    auto capture_float4_count = 0u;
     auto trace_mode = TraceMode::cutout_query;
     auto enable_ray_query_pipeline = true;
+    auto force_ray_query_pipeline = false;
     for (auto i = 2; i < argc; i++) {
         auto option = std::string_view{argv[i]};
         if (option == "--max-registers") {
@@ -125,8 +127,10 @@ int main(int argc, char *argv[]) {
             auto lowering = std::string_view{argv[++i]};
             if (lowering == "pipeline") {
                 enable_ray_query_pipeline = true;
+                force_ray_query_pipeline = true;
             } else if (lowering == "loop") {
                 enable_ray_query_pipeline = false;
+                force_ray_query_pipeline = false;
             } else {
                 LUISA_WARNING(
                     "Invalid --ray-query-lowering '{}'; expected "
@@ -134,11 +138,34 @@ int main(int argc, char *argv[]) {
                     lowering);
                 return 1;
             }
+        } else if (option == "--capture-float4s") {
+            if (i + 1 >= argc) {
+                LUISA_WARNING("Missing value for {}.", option);
+                return 1;
+            }
+            auto value = std::string_view{argv[++i]};
+            auto parsed = luisa::ref::parse_uint32_option_value(value);
+            if (!parsed || *parsed > 64u) {
+                LUISA_WARNING(
+                    "Invalid value '{}' for {}; expected an integer in "
+                    "[0, 64].",
+                    value, option);
+                return 1;
+            }
+            capture_float4_count = *parsed;
         }
     }
-    LUISA_INFO("Trace microbenchmark mode: {}; ray-query lowering: {}.",
+    LUISA_INFO("Trace microbenchmark mode: {}; ray-query lowering: {}; "
+               "mutable callback state: {} float4 ({} source byte(s); "
+               "IFT input/output payload is reported by the XIR pass).",
                trace_mode_name(trace_mode),
-               enable_ray_query_pipeline ? "pipeline/IFT" : "stateful loop");
+               !enable_ray_query_pipeline ?
+                   "stateful loop (forced)" :
+               force_ray_query_pipeline ?
+                   "pipeline/IFT (forced)" :
+                   "automatic",
+               capture_float4_count,
+               capture_float4_count * static_cast<uint>(sizeof(float4)));
 
     Device device = context.create_device(argv[1]);
 
@@ -283,10 +310,15 @@ int main(int argc, char *argv[]) {
         return pdf_a / max(pdf_a + pdf_b, 1e-4f);
     };
 
-    Callable filter_triangle_hit = [&](Var<TriangleHit> h) noexcept {
+    Callable filter_triangle_hit = [&](Var<TriangleHit> h,
+                                       Float capture_bias) noexcept {
         Bool valid = def(true);
-        $if (h.inst == tall_inst) { valid = fract(6.f * h.bary.y) < .6f; }
-        $elif (h.inst == short_inst) { valid = fract(10.f * h.bary.x) < .5f; };
+        $if (h.inst == tall_inst) {
+            valid = fract(6.f * h.bary.y + capture_bias) < .6f;
+        }
+        $elif (h.inst == short_inst) {
+            valid = fract(10.f * h.bary.x + capture_bias) < .5f;
+        };
         return valid;
     };
 
@@ -306,6 +338,40 @@ int main(int argc, char *argv[]) {
 
     Kernel2D raytracing_kernel = [&](ImageFloat image, ImageUInt seed_image, AccelVar accel, UInt2 resolution, UInt dispatch_spp) noexcept {
         set_block_size(16u, 16u, 1u);
+        auto make_capture_state = [&](Expr<Ray> query_ray) noexcept {
+            luisa::vector<Float4> state;
+            state.reserve(capture_float4_count);
+            auto ray_value = def(query_ray);
+            for (auto i = 0u; i < capture_float4_count; i++) {
+                auto lane = static_cast<float>(i + 1u);
+                state.emplace_back(def(make_float4(
+                    ray_value->origin() +
+                        ray_value->direction() * (lane * 0.0009765625f),
+                    ray_value->t_min() + lane * 0.00390625f)));
+            }
+            return state;
+        };
+        auto update_capture_state = [&](luisa::vector<Float4> &state,
+                                        Var<TriangleHit> hit) noexcept {
+            Float checksum = def(0.0f);
+            for (auto i = 0u; i < capture_float4_count; i++) {
+                auto lane = static_cast<float>(i + 1u);
+                auto candidate_value = make_float4(
+                    hit.bary,
+                    cast<float>(hit.prim & 255u),
+                    cast<float>(hit.inst & 255u));
+                state[i] = state[i] *
+                               make_float4(0.96875f, 0.953125f,
+                                           0.9375f, 0.921875f) +
+                           candidate_value * (lane * 0.000244140625f);
+                checksum += dot(
+                    state[i],
+                    make_float4(0.25f, 0.125f, 0.0625f,
+                                0.03125f) /
+                        lane);
+            }
+            return fract(abs(checksum) * 0.0009765625f) * 0.05f;
+        };
         auto trace_closest = [&](Expr<Ray> query_ray) noexcept {
             if (trace_mode == TraceMode::direct) {
                 auto surface_hit = accel.intersect(query_ray, {});
@@ -326,9 +392,13 @@ int main(int argc, char *argv[]) {
                     })
                     .trace();
             }
+            auto capture_state = make_capture_state(query_ray);
             return accel.traverse(query_ray, {})
                 .on_surface_candidate([&](auto &candidate) noexcept {
-                    $if (filter_triangle_hit(candidate.hit())) {
+                    auto candidate_hit = candidate.hit();
+                    auto capture_bias = update_capture_state(
+                        capture_state, candidate_hit);
+                    $if (filter_triangle_hit(candidate_hit, capture_bias)) {
                         candidate.commit();
                     };
                 })
@@ -349,9 +419,14 @@ int main(int argc, char *argv[]) {
                             .trace()
                             ->miss();
             }
+            auto capture_state = make_capture_state(query_ray);
             return !accel.traverse_any(query_ray, {})
                         .on_surface_candidate([&](auto &candidate) noexcept {
-                            $if (filter_triangle_hit(candidate.hit())) {
+                            auto candidate_hit = candidate.hit();
+                            auto capture_bias = update_capture_state(
+                                capture_state, candidate_hit);
+                            $if (filter_triangle_hit(
+                                     candidate_hit, capture_bias)) {
                                 candidate.commit();
                             };
                         })
@@ -490,6 +565,8 @@ int main(int argc, char *argv[]) {
     ShaderOption raytracing_option{.max_registers = max_registers};
     raytracing_option.enable_ray_query_pipeline =
         enable_ray_query_pipeline;
+    raytracing_option.force_ray_query_pipeline =
+        force_ray_query_pipeline;
     Clock raytracing_compile_clock;
     auto raytracing_shader = device.compile(
         raytracing_kernel, raytracing_option);

--- a/include/luisa/runtime/rhi/resource.h
+++ b/include/luisa/runtime/rhi/resource.h
@@ -184,9 +184,17 @@ struct ShaderOption {
     ///   native ray-query pipelines and intersection functions.
     /// \details This is enabled by default. Disabling it preserves the
     ///   stateful query-loop representation and is primarily useful for
-    ///   validation and performance comparisons. It currently affects the
-    ///   Metal4 AIR backend; other backends may ignore it.
+    ///   validation and performance comparisons. When enabled, a backend may
+    ///   still retain a stateful loop when its device/capture profitability
+    ///   policy prefers that representation. It currently affects the Metal4
+    ///   AIR backend; other backends may ignore it.
     bool enable_ray_query_pipeline{true};
+    /// \brief Force eligible ray-query loops into native pipelines.
+    /// \details This bypasses backend profitability selection but never
+    ///   bypasses semantic/ABI rejection (for example procedural candidates
+    ///   unsupported by an intersection-function path). It is intended for
+    ///   validation and matched performance experiments.
+    bool force_ray_query_pipeline{false};
     /// \brief Whether the native driver may run its full optimization
     ///   pipeline while creating the shader.
     /// \details Disabling this option provides a bounded-compilation escape
@@ -337,6 +345,7 @@ struct hash<compute::ShaderOption> {
         constexpr auto enable_driver_optimization_shift = 5u;
         constexpr auto enable_scalarizer_shift = 6u;
         constexpr auto enable_ray_query_pipeline_shift = 7u;
+        constexpr auto force_ray_query_pipeline_shift = 8u;
         auto opt_hash = hash_value((static_cast<uint>(option.enable_cache) << enable_cache_shift) |
                                        (static_cast<uint>(option.enable_fast_math) << enable_fast_math_shift) |
                                        (static_cast<uint>(option.enable_debug_info) << enable_debug_info_shift) |
@@ -344,7 +353,8 @@ struct hash<compute::ShaderOption> {
                                        (static_cast<uint>(option.enable_extended_accel_limits) << enable_extended_accel_limits_shift) |
                                        (static_cast<uint>(option.enable_driver_optimization) << enable_driver_optimization_shift) |
                                        (static_cast<uint>(option.enable_scalarizer) << enable_scalarizer_shift) |
-                                       (static_cast<uint>(option.enable_ray_query_pipeline) << enable_ray_query_pipeline_shift),
+                                       (static_cast<uint>(option.enable_ray_query_pipeline) << enable_ray_query_pipeline_shift) |
+                                       (static_cast<uint>(option.force_ray_query_pipeline) << force_ray_query_pipeline_shift),
                                    seed);
         auto name_hash = hash_value(option.name, seed);
         auto native_include_hash = hash_value(option.native_include, seed);

--- a/include/luisa/xir/passes/lower_ray_query_to_pipeline.h
+++ b/include/luisa/xir/passes/lower_ray_query_to_pipeline.h
@@ -68,6 +68,15 @@ struct LowerRayQueryToPipelineOptions {
     // remove are conservatively presented to this callback as well.
     bool (*captured_argument_filter)(const Value *, bool is_output) noexcept{
         nullptr};
+    // Optional backend payload-cost model and aggregate budget. The callback
+    // returns the stored payload bytes for one capture. Selection uses the raw
+    // pre-localization cost conservatively: handler-local allocation proofs
+    // may reduce argument count, but never turn an over-budget payload into an
+    // outlined pipeline. Defaults preserve unconditional lowering.
+    size_t (*captured_argument_cost)(const Value *, bool is_output) noexcept {
+        nullptr};
+    size_t max_captured_argument_cost{
+        std::numeric_limits<size_t>::max()};
     // Optional backend profitability filter. A capture-eligible loop is
     // selected when its two handler regions contain at least this many XIR
     // instructions, or when its function contains at least

--- a/scripts/audit_ios_bundles.sh
+++ b/scripts/audit_ios_bundles.sh
@@ -11,12 +11,12 @@ usage() {
         '' \
         'Options:' \
         '  --bin-dir PATH       Directory containing the .app bundles.' \
-        '  --expected-count N   Required bundle count (default: 20).' \
+        '  --expected-count N   Required bundle count (default: 21 for --mode all).' \
         '  -h, --help           Show this help.'
 }
 
 bin_dir=
-expected_count=20
+expected_count=21
 while (($#)); do
     case "$1" in
         --bin-dir)

--- a/src/backends/metal4/llvm_codegen/AIR_INTRINSICS_AND_TRANSLATION.md
+++ b/src/backends/metal4/llvm_codegen/AIR_INTRINSICS_AND_TRANSLATION.md
@@ -154,6 +154,7 @@ malformed call sites into LLVM lowering.
    - `lower-ray-query-to-loop` for every retained query loop
    - `destructure_cfg`
    - `inline_all`
+   - hoist every remaining `AllocaInst` into the function-entry prefix
    - `mem2reg`
 6. Run `create_ssa_optimization_pipeline`.
 7. Run cleanup:
@@ -166,7 +167,13 @@ malformed call sites into LLVM lowering.
 The outlining pass is scheduled before retained ray-query-loop lowering and
 before CFG destructuring. Inlining is deliberately scheduled immediately after
 CFG destructuring in both normalization paths; no pass is inserted between
-`destructure_cfg` and `inline_all`. Multi-block inlining rejects structured
+`destructure_cfg` and `inline_all`. The main path then walks every function and
+moves every remaining alloca, not only ray-query storage, into its entry
+prefix while preserving instruction order. Ordinary locals are subsequently
+promoted by `mem2reg`; opaque stateful intersection-query locals remain
+entry-local for the AIR allocate/reset/deallocate lifetime contract. This
+canonicalization is required because multi-block callable inlining clones
+callee-local allocations into the cloned CFG region. Multi-block inlining rejects structured
 caller or callee CFG; for functions made plain by
 `destructure_cfg`, its block splitting and branch insertion preserve the
 unstructured form expected by LLVM lowering. Recursive callables and functions
@@ -1554,10 +1561,24 @@ air.intersect(..., non-null IFT, ray-data payload, payload size, ...)
                     +-- returns {accept_intersection, continue_search}
 ~~~
 
-This conversion is controlled by
-`ShaderOption::enable_ray_query_pipeline`, which defaults to true. Setting it
-to false is an explicit validation and performance-comparison mode; it retains
-the native stateful representation and is not an MSL fallback.
+This conversion is allowed by
+`ShaderOption::enable_ray_query_pipeline`, which defaults to true. The default
+is an automatic policy, not an unconditional outline request. Setting it to
+false explicitly retains the native stateful representation and is not an MSL
+fallback. `ShaderOption::force_ray_query_pipeline` bypasses profitability
+selection for matched experiments and strict tests, but cannot bypass any
+semantic or ABI rejection described below.
+
+The runtime derives the automatic policy before cache lookup and hashes that
+policy into the shader cache identity. A motion ray query is allowed an
+unbounded payload because the public stateful AIR form cannot express its
+motion AS and ray time. For static queries, Apple10 devices allow IFT outlining
+only when the conservative raw callback payload costs at most 128 bytes.
+Apple7, Apple8, and Apple9 currently retain the stateful path automatically;
+Apple7 is measured, while Apple8/9 remain conservative until matched physical-
+device evidence exists. The force option retains an unbounded budget on every
+device. None of these choices changes the semantic triangle/procedural/curve
+gate.
 
 **Selection and scheduling.** `outline-ray-query-pipelines` runs after the
 basic XIR optimizations, but before `lower-ray-query-to-loop`, CFG
@@ -1602,6 +1623,16 @@ element types are not payload captures. The acceleration structure used to
 construct the query remains an ordinary kernel-side operand; attempting to
 reference an independent `Accel` from inside the outlined callback is not
 silently converted to a pointer capture.
+
+The profitability budget is expressed in payload bytes rather than argument
+count. A Buffer costs 16 bytes (`{device pointer, uint64 size}`), a Bindless
+array costs 8 bytes, and ordinary scalar/vector/matrix/array/structure captures
+use `Type::size()`. This preserves Luisa storage rules: `bool4` and `byte4`
+each cost four bytes rather than the one byte that four packed LLVM `i1`
+values might suggest. Input and output payload fields are both charged with
+saturating arithmetic. Selection deliberately uses the raw pre-localization
+capture set as a conservative bound; proving handler-private allocas can reduce
+argument count, but cannot make an over-budget payload eligible.
 
 The payload is a natural-layout LLVM structure named
 `%LuisaRayQueryPayloadN`. Its fixed logical field order is:
@@ -3590,9 +3621,24 @@ run passes **36/36**, including all fifteen rendering examples and the
 extended-limits direct-trace regression.
 
 Apple GPU Shader Validation is a separate instrumenting tool and has narrower
-coverage than API Validation. The supported subset passes **33/33** with
-`MTL_SHADER_VALIDATION=1`, error reporting, and abort-on-fault enabled. The
-three deliberately separated registrations are:
+coverage than API Validation. On the current macOS/Xcode toolchain,
+`MTL_SHADER_VALIDATION_FAIL_MODE` accepts `allow` or `zerofill`, not the older
+`assert` spelling. With `MTL_SHADER_VALIDATION=1`, fail mode `allow`, Metal API
+Validation, and Luisa validation enabled, the selected non-RTX subset passes
+**19/19**. It covers typed bindless resources, raster and stencil JIT/AOT,
+timeline events, autodiff, native logging, buffer I/O, bindless buffers,
+native include, cooperative vectors, and six non-RTX renderers.
+
+The Apple7 M1 Max cannot execute a Metal4 ray-tracing workload after GPU Shader
+Validation instruments it: both a focused ray-query state-machine run and the
+RTX-containing device-conformance aggregate end with an
+`MTL4CommandQueueErrorDomain` command-queue failure. The same runtime paths
+pass ordinary execution and the full **39/39** Metal API Validation matrix, so
+this is kept as a device/tool instrumentation boundary rather than reported as
+a Metal4 runtime failure. All acceleration, motion, ray-query, procedural,
+path-tracing, and photon-mapping registrations are therefore outside the
+current GPU-Validation subset. Three additional non-RTX/aggregate exclusions
+remain:
 
 - `test_metal4_air_indirect`, because Luisa's GPU-written ICB stores its
   pipeline and two buffer bindings per command. Apple documents that Shader
@@ -3607,12 +3653,11 @@ three deliberately separated registrations are:
   contains both of the preceding ICB and bindless-sampler paths. Its full
   semantics pass ordinary execution and API Validation.
 
-This is not treated as three runtime failures or silently weakened into a
-passing GPU-Validation result. ICB and bindless sampling retain their strict
-executing tests, while GPU Shader Validation remains enabled for every path it
-can instrument without changing the program contract, including acceleration,
-motion, ray queries, raster JIT/AOT, stencil, logging, native include,
-cooperative vectors, and all fifteen renderers.
+These exclusions are not treated as runtime failures or silently weakened into
+a passing GPU-Validation result. RTX, ICB, and bindless-sampler paths retain
+their strict ordinary and API-Validation executing tests. GPU Shader
+Validation remains enabled only where this device/tool pair can instrument the
+program without changing its contract.
 
 MTL4 commit feedback publishes a submission's host-visible completion only
 after callbacks, resource release, profiling, and the in-flight decrement have
@@ -3790,10 +3835,12 @@ still execute their independent two-draw Replace/Equal stencil tests.
 ### 16.5 Loop-to-IFT closure and M1 Max A/B (2026-09-01)
 
 The loop-to-pipeline implementation was closed on the Apple M1 Max with a
-CMake/Ninja build. The full configured CTest matrix passes **167/167**. The
-Metal4 integration matrix passes **38/38** both normally and with
+CMake/Ninja build. After the captured-payload/callable follow-up in Section
+16.6, the latest full configured CTest matrix passes **168/168** in 73.56 seconds.
+The Metal4 integration matrix passes **39/39** both normally and with
 `MTL_DEBUG_LAYER=1` plus `LUISA_ENABLE_VALIDATION=1`; this includes all fifteen
-registered rendering examples. The explicit state-machine test covers the
+registered rendering examples. The strict run completes in 19.93 seconds.
+The explicit state-machine test covers the
 pipeline/stateful and direct/GPU-written-indirect Cartesian product for a
 triangle query, while its procedural-AABB query proves conservative stateful
 retention. The motion test covers dynamic ray time, `QueryAll`, `QueryAny`,
@@ -3838,7 +3885,103 @@ One reproducible warm pair is:
   --trace-mode cutout-query --ray-query-lowering loop
 ~~~
 
-### 16.6 Useful commands
+### 16.6 Captured-payload, callable, and Apple10 gate closure (2026-09-01)
+
+The cutout benchmark also accepts `--capture-float4s N`. Each requested
+`float4` is initialized from runtime ray data, mutated and read in both query
+callbacks, and contributes to the cutout decision, so the values cannot be
+removed as dead benchmark scaffolding. In the current mutable-state form each
+source `float4` produces an input and an output capture. Thus source counts
+4, 16, and 32 produced 8, 32, and 64 captured fields, with conservative costs
+128, 512, and 1,024 bytes per query respectively.
+
+Matched macOS runs used the Apple7 M1 Max, 1024 by 1024 pixels, 64 spp, five
+measured iterations, a 64-spp dispatch cap, deterministic cutout mode, and
+AB/BA order reversal. For each row, all four pipeline/stateful PNGs were byte-
+identical:
+
+| Source callback state | Pipeline/IFT | Stateful loop | IFT difference |
+|---:|---:|---:|---:|
+| 0 `float4` | 39.171 spp/s | 45.030 spp/s | **13.0% slower** |
+| 4 `float4` | 32.896 spp/s | 39.194 spp/s | **16.1% slower** |
+| 16 `float4` | 19.447 spp/s | 29.236 spp/s | **33.5% slower** |
+| 32 `float4` | 9.247 spp/s | 20.228 spp/s | **54.3% slower** |
+
+The same executable and settings were signed and run on the physical Apple10
+A19 Pro GPU in an iPhone 17 Pro Max. Each mode's repeated PNGs were byte-
+identical. Pipeline versus stateful differed at only 3 of 1,048,576 pixels,
+five channel components total, at most three 8-bit levels; PSNR was
+100.555290 dB for every row. Opposite-order pairwise ratios agree with the
+reported direction except in the separately investigated crossover region:
+
+| Source callback state | Pipeline/IFT | Stateful loop | IFT difference |
+|---:|---:|---:|---:|
+| 0 `float4` | 98.271 spp/s | 58.983 spp/s | **66.6% faster** |
+| 4 `float4` / 128-byte raw payload | 63.384 spp/s | 54.272 spp/s | **16.8% faster** |
+| 16 `float4` / 512-byte raw payload | 26.209 spp/s | 49.864 spp/s | **47.4% slower** |
+| 32 `float4` / 1,024-byte raw payload | 8.047 spp/s | 26.889 spp/s | **70.1% slower** |
+
+A threshold sweep found 192 bytes (six source `float4`) only 4.8% to 12.0%
+faster, 256 bytes (eight source `float4`) order/thermal sensitive with opposite
+signs, and 384 bytes (twelve source `float4`) 33.8% to 35.5% slower. The
+automatic Apple10 cap is therefore the last decisively positive measured point,
+128 bytes, rather than an interpolation through the unstable crossover. This
+is a device-family-and-payload result, not evidence that every newer ray-
+tracing implementation favors an IFT pipeline.
+
+A final signed-device gate audit launched the default automatic mode, rather
+than either benchmark override, on that iPhone. At zero source captures the
+runtime selected the Apple10 128-byte policy and outlined both query loops with
+zero payload bytes. At four source `float4` values it outlined both loops at
+the exact 128-byte boundary (eight raw input fields). At sixteen source values
+it rejected both loops at 512 bytes before handler-localization analysis and
+then lowered both through the stateful path. All three 1024 by 1024, one-spp
+finite renders reported `finished=1` with exit code zero. The same isolated
+checkout also completed an unsigned Release `ALL_BUILD` for all 49 Xcode
+targets, including all 19 rendering-example app bundles, before the cutout app
+was separately signed and installed.
+
+The direct state-machine regression now places its procedural query inside the
+named callable `metal4_retained_procedural_state_machine_callable`. That
+callable captures an acceleration structure, writable and read-only buffers,
+a bindless array, reference outputs, local mutable state, and executes nested
+conditionals and a direct `query.proceed()` software state machine with
+procedural candidate reads and commit. It is compiled with IFT force enabled
+to prove the semantic module gate still retains it, and with IFT disabled;
+both variants run direct and GPU-written indirect dispatch and match exact
+results. `test_procedural_callable metal4 --spp 4` is additionally registered
+as `test_metal4_procedural_callable`; it renders a mixed triangle/procedural
+scene whose ray query lives inside a high-level Callable and captures scene
+resources, a reference validity flag, and local normal state.
+
+These callable cases exposed that forced inlining alone was insufficient:
+multi-block inlining had correctly removed the call but left cloned query
+storage in a non-entry CFG block. The post-inline alloca canonicalization in
+Section 2.1 now hoists all allocas before `mem2reg`. The strict state-machine
+executable passes 50 assertions under Metal API Validation, and the registered
+procedural Callable render also passes. Its optimized XIR contains the native
+procedural state-machine read/write operations and no `RayQueryPipelineInst`,
+proving that success did not come from silently taking the triangle IFT path.
+The physical c0/c4 shaders each reported eleven moved allocas followed by 24
+successful `mem2reg` promotions; the retained c16 stateful shader reported the
+same eleven moves and 56 promotions. This confirms the pass is exercised by
+real callable/query control flow and is not a ray-query-object-only special
+case.
+
+Reproduce one captured pair with:
+
+~~~sh
+./bin/example_path_tracing_cutout metal4 --offline --spp 64 \
+  --iterations 5 --max-spp-per-dispatch 64 --trace-mode cutout-query \
+  --capture-float4s 4 --ray-query-lowering pipeline
+./bin/example_path_tracing_cutout metal4 --offline --spp 64 \
+  --iterations 5 --max-spp-per-dispatch 64 --trace-mode cutout-query \
+  --capture-float4s 4 --ray-query-lowering loop
+~~~
+
+Omit `--ray-query-lowering` to exercise the automatic device/payload gate.
+
+### 16.7 Useful commands
 
 Dump XIR and optimized LLVM:
 
@@ -3938,10 +4081,13 @@ correct atomic lowering requires an explicit AIR intrinsic/ABI convention.
   and numeric control operands are private Apple conventions and need
   differential revalidation on each toolchain/AIR-version update.
 - Apple GPU Shader Validation cannot instrument Luisa's non-inherited
-  GPU-written ICB without changing its per-command buffer ABI, and currently
-  changes private bindless sampler-table behavior without reporting a fault.
-  Keep full API Validation and exact executing regressions for those paths;
-  do not report them as GPU-Validation-passing or loosen their numeric checks.
+  GPU-written ICB without changing its per-command buffer ABI, currently
+  changes private bindless sampler-table behavior without reporting a fault,
+  and on the local Apple7 M1 Max fails MTL4 command-queue execution for RTX-
+  containing workloads. The verified non-RTX subset is 19/19; the complete
+  ordinary and Metal API Validation matrices remain 39/39. Keep full API
+  Validation and exact executing regressions for excluded paths; do not report
+  them as GPU-Validation-passing or loosen their numeric checks.
 - Direct compute textures, 32-bit atomics, volatile device-buffer access, the
   documented subgroup subset, the documented bindless buffer/texture subset,
   GPU-written indirect dispatch records, and the static instanced-triangle
@@ -3993,8 +4139,9 @@ correct atomic lowering requires an explicit AIR intrinsic/ABI convention.
 | Fail-closed support preflight | [metal_codegen_llvm_preflight.cpp](metal_codegen_llvm_preflight.cpp) |
 | Public codegen configuration/result | [metal_codegen_llvm.h](metal_codegen_llvm.h) |
 | LLVM-generated runtime builtin entries and ABI metadata | [metal_codegen_llvm_builtin.cpp](metal_codegen_llvm_builtin.cpp) |
-| AST-to-XIR orchestration | [metal_xir_pipeline.cpp](../metal_xir_pipeline.cpp) |
-| Transactional XIR query-loop outlining and capture analysis | [lower_ray_query_to_pipeline.cpp](../../../xir/passes/lower_ray_query_to_pipeline.cpp) |
+| AST-to-XIR orchestration and post-inline alloca canonicalization | [metal_xir_pipeline.cpp](../metal_xir_pipeline.cpp) |
+| Device/payload automatic ray-query policy | [metal_device.cpp](../metal_device.cpp) |
+| Transactional XIR query-loop outlining and capture-cost analysis | [lower_ray_query_to_pipeline.cpp](../../../xir/passes/lower_ray_query_to_pipeline.cpp), [lower_ray_query_to_pipeline_capture_cost.h](../../../xir/passes/lower_ray_query_to_pipeline_capture_cost.h) |
 | Shared XIR pipeline factories | [pass_pipeline.cpp](../../../xir/passes/pass_pipeline.cpp) |
 | LLVM O2, version selection, dual entries, packaging | [metal_air_pipeline.cpp](../metal_air_pipeline.cpp) |
 | Runtime builtin verification, downgrade, and five-entry packaging | [metal_builtin_air.cpp](../metal_builtin_air.cpp) |

--- a/src/backends/metal4/metal_device.cpp
+++ b/src/backends/metal4/metal_device.cpp
@@ -47,7 +47,7 @@ namespace {
 // Bump this whenever a Metal AIR lowering or ABI change can alter generated
 // code without changing the source AST, ShaderOption, or target tuple.
 constexpr auto metal_air_compute_cache_revision =
-    0x4c55495341414908ull;
+    0x4c55495341414909ull;
 
 [[nodiscard]] uint64_t pack_air_version(
     MetalAIRVersion version) noexcept {
@@ -58,13 +58,62 @@ constexpr auto metal_air_compute_cache_revision =
 
 [[nodiscard]] uint64_t metal_air_compute_cache_key(
     Function kernel, const ShaderOption &option,
-    const MetalAIRTarget &target) noexcept {
+    const MetalAIRTarget &target,
+    MetalRayQueryPipelinePolicy ray_query_policy) noexcept {
     return luisa::hash_combine({kernel.hash(),
                                 luisa::hash_value(option),
                                 static_cast<uint64_t>(target.platform),
                                 pack_air_version(target.operating_system_version),
                                 pack_air_version(target.sdk_version),
+                                static_cast<uint64_t>(ray_query_policy.enabled),
+                                static_cast<uint64_t>(
+                                    ray_query_policy.max_captured_payload_bytes),
                                 metal_air_compute_cache_revision});
+}
+
+[[nodiscard]] MetalRayQueryPipelinePolicy
+metal_ray_query_pipeline_policy(
+    MTL::Device *device, Function kernel,
+    const ShaderOption &option) noexcept {
+    auto builtin_callables = kernel.propagated_builtin_callables();
+    auto uses_ray_query = builtin_callables.uses_ray_query();
+    auto uses_motion_ray_query =
+        builtin_callables.uses_ray_query_motion_blur();
+    MetalRayQueryPipelinePolicy policy{
+        .enabled = false,
+        .max_captured_payload_bytes = 0u};
+    if (uses_ray_query && option.enable_ray_query_pipeline) {
+        if (option.force_ray_query_pipeline || uses_motion_ray_query) {
+            policy = {};
+        } else if (device->supportsFamily(MTL::GPUFamilyApple10)) {
+            // Matched AB/BA measurements on Apple10 show that the IFT path is
+            // decisively faster through 128 bytes of callback payload, while
+            // larger payloads cross over or regress. Older measured Apple7
+            // hardware consistently favors the stateful loop; Apple8/9 stay
+            // conservative until matched device evidence is available.
+            policy.enabled = true;
+            policy.max_captured_payload_bytes = 128u;
+        }
+    }
+    if (uses_ray_query) {
+        auto payload_budget = luisa::string{"not applicable"};
+        if (policy.enabled) {
+            payload_budget =
+                policy.max_captured_payload_bytes ==
+                        std::numeric_limits<size_t>::max() ?
+                    luisa::string{"unlimited"} :
+                    luisa::format(
+                        "{} byte(s)", policy.max_captured_payload_bytes);
+        }
+        LUISA_VERBOSE(
+            "Metal4 ray-query lowering policy: {} (payload budget = {}, "
+            "forced = {}, motion-required = {}).",
+            policy.enabled ? "IFT enabled" : "stateful loop",
+            payload_budget,
+            option.force_ray_query_pipeline,
+            uses_motion_ray_query);
+    }
+    return policy;
 }
 
 class SampledTextureArgumentAnalysis {
@@ -561,8 +610,10 @@ ShaderCreationInfo MetalDevice::create_shader(const ShaderOption &option, Functi
         metadata.argument_sampled =
             SampledTextureArgumentAnalysis{}.analyze(kernel);
         auto air_target = metal_air_target_for_current_device();
+        auto ray_query_policy = metal_ray_query_pipeline_policy(
+            _handle, kernel, option);
         auto cache_key = metal_air_compute_cache_key(
-            kernel, option, air_target);
+            kernel, option, air_target, ray_query_policy);
         metadata.checksum = cache_key;
 
         MetalShaderHandle pipeline;
@@ -578,7 +629,8 @@ ShaderCreationInfo MetalDevice::create_shader(const ShaderOption &option, Functi
         }
         if (!pipeline.entry || !pipeline.indirect_entry) {
             Clock codegen_clock;
-            auto xir_module = metal_translate_ast_to_xir(kernel, option);
+            auto xir_module = metal_translate_ast_to_xir(
+                kernel, option, ray_query_policy);
             luisa::string unsupported_reason;
             if (!luisa_compute_metal_codegen_llvm_supported(
                     *xir_module, &unsupported_reason)) {

--- a/src/backends/metal4/metal_xir_pipeline.cpp
+++ b/src/backends/metal4/metal_xir_pipeline.cpp
@@ -16,6 +16,7 @@
 #include <luisa/xir/passes/restructure_cfg.h>
 #include <luisa/xir/passes/simplify_cfg.h>
 #include <luisa/xir/passes/unused_callable_removal.h>
+#include <luisa/xir/builder.h>
 #include <luisa/xir/instructions/ray_query.h>
 #include <luisa/xir/instructions/resource.h>
 #include <luisa/xir/metadata/curve_basis.h>
@@ -137,8 +138,27 @@ void verify_xir_or_error(
     return true;
 }
 
+[[nodiscard]] size_t metal_ray_payload_capture_cost(
+    const xir::Value *value, bool) noexcept {
+    LUISA_ASSERT(value != nullptr && value->type() != nullptr,
+                 "Invalid Metal ray-query payload capture.");
+    auto type = value->type();
+    switch (type->tag()) {
+        // AIR stores a buffer capture as {device pointer, uint64 size} and a
+        // bindless capture as its argument-buffer device pointer.
+        case Type::Tag::BUFFER: return 16u;
+        case Type::Tag::BINDLESS_ARRAY: return 8u;
+        default:
+            LUISA_ASSERT(!type->is_resource() && !type->is_custom(),
+                         "Unsupported Metal ray-query payload cost type '{}'.",
+                         type->description());
+            return type->size();
+    }
+}
+
 [[nodiscard]] bool outline_ray_query_pipelines(
-    xir::Module *module, xir::PassReport &report) noexcept {
+    xir::Module *module, xir::PassReport &report,
+    MetalRayQueryPipelinePolicy policy) noexcept {
     auto requires_stateful_lowering = false;
     for (auto function : module->function_list()) {
         if (auto definition = function->definition()) {
@@ -194,6 +214,10 @@ void verify_xir_or_error(
     xir::LowerRayQueryToPipelineOptions options;
     options.captured_argument_filter =
         metal_ray_payload_capture_supported;
+    options.captured_argument_cost =
+        metal_ray_payload_capture_cost;
+    options.max_captured_argument_cost =
+        policy.max_captured_payload_bytes;
     auto result = xir::lower_ray_query_to_pipeline_pass_run_on_module(
         module, &report, options);
     if (!result.succeeded()) {
@@ -222,8 +246,44 @@ void verify_xir_or_error(
     return result.inlined_call_count > 0u;
 }
 
+[[nodiscard]] bool hoist_allocas_after_inlining(
+    xir::Module *module, xir::PassReport &report) noexcept {
+    auto hoisted_count = 0u;
+    for (auto function : module->function_list()) {
+        auto definition = function->definition();
+        if (definition == nullptr || definition->body_block() == nullptr) {
+            continue;
+        }
+        luisa::vector<xir::AllocaInst *> allocas;
+        definition->traverse_instructions(
+            [&allocas](xir::Instruction *instruction) noexcept {
+                if (instruction->isa<xir::AllocaInst>()) {
+                    allocas.emplace_back(
+                        static_cast<xir::AllocaInst *>(instruction));
+                }
+            });
+        auto insertion_point =
+            definition->body_block()->instructions().head_sentinel();
+        xir::XIRBuilder builder;
+        builder.set_insertion_point(insertion_point);
+        for (auto alloca : allocas) {
+            if (alloca->parent_block() == definition->body_block() &&
+                alloca->prev() == insertion_point) {
+                insertion_point = alloca;
+                builder.set_insertion_point(insertion_point);
+                continue;
+            }
+            insertion_point = builder.append(alloca->remove_self());
+            hoisted_count++;
+        }
+    }
+    report.set("hoisted_alloca", hoisted_count);
+    return hoisted_count > 0u;
+}
+
 void optimize_xir_for_air(
-    xir::Module *module, const ShaderOption &option) noexcept {
+    xir::Module *module, const ShaderOption &option,
+    MetalRayQueryPipelinePolicy ray_query_policy) noexcept {
     verify_xir_or_error(module, "AST translation");
 
     auto optimization_options = xir::OptimizationPipelineOptions{
@@ -235,9 +295,12 @@ void optimize_xir_for_air(
 
     if (has_autodiff_scope(module)) {
         xir::PassPipeline pre_autodiff;
-        if (option.enable_ray_query_pipeline) {
+        if (option.enable_ray_query_pipeline && ray_query_policy.enabled) {
             pre_autodiff.add("outline-ray-query-pipelines",
-                             outline_ray_query_pipelines);
+                             [ray_query_policy](xir::Module *m, xir::PassReport &report) {
+                                 return outline_ray_query_pipelines(
+                                     m, report, ray_query_policy);
+                             });
         }
         pre_autodiff.add("lower-ray-query-to-loop", lower_ray_query_loops);
         pre_autodiff.add("destructure-cfg-before-inline", destructure_cfg);
@@ -295,15 +358,26 @@ void optimize_xir_for_air(
     }
 
     xir::PassPipeline lowering;
-    if (option.enable_ray_query_pipeline) {
+    if (option.enable_ray_query_pipeline && ray_query_policy.enabled) {
         lowering.add("outline-ray-query-pipelines",
-                     outline_ray_query_pipelines);
+                     [ray_query_policy](xir::Module *m, xir::PassReport &report) {
+                         return outline_ray_query_pipelines(
+                             m, report, ray_query_policy);
+                     });
     }
     lowering.add("lower-ray-query-to-loop", lower_ray_query_loops);
     lowering.add("destructure-cfg", destructure_cfg);
     lowering.add("inline-all", [](xir::Module *m, xir::PassReport &report) {
         return inline_all(m, report);
     });
+    // Multi-block callable inlining clones its function-local allocations into
+    // the cloned region. AIR stateful intersection-query storage has function
+    // lifetime and must be allocated/deallocated on every function exit, so
+    // canonicalize all local allocations into the entry prefix before
+    // mem2reg. This also keeps ordinary callable-local temporaries on the same
+    // lifetime model already used by reg2mem and the IFT outliner.
+    lowering.add("hoist-allocas-after-inline",
+                 hoist_allocas_after_inlining);
     lowering.add("mem2reg", [](xir::Module *m, xir::PassReport &report) {
         auto result = xir::mem2reg_pass_run_on_module(m, &report);
         return result.promoted_alloca_count > 0u;
@@ -338,7 +412,9 @@ void optimize_xir_for_air(
 }// namespace
 
 luisa::unique_ptr<xir::Module>
-metal_translate_ast_to_xir(Function kernel, const ShaderOption &option) noexcept {
+metal_translate_ast_to_xir(
+    Function kernel, const ShaderOption &option,
+    MetalRayQueryPipelinePolicy ray_query_policy) noexcept {
     Clock translate_clock;
     auto module = xir::ast_to_xir_translate(kernel, {});
     module->set_name(luisa::format("kernel_{:016x}", kernel.hash()));
@@ -349,7 +425,7 @@ metal_translate_ast_to_xir(Function kernel, const ShaderOption &option) noexcept
     if (dump_xir_enabled()) {
         dump_xir(module.get(), luisa::format("kernel.{:016x}.metal.xir", kernel.hash()));
     }
-    optimize_xir_for_air(module.get(), option);
+    optimize_xir_for_air(module.get(), option, ray_query_policy);
 
     if (dump_xir_enabled()) {
         dump_xir(module.get(), luisa::format("kernel.{:016x}.metal.opt.xir", kernel.hash()));
@@ -387,7 +463,7 @@ metal_translate_raster_ast_to_xir(
                 "raster.{}.{:016x}.metal.xir",
                 stage_name, stage_function.hash()));
     }
-    optimize_xir_for_air(module.get(), option);
+    optimize_xir_for_air(module.get(), option, {});
     if (dump_xir_enabled()) {
         dump_xir(
             module.get(),

--- a/src/backends/metal4/metal_xir_pipeline.h
+++ b/src/backends/metal4/metal_xir_pipeline.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstddef>
+#include <limits>
+
 #include <luisa/ast/function.h>
 #include <luisa/core/stl/memory.h>
 #include <luisa/runtime/rhi/resource.h>
@@ -7,8 +10,16 @@
 
 namespace luisa::compute::metal {
 
+struct MetalRayQueryPipelinePolicy {
+    bool enabled{true};
+    size_t max_captured_payload_bytes{
+        std::numeric_limits<size_t>::max()};
+};
+
 [[nodiscard]] luisa::unique_ptr<xir::Module>
-metal_translate_ast_to_xir(Function kernel, const ShaderOption &option) noexcept;
+metal_translate_ast_to_xir(
+    Function kernel, const ShaderOption &option,
+    MetalRayQueryPipelinePolicy ray_query_policy = {}) noexcept;
 
 [[nodiscard]] luisa::unique_ptr<xir::Module>
 metal_translate_raster_ast_to_xir(

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -759,6 +759,13 @@ luisa_compute_add_test(test_xir_pass_mutation_safety unit/xir/test_xir_pass_muta
 luisa_compute_add_test(test_device_debugger         integration/runtime/test_device_debugger.cpp)
 luisa_compute_add_test(test_dstorage_decompression  integration/runtime/test_dstorage_decompression.cpp)
 luisa_compute_add_test(test_procedural_callable      integration/runtime/test_procedural_callable.cpp)
+if (TARGET luisa-compute-backend-metal4)
+    add_test(NAME test_metal4_procedural_callable
+            COMMAND test_procedural_callable metal4 --spp 4)
+    set_tests_properties(test_metal4_procedural_callable PROPERTIES
+            LABELS "integration;integration_metal4;integration_render"
+            TIMEOUT 300)
+endif ()
 luisa_compute_add_test(test_rtx                      integration/runtime/test_rtx.cpp)
 luisa_compute_add_test(test_aot                      integration/runtime/test_aot.cpp)
 luisa_compute_add_test(test_oso_parser               integration/runtime/test_oso_parser.cpp)

--- a/src/tests/integration/runtime/test_metal_xir_air_ray_query_state_machine.cpp
+++ b/src/tests/integration/runtime/test_metal_xir_air_ray_query_state_machine.cpp
@@ -165,7 +165,8 @@ void test_outlineable_triangle_state_machine(Device &device) {
         state_machine,
         ShaderOption{
             .enable_cache = false,
-            .enable_ray_query_pipeline = true});
+            .enable_ray_query_pipeline = true,
+            .force_ray_query_pipeline = true});
     auto stateful_shader = device.compile(
         state_machine,
         ShaderOption{
@@ -272,21 +273,20 @@ void test_retained_procedural_state_machine(Device &device) {
     auto accel = device.create_accel();
     accel.emplace_back(primitive);
 
-    Kernel1D state_machine = [](
-                                 AccelVar scene,
-                                 BufferUInt result,
-                                 BufferUInt scratch,
-                                 BufferFloat4 ray_data,
-                                 BufferFloat distances,
-                                 BufferUInt selection,
-                                 BindlessVar heap) noexcept {
+    Callable trace_procedural = [](
+                                    AccelVar scene,
+                                    BufferUInt scratch,
+                                    BufferFloat4 ray_data,
+                                    BufferFloat distances,
+                                    BufferUInt selection,
+                                    BindlessVar heap,
+                                    UInt &candidate_count,
+                                    UInt &checksum) noexcept {
         auto ray = make_ray(
             make_float3(0.0f, 0.0f, 1.0f),
             make_float3(0.0f, 0.0f, -1.0f),
             0.0f, 10.0f);
         auto query = scene.query(ray, {});
-        UInt candidate_count = 0u;
-        UInt checksum = 0u;
         $while (query.proceed()) {
             $if (query.is_procedural_candidate()) {
                 auto candidate = query.procedural_candidate();
@@ -330,7 +330,24 @@ void test_retained_procedural_state_machine(Device &device) {
                 // The test scene has no triangle geometry.
             };
         };
-        auto committed = query.committed_hit();
+        return query.committed_hit();
+    };
+    trace_procedural.function_builder()->set_name(
+        "metal4_retained_procedural_state_machine_callable");
+
+    Kernel1D state_machine = [&trace_procedural](
+                                 AccelVar scene,
+                                 BufferUInt result,
+                                 BufferUInt scratch,
+                                 BufferFloat4 ray_data,
+                                 BufferFloat distances,
+                                 BufferUInt selection,
+                                 BindlessVar heap) noexcept {
+        UInt candidate_count = 0u;
+        UInt checksum = 0u;
+        auto committed = trace_procedural(
+            scene, scratch, ray_data, distances, selection, heap,
+            candidate_count, checksum);
         result.write(0u, candidate_count);
         result.write(1u, committed.hit_type);
         result.write(2u, committed.prim);
@@ -341,7 +358,8 @@ void test_retained_procedural_state_machine(Device &device) {
         state_machine,
         ShaderOption{
             .enable_cache = false,
-            .enable_ray_query_pipeline = true});
+            .enable_ray_query_pipeline = true,
+            .force_ray_query_pipeline = true});
     auto explicitly_stateful_shader = device.compile(
         state_machine,
         ShaderOption{

--- a/src/tests/integration/runtime/test_procedural_callable.cpp
+++ b/src/tests/integration/runtime/test_procedural_callable.cpp
@@ -3,7 +3,9 @@
 #include <luisa/luisa-compute.h>
 #include <luisa/dsl/sugar.h>
 #include "reference_image.h"
+#include <cstdlib>
 #include <iostream>
+#include <string_view>
 
 using namespace luisa;
 using namespace luisa::compute;
@@ -68,7 +70,24 @@ void test_procedural_callable(Device &device, int argc, char *argv[]) {
            << accel.build()
            << synchronize();
 
-    static constexpr auto spp = 1024u;
+    auto spp = 1024u;
+    for (auto i = 1; i < argc; i++) {
+        if (std::string_view{argv[i]} == "--spp") {
+            if (++i >= argc) {
+                expect(false) << "missing value for --spp";
+                return;
+            }
+            char *end = nullptr;
+            auto value = std::strtoul(argv[i], &end, 10);
+            if (end == argv[i] || *end != '\0' || value == 0u ||
+                value > 65536u) {
+                expect(false) << "invalid --spp value";
+                return;
+            }
+            spp = static_cast<uint>(value);
+        }
+    }
+    LUISA_INFO("Procedural callable rendering with {} spp.", spp);
 
     Callable tea = [](UInt v0, UInt v1) noexcept {
         auto s0 = def(0u);

--- a/src/tests/unit/core/test_hash.cpp
+++ b/src/tests/unit/core/test_hash.cpp
@@ -251,12 +251,20 @@ void reg_shader_option_hash() {
         native_include.native_include = "define i32 @external() { ret i32 1 }";
         auto register_limit = base;
         register_limit.max_registers = 32u;
+        auto retain_ray_query_loop = base;
+        retain_ray_query_loop.enable_ray_query_pipeline = false;
+        auto force_ray_query_pipeline = base;
+        force_ray_query_pipeline.force_ray_query_pipeline = true;
 
         auto base_hash = luisa::hash_value(base);
         expect(luisa::hash_value(native_include) != base_hash)
             << "native_include changes generated shader code";
         expect(luisa::hash_value(register_limit) != base_hash)
             << "max_registers changes backend compilation semantics";
+        expect(luisa::hash_value(retain_ray_query_loop) != base_hash)
+            << "ray-query lowering mode changes generated shader code";
+        expect(luisa::hash_value(force_ray_query_pipeline) != base_hash)
+            << "forced ray-query policy changes generated shader code";
     };
 }
 

--- a/src/tests/unit/xir/test_xir_pass_lower_ray_query_to_pipeline.cpp
+++ b/src/tests/unit/xir/test_xir_pass_lower_ray_query_to_pipeline.cpp
@@ -55,6 +55,11 @@ namespace {
     return value->type() != Type::of<int>();
 }
 
+[[nodiscard]] size_t natural_ray_query_capture_cost(
+    const Value *value, bool) noexcept {
+    return value->type()->size();
+}
+
 struct RayQueryFixture {
     KernelFunction *kernel;
     BasicBlock *body;
@@ -1190,6 +1195,45 @@ void register_tests() {
         expect(capture_free.body->terminator() == nullptr ||
                !capture_free.body->terminator()->isa<RayQueryLoopInst>());
         expect(captured.body->terminator() == captured.loop);
+        expect(xir_verify_module(&m).succeeded());
+    };
+
+    "capture_cost_selectively_retains_over_budget_payloads"_test = [] {
+        Module m;
+        auto small = make_fixture(m);
+        auto large = make_fixture(m);
+        XIRBuilder b;
+        auto add_mutable_capture = [&](RayQueryFixture fixture,
+                                       const Type *type) noexcept {
+            auto *value = fixture.kernel->create_value_argument(type);
+            b.set_insertion_point(fixture.body->instructions().front());
+            auto *state = b.alloca_local(type);
+            b.set_insertion_point(fixture.surface);
+            b.store(state, value);
+            b.br(fixture.dispatch);
+        };
+        add_mutable_capture(small, Type::of<int>());
+        add_mutable_capture(large, Type::of<float4>());
+
+        expect(xir_verify_module(&m).succeeded());
+        size_t skipped_loop_count = 0u;
+        PassReport report;
+        auto info = lower_ray_query_to_pipeline_pass_run_on_module(
+            &m, &report,
+            {.captured_argument_cost = natural_ray_query_capture_cost,
+             .max_captured_argument_cost = 8u,
+             .skipped_loop_count = &skipped_loop_count});
+
+        expect(info.succeeded());
+        expect(info.error_count == 0u);
+        expect(info.lowered_loop_count == 1u);
+        expect(skipped_loop_count == 1u);
+        expect(report_value(
+                   report,
+                   "selection_localization_analysis") == 0u);
+        expect(small.body->terminator() == nullptr ||
+               !small.body->terminator()->isa<RayQueryLoopInst>());
+        expect(large.body->terminator() == large.loop);
         expect(xir_verify_module(&m).succeeded());
     };
 

--- a/src/xir/passes/lower_ray_query_to_pipeline.cpp
+++ b/src/xir/passes/lower_ray_query_to_pipeline.cpp
@@ -27,14 +27,13 @@
 
 #include "helpers.h"
 #include "lower_ray_query_handler_graph.h"
-
+#include "lower_ray_query_to_pipeline_capture_cost.h"
 namespace luisa::compute::xir {
 
 // This result is returned by the established exported overloads. Growing it
 // changes the platform return convention (for example, register return to
 // sret on x86-64), so new optional outputs belong in the options overload.
-static_assert(sizeof(LowerRayQueryToPipelineInfo) ==
-              2u * sizeof(size_t));
+static_assert(sizeof(LowerRayQueryToPipelineInfo) == 2u * sizeof(size_t));
 
 namespace detail {
 
@@ -1337,6 +1336,7 @@ select_ray_query_loops(
         size_t handler_instruction_count;
         size_t input_capture_count;
         size_t output_capture_count;
+        size_t capture_cost;
         bool capture_filter_eligible;
         bool capture_eligible;
     };
@@ -1361,48 +1361,44 @@ select_ray_query_loops(
                 ++handler_instruction_count;
             }
         }
-        // Localization can affect selection only when the raw capture count
-        // exceeds the finite budget. If the raw count already fits (including
-        // the unbounded default), proving which inputs will later become
-        // handler-local is dead analysis: every possible proof result selects
-        // the same loop. The lowering phase still performs the complete proof
-        // exactly once before changing the callback ABI.
+        // Localization affects count selection only when the raw count exceeds
+        // its budget. Payload cost deliberately remains a conservative raw
+        // bound; lowering performs the complete proof once before ABI changes.
         auto input_capture_count = capture_list.in_values.size();
         auto output_capture_count = capture_list.out_values.size();
+        auto capture_cost = detail::ray_query_capture_cost(luisa::span{capture_list.in_values},
+                                                           luisa::span{capture_list.out_values}, options);
         auto capture_filter_eligible = true;
         if (options.captured_argument_filter != nullptr) {
             for (auto *value : capture_list.in_values) {
-                capture_filter_eligible &=
-                    options.captured_argument_filter(value, false);
+                capture_filter_eligible &= options.captured_argument_filter(value, false);
             }
             for (auto *value : capture_list.out_values) {
-                capture_filter_eligible &=
-                    options.captured_argument_filter(value, true);
+                capture_filter_eligible &= options.captured_argument_filter(value, true);
             }
         }
         auto capture_eligible =
             capture_filter_eligible &&
-            capture_count_within_limit(
-                input_capture_count, output_capture_count,
-                options.max_captured_argument_count);
+            capture_cost.total() <= options.max_captured_argument_cost &&
+            capture_count_within_limit(input_capture_count, output_capture_count,
+                                       options.max_captured_argument_count);
         // Output captures cannot be localized. If they alone exceed the
         // budget, no input-localization result can make the loop eligible.
         if (!capture_eligible && capture_filter_eligible &&
-            output_capture_count <=
-                options.max_captured_argument_count) {
+            capture_cost.total() <= options.max_captured_argument_cost &&
+            output_capture_count <= options.max_captured_argument_count) {
             ++info.selection_localization_analysis_count;
             auto localized_input_capture_count =
                 count_handler_localized_input_captures(
                     loop, capture_list, info);
-            LUISA_DEBUG_ASSERT(
-                localized_input_capture_count <= input_capture_count,
-                "Localized ray-query handler captures exceed input captures.");
+            LUISA_DEBUG_ASSERT(localized_input_capture_count <= input_capture_count,
+                               "Localized ray-query handler captures exceed input captures.");
             input_capture_count -= localized_input_capture_count;
             capture_eligible =
                 capture_filter_eligible &&
-                capture_count_within_limit(
-                    input_capture_count, output_capture_count,
-                    options.max_captured_argument_count);
+                capture_cost.total() <= options.max_captured_argument_cost &&
+                capture_count_within_limit(input_capture_count, output_capture_count,
+                                           options.max_captured_argument_count);
         }
         capture_eligible_loop_count += capture_eligible ? 1u : 0u;
         candidates.emplace_back(Candidate{
@@ -1411,6 +1407,7 @@ select_ray_query_loops(
             .handler_instruction_count = handler_instruction_count,
             .input_capture_count = input_capture_count,
             .output_capture_count = output_capture_count,
+            .capture_cost = capture_cost.total(),
             .capture_filter_eligible = capture_filter_eligible,
             .capture_eligible = capture_eligible});
     }
@@ -1424,21 +1421,24 @@ select_ray_query_loops(
                 options.min_small_handler_loop_count;
         if (candidate.capture_eligible && profitability_eligible) {
             LUISA_VERBOSE(
-                "lower_ray_query_to_pipeline: selecting loop with {} handler block(s), {} handler instruction(s), at most {} input and {} output captured argument(s).",
-                candidate.handler_block_count,
-                candidate.handler_instruction_count,
-                candidate.input_capture_count,
-                candidate.output_capture_count);
-            selected.emplace_back(candidate.loop);
-        } else {
-            LUISA_VERBOSE(
-                "lower_ray_query_to_pipeline: retaining loop with {} handler block(s), {} handler instruction(s), at most {} input and {} output captured argument(s) (capture_filter={}, capture_limit={}, min_handler_instructions={}, eligible_loop_count={}, small_handler_loop_threshold={}).",
+                "lower_ray_query_to_pipeline: selecting loop with {} handler block(s), {} handler instruction(s), at most {} input and {} output captured argument(s), costing {} payload byte(s).",
                 candidate.handler_block_count,
                 candidate.handler_instruction_count,
                 candidate.input_capture_count,
                 candidate.output_capture_count,
+                candidate.capture_cost);
+            selected.emplace_back(candidate.loop);
+        } else {
+            LUISA_VERBOSE(
+                "lower_ray_query_to_pipeline: retaining loop with {} handler block(s), {} handler instruction(s), at most {} input and {} output captured argument(s), costing {} payload byte(s) (capture_filter={}, capture_limit={}, capture_cost_limit={}, min_handler_instructions={}, eligible_loop_count={}, small_handler_loop_threshold={}).",
+                candidate.handler_block_count,
+                candidate.handler_instruction_count,
+                candidate.input_capture_count,
+                candidate.output_capture_count,
+                candidate.capture_cost,
                 candidate.capture_filter_eligible,
                 options.max_captured_argument_count,
+                options.max_captured_argument_cost,
                 options.min_handler_instruction_count,
                 capture_eligible_loop_count,
                 options.min_small_handler_loop_count);

--- a/src/xir/passes/lower_ray_query_to_pipeline_capture_cost.h
+++ b/src/xir/passes/lower_ray_query_to_pipeline_capture_cost.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <limits>
+
+#include <luisa/core/stl/memory.h>
+#include <luisa/xir/passes/lower_ray_query_to_pipeline.h>
+
+namespace luisa::compute::xir::detail {
+
+struct RayQueryCaptureCost {
+    size_t input{0u};
+    size_t output{0u};
+
+    [[nodiscard]] size_t total() const noexcept {
+        auto limit = std::numeric_limits<size_t>::max();
+        return input > limit - output ? limit : input + output;
+    }
+};
+
+[[nodiscard]] inline size_t saturating_capture_cost_add(
+    size_t total, size_t increment) noexcept {
+    auto limit = std::numeric_limits<size_t>::max();
+    return total > limit - increment ? limit : total + increment;
+}
+
+template<typename Input, typename Output>
+[[nodiscard]] inline RayQueryCaptureCost ray_query_capture_cost(
+    luisa::span<Input> inputs,
+    luisa::span<Output> outputs,
+    const LowerRayQueryToPipelineOptions &options) noexcept {
+    RayQueryCaptureCost cost;
+    if (options.captured_argument_cost == nullptr) { return cost; }
+    for (auto value : inputs) {
+        cost.input = saturating_capture_cost_add(
+            cost.input,
+            options.captured_argument_cost(value, false));
+    }
+    for (auto value : outputs) {
+        cost.output = saturating_capture_cost_add(
+            cost.output,
+            options.captured_argument_cost(value, true));
+    }
+    return cost;
+}
+
+}// namespace luisa::compute::xir::detail


### PR DESCRIPTION
## Summary

- hoist every post-inline XIR `alloca` into the function entry before `mem2reg`
- select Metal4 ray-query IFT lowering by device family and captured-payload cost
- preserve semantic fail-closed behavior for unsupported procedural/curve/object-ray forms
- add captured-state benchmarks plus complex callable/procedural direct ray-query tests
- document AIR conventions, Apple7/Apple10 measurements, iOS build, and bundle auditing

## Validation

- CMake/Ninja full build: passed
- CTest: 168/168 passed (15 rendering, 39 Metal4 integration)
- Metal API Validation + Luisa validation: 39/39 passed
- iOS Xcode ALL_BUILD: 49 targets passed
- iOS audit: 19/19 app bundles are arm64 iPhoneOS; only Apple dynamic dependencies
- physical iPhone 17 Pro Max: automatic 0B/128B payloads use IFT; 512B falls back to stateful; all finite renders completed
- Mac M1 Max and iPhone matched pipeline/loop A/B results and image comparisons are recorded in the AIR document