### PR TITLE
remote: add pure C++ network backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ endif ()
 # runtime shell reaches parity with the selected fallback core suite.
 option(LUISA_COMPUTE_ENABLE_SIMD "Enable experimental SIMD CPU backend" OFF)
 
+# The C++ remote backend is opt-in while its protocol and backend coverage are
+# being brought to parity with the native backends. It has no dependency on
+# the removed legacy Rust workspace.
+option(LUISA_COMPUTE_ENABLE_REMOTE "Enable experimental C++ remote backend" OFF)
+
 # iOS device tests are signed application bundles rather than host executables.
 # Keep them separate from the ordinary test suite so cross-compiling the runtime
 # does not implicitly pull test applications, provisioning, or UIKit into a

--- a/include/luisa/ast/ast2json.h
+++ b/include/luisa/ast/ast2json.h
@@ -4,10 +4,82 @@
 //
 
 #include <luisa/core/dll_export.h>
+#include <luisa/core/stl/memory.h>
 #include <luisa/core/stl/string.h>
 #include <luisa/ast/function.h>
 
 namespace luisa::compute {
+
+constexpr uint32_t ast_json_schema_version = 1u;
+constexpr luisa::string_view ast_json_indirect_dispatch_buffer_type_name =
+    "LC_IndirectDispatchBuffer";
+constexpr luisa::string_view ast_json_ray_query_all_type_name =
+    "LC_RayQueryAll";
+constexpr luisa::string_view ast_json_ray_query_any_type_name =
+    "LC_RayQueryAny";
+
+struct ASTJsonLimits {
+    size_t max_document_bytes{64u * 1024u * 1024u};
+    size_t max_parse_memory_bytes{256u * 1024u * 1024u};
+    size_t max_functions{256u};
+    size_t max_types{4096u};
+    size_t max_nodes{1u << 20u};
+    size_t max_depth{256u};
+    size_t max_constant_bytes{16u * 1024u * 1024u};
+    size_t max_string_bytes{1u * 1024u * 1024u};
+};
+
+class LUISA_AST_API ASTJsonBindingResolver {
+
+public:
+    virtual ~ASTJsonBindingResolver() noexcept = default;
+
+    [[nodiscard]] virtual bool resolve_buffer(
+        const Type *serialized_type, uint64_t serialized_handle,
+        size_t serialized_offset,
+        size_t serialized_size, Function::BufferBinding &binding,
+        luisa::string &error) const noexcept;
+
+    [[nodiscard]] virtual bool resolve_texture(
+        uint64_t serialized_handle, uint32_t serialized_level,
+        Function::TextureBinding &binding,
+        luisa::string &error) const noexcept;
+
+    [[nodiscard]] virtual bool resolve_bindless_array(
+        uint64_t serialized_handle, Function::BindlessArrayBinding &binding,
+        luisa::string &error) const noexcept;
+
+    [[nodiscard]] virtual bool resolve_accel(
+        uint64_t serialized_handle, Function::AccelBinding &binding,
+        luisa::string &error) const noexcept;
+};
+
+struct ASTJsonEncodeResult {
+    luisa::string json;
+    luisa::string error;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error.empty();
+    }
+};
+
+struct ASTJsonDecodeResult {
+    luisa::shared_ptr<const detail::FunctionBuilder> function;
+    luisa::string error;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return function != nullptr && error.empty();
+    }
+};
+
 [[nodiscard]] LUISA_AST_API luisa::string to_json(const Type *type) noexcept;
 [[nodiscard]] LUISA_AST_API luisa::string to_json(Function function) noexcept;
+
+[[nodiscard]] LUISA_AST_API ASTJsonEncodeResult try_to_json(
+    Function function, const ASTJsonLimits &limits = {}) noexcept;
+
+[[nodiscard]] LUISA_AST_API ASTJsonDecodeResult from_json(
+    luisa::string_view json, const ASTJsonLimits &limits = {},
+    const ASTJsonBindingResolver *binding_resolver = nullptr) noexcept;
+
 }// namespace luisa::compute

--- a/include/luisa/ast/function_builder.h
+++ b/include/luisa/ast/function_builder.h
@@ -461,6 +461,9 @@ public:
     void comment_(luisa::string comment) noexcept;
     /// Add assign statement
     void assign(const Expression *lhs, const Expression *rhs) noexcept;
+    /// Add an expression statement. This is primarily used by structured AST
+    /// reconstruction where the expression has already been materialized.
+    void expression_statement(const Expression *expr) noexcept;
 
     /// Add if statement
     [[nodiscard]] IfStmt *if_(const Expression *cond) noexcept;

--- a/include/luisa/backends/ext/remote_config_ext.h
+++ b/include/luisa/backends/ext/remote_config_ext.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include <luisa/core/stl/string.h>
+#include <luisa/runtime/rhi/device_interface.h>
+
+namespace luisa::compute {
+
+class RemoteDeviceConfigExt final : public DeviceConfigExt {
+
+private:
+    luisa::string _host;
+    uint16_t _port;
+    luisa::string _token;
+    uint64_t _connect_timeout_ms;
+    uint64_t _request_timeout_ms;
+    uint64_t _max_in_flight_bytes;
+    bool _enable_blob_cache;
+    uint64_t _blob_cache_min_size;
+    luisa::string _local_present_backend;
+    luisa::string _server_backend;
+    size_t _server_device_index;
+    bool _server_enable_validation;
+
+public:
+    explicit RemoteDeviceConfigExt(
+        luisa::string host = "127.0.0.1",
+        uint16_t port = 18080u,
+        luisa::string token = {},
+        uint64_t connect_timeout_ms = 10'000u,
+        uint64_t request_timeout_ms = 60'000u,
+        uint64_t max_in_flight_bytes = 256ull * 1024ull * 1024ull,
+        bool enable_blob_cache = true,
+        uint64_t blob_cache_min_size = 64ull * 1024ull,
+        luisa::string local_present_backend = {},
+        luisa::string server_backend = {},
+        size_t server_device_index = std::numeric_limits<size_t>::max(),
+        bool server_enable_validation = false) noexcept
+        : _host{std::move(host)},
+          _port{port},
+          _token{std::move(token)},
+          _connect_timeout_ms{connect_timeout_ms},
+          _request_timeout_ms{request_timeout_ms},
+          _max_in_flight_bytes{max_in_flight_bytes},
+          _enable_blob_cache{enable_blob_cache},
+          _blob_cache_min_size{blob_cache_min_size},
+          _local_present_backend{std::move(local_present_backend)},
+          _server_backend{std::move(server_backend)},
+          _server_device_index{server_device_index},
+          _server_enable_validation{server_enable_validation} {}
+
+    [[nodiscard]] auto host() const noexcept { return luisa::string_view{_host}; }
+    [[nodiscard]] auto port() const noexcept { return _port; }
+    [[nodiscard]] auto token() const noexcept { return luisa::string_view{_token}; }
+    [[nodiscard]] auto connect_timeout_ms() const noexcept { return _connect_timeout_ms; }
+    [[nodiscard]] auto request_timeout_ms() const noexcept { return _request_timeout_ms; }
+    [[nodiscard]] auto max_in_flight_bytes() const noexcept { return _max_in_flight_bytes; }
+    [[nodiscard]] auto enable_blob_cache() const noexcept { return _enable_blob_cache; }
+    [[nodiscard]] auto blob_cache_min_size() const noexcept { return _blob_cache_min_size; }
+    [[nodiscard]] auto local_present_backend() const noexcept { return luisa::string_view{_local_present_backend}; }
+    [[nodiscard]] auto server_backend() const noexcept { return luisa::string_view{_server_backend}; }
+    [[nodiscard]] auto server_device_index() const noexcept { return _server_device_index; }
+    [[nodiscard]] auto server_enable_validation() const noexcept { return _server_enable_validation; }
+};
+
+}// namespace luisa::compute

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LUISA_COMPUTE_AST_SOURCES
         ast2json.cpp
+        json2ast.cpp
         atomic_ref_node.cpp
         callable_library.cpp
         constant_data.cpp

--- a/src/ast/ast2json.cpp
+++ b/src/ast/ast2json.cpp
@@ -452,7 +452,18 @@ public:
                 case '\n': ss.append("\\n"); break;
                 case '\r': ss.append("\\r"); break;
                 case '\t': ss.append("\\t"); break;
-                default: ss.push_back(c); break;
+                default: {
+                    auto u = static_cast<unsigned char>(c);
+                    if (u < 0x20u) {
+                        constexpr auto hex = "0123456789abcdef";
+                        ss.append("\\u00");
+                        ss.push_back(hex[u >> 4u]);
+                        ss.push_back(hex[u & 0x0fu]);
+                    } else {
+                        ss.push_back(c);
+                    }
+                    break;
+                }
             }
         }
         ss.push_back('"');
@@ -660,10 +671,15 @@ private:
         auto tag = (v.is_local() || v.is_builtin()) && is_argument ?
                        "ARGUMENT" :
                        luisa::to_string(v.tag());
-        vars.emplace_back(JSON::Object{
+        auto variable = JSON{JSON::Object{
             {"tag", tag},
             {"type", _type_index(v.type())},
-        });
+            {"usage", luisa::to_string(_func_ctx->f.variable_usage(v.uid()))},
+        }};
+        if (auto name = _func_ctx->f.get_variable_name(v.uid()); !name.empty()) {
+            variable["name"] = name;
+        }
+        vars.emplace_back(std::move(variable));
         return index;
     }
     [[nodiscard]] uint _constant_index(ConstantData c) noexcept {
@@ -747,6 +763,10 @@ private:
         auto old_ctx = std::exchange(_func_ctx, &ctx);
         // convert
         ctx.j["tag"] = luisa::to_string(f.tag());
+        if (!f.name().empty()) { ctx.j["name"] = f.name(); }
+        if (auto warp_size = f.allowed_warp_size()) {
+            ctx.j["allowed_warp_size"] = static_cast<uint32_t>(*warp_size);
+        }
         ctx.j["curve_bases"] = [bs = f.required_curve_bases()] {
             JSON::Array a;
             a.reserve(bs.count());
@@ -908,6 +928,18 @@ private:
             }
             return a;
         }();
+        if (expr->is_builtin() && expr->curve_basis_set().any()) {
+            j["curve_bases"] = [bs = expr->curve_basis_set()] {
+                JSON::Array a;
+                a.reserve(bs.count());
+                for (auto i = 0u; i < curve_basis_count; i++) {
+                    if (auto basis = static_cast<CurveBasis>(i); bs.test(basis)) {
+                        a.emplace_back(luisa::to_string(basis));
+                    }
+                }
+                return a;
+            }();
+        }
     }
     void _convert_cast_expr(JSON &j, const CastExpr *expr) noexcept {
         j["op"] = luisa::to_string(expr->op());
@@ -1113,6 +1145,8 @@ public:
         LUISA_ASSERT(converter._func_ctx == nullptr,
                      "Function context stack corrupted.");
         auto j = std::move(converter._root);
+        j["schema"] = "luisa.compute.ast";
+        j["version"] = ast_json_schema_version;
         j["entry"] = entry;
         return j;
     }
@@ -1120,6 +1154,8 @@ public:
         AST2JSON converter;
         auto t = converter._type_index(type);
         auto j = std::move(converter._root);
+        j["schema"] = "luisa.compute.type";
+        j["version"] = ast_json_schema_version;
         j["root"] = t;
         return j;
     }

--- a/src/ast/function_builder.cpp
+++ b/src/ast/function_builder.cpp
@@ -282,6 +282,10 @@ void FunctionBuilder::_void_expr(const Expression *expr) noexcept {
     if (expr != nullptr) { _create_and_append_statement<ExprStmt>(expr); }
 }
 
+void FunctionBuilder::expression_statement(const Expression *expr) noexcept {
+    _void_expr(expr);
+}
+
 SwitchStmt *FunctionBuilder::switch_(const Expression *expr) noexcept {
     expr = _internalize(expr);
     return _create_and_append_statement<SwitchStmt>(expr);

--- a/src/ast/json2ast.cpp
+++ b/src/ast/json2ast.cpp
@@ -1049,7 +1049,7 @@ private:
         return false;
     }
 
-    [[nodiscard]] bool _int32(
+    [[nodiscard]] bool _decode_int32(
         yyjson_val *value, int32_t &result,
         luisa::string_view path) noexcept {
         if (yyjson_is_sint(value)) {
@@ -1657,7 +1657,7 @@ private:
             case Statement::Tag::SWITCH_CASE: {
                 if (!_check_keys(object, {"tag", "value", "body"}, path)) { return false; }
                 int32_t value{};
-                if (!_int32(
+                if (!_decode_int32(
                         _member(object, "value", path), value,
                         luisa::format("{}.value", path))) {
                     return false;

--- a/src/ast/json2ast.cpp
+++ b/src/ast/json2ast.cpp
@@ -1,0 +1,2406 @@
+#include <luisa/ast/ast2json.h>
+
+#include <algorithm>
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <unordered_set>
+
+#include <yyjson.h>
+
+#include <luisa/ast/function_builder.h>
+#include <luisa/core/magic_enum.h>
+#include <luisa/core/stl/format.h>
+
+namespace luisa::compute {
+
+bool ASTJsonBindingResolver::resolve_buffer(
+    const Type *, uint64_t serialized_handle, size_t serialized_offset,
+    size_t serialized_size, Function::BufferBinding &binding,
+    luisa::string &) const noexcept {
+    binding = Function::BufferBinding{
+        serialized_handle, serialized_offset, serialized_size};
+    return true;
+}
+
+bool ASTJsonBindingResolver::resolve_texture(
+    uint64_t serialized_handle, uint32_t serialized_level,
+    Function::TextureBinding &binding,
+    luisa::string &) const noexcept {
+    binding = Function::TextureBinding{
+        serialized_handle, serialized_level};
+    return true;
+}
+
+bool ASTJsonBindingResolver::resolve_bindless_array(
+    uint64_t serialized_handle, Function::BindlessArrayBinding &binding,
+    luisa::string &) const noexcept {
+    binding = Function::BindlessArrayBinding{serialized_handle};
+    return true;
+}
+
+bool ASTJsonBindingResolver::resolve_accel(
+    uint64_t serialized_handle, Function::AccelBinding &binding,
+    luisa::string &) const noexcept {
+    binding = Function::AccelBinding{serialized_handle};
+    return true;
+}
+
+namespace {
+
+[[nodiscard]] bool is_remote_safe_custom_type(
+    const Type *type) noexcept {
+    if (type == nullptr || !type->is_custom()) { return false; }
+    auto id = type->description();
+    return id == ast_json_indirect_dispatch_buffer_type_name ||
+           id == ast_json_ray_query_all_type_name ||
+           id == ast_json_ray_query_any_type_name;
+}
+
+[[nodiscard]] bool is_indirect_dispatch_buffer_type(
+    const Type *type) noexcept {
+    return type != nullptr && type->is_custom() &&
+           type->description() ==
+               ast_json_indirect_dispatch_buffer_type_name;
+}
+
+[[nodiscard]] bool is_ray_query_type(
+    const Type *type) noexcept {
+    if (type == nullptr || !type->is_custom()) { return false; }
+    auto id = type->description();
+    return id == ast_json_ray_query_all_type_name ||
+           id == ast_json_ray_query_any_type_name;
+}
+
+[[nodiscard]] bool is_buffer_variable_type(
+    const Type *type) noexcept {
+    return type != nullptr &&
+           (type->is_buffer() || is_indirect_dispatch_buffer_type(type));
+}
+
+[[nodiscard]] bool assignment_types_compatible(
+    const Type *lhs, const Type *rhs) noexcept {
+    return lhs == rhs ||
+           (lhs != nullptr && rhs != nullptr &&
+            lhs->is_scalar() && rhs->is_scalar());
+}
+
+[[nodiscard]] bool is_assignable_expression(
+    const Expression *expression) noexcept {
+    if (expression == nullptr) { return false; }
+    switch (expression->tag()) {
+        case Expression::Tag::REF: return true;
+        case Expression::Tag::MEMBER:
+            return is_assignable_expression(
+                static_cast<const MemberExpr *>(expression)->self());
+        case Expression::Tag::ACCESS:
+            return is_assignable_expression(
+                static_cast<const AccessExpr *>(expression)->range());
+        default: return false;
+    }
+}
+
+class ASTJsonPreflight {
+
+private:
+    const ASTJsonLimits &_limits;
+    luisa::unordered_set<const detail::FunctionBuilder *> _visited_functions;
+    luisa::unordered_set<const detail::FunctionBuilder *> _active_functions;
+    luisa::unordered_set<const Type *> _visited_types;
+    luisa::unordered_set<const void *> _visited_constants;
+    size_t _node_count{};
+    size_t _constant_bytes{};
+    luisa::string _error;
+
+private:
+    void _fail(luisa::string message) noexcept {
+        if (_error.empty()) { _error = std::move(message); }
+    }
+
+    [[nodiscard]] bool _check_depth(size_t depth) noexcept {
+        if (depth > _limits.max_depth) {
+            _fail("AST JSON nesting exceeds the configured depth limit.");
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _count_node() noexcept {
+        if (++_node_count > _limits.max_nodes) {
+            _fail("AST JSON node count exceeds the configured limit.");
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _check_string(luisa::string_view value) noexcept {
+        if (value.size() > _limits.max_string_bytes) {
+            _fail("AST JSON string exceeds the configured limit.");
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _visit_type(const Type *type, size_t depth) noexcept {
+        if (type == nullptr || !_error.empty()) { return _error.empty(); }
+        if (!_check_depth(depth)) { return false; }
+        if (!_visited_types.emplace(type).second) { return true; }
+        if (_visited_types.size() > _limits.max_types) {
+            _fail("AST JSON type count exceeds the configured limit.");
+            return false;
+        }
+        if ((type->is_structure() || type->is_buffer() || type->is_texture()) &&
+            !type->member_attributes().empty()) {
+            _fail("Attributed AST types are not portable in AST JSON schema v1.");
+            return false;
+        }
+        switch (type->tag()) {
+            case Type::Tag::COOPERATIVE_VECTOR:
+            case Type::Tag::COOPERATIVE_VECTOR_REF:
+            case Type::Tag::COOPERATIVE_MATRIX_REF:
+                _fail("Cooperative AST types are not supported by AST JSON schema v1.");
+                return false;
+            case Type::Tag::CUSTOM:
+                if (!is_remote_safe_custom_type(type)) {
+                    _fail("Custom AST types are not supported by remote-safe AST JSON.");
+                    return false;
+                }
+                return _check_string(type->description());
+            case Type::Tag::VECTOR:
+            case Type::Tag::MATRIX:
+            case Type::Tag::ARRAY:
+            case Type::Tag::TEXTURE:
+                return _visit_type(type->element(), depth + 1u);
+            case Type::Tag::BUFFER:
+                if (auto element = type->element();
+                    element != nullptr && element->is_custom()) {
+                    _fail("Custom AST types cannot be nested in buffers.");
+                    return false;
+                }
+                return _visit_type(type->element(), depth + 1u);
+            case Type::Tag::STRUCTURE:
+                for (auto member : type->members()) {
+                    if (!_visit_type(member, depth + 1u)) { return false; }
+                }
+                return true;
+            default: return true;
+        }
+    }
+
+    [[nodiscard]] bool _visit_constant(
+        ConstantData data, size_t depth) noexcept {
+        if (!_visited_constants.emplace(data.raw()).second) { return true; }
+        auto size = data.type()->size();
+        if (size > _limits.max_constant_bytes -
+                       std::min(_constant_bytes, _limits.max_constant_bytes)) {
+            _fail("AST JSON constants exceed the configured byte limit.");
+            return false;
+        }
+        _constant_bytes += size;
+        return _visit_type(data.type(), depth);
+    }
+
+    [[nodiscard]] bool _visit_expr(const Expression *expr,
+                                   size_t depth) noexcept {
+        if (expr == nullptr || !_error.empty()) { return _error.empty(); }
+        if (!_check_depth(depth) || !_count_node() ||
+            !_visit_type(expr->type(), depth + 1u)) {
+            return false;
+        }
+        switch (expr->tag()) {
+            case Expression::Tag::UNARY:
+                return _visit_expr(
+                    static_cast<const UnaryExpr *>(expr)->operand(), depth + 1u);
+            case Expression::Tag::BINARY: {
+                auto e = static_cast<const BinaryExpr *>(expr);
+                return _visit_expr(e->lhs(), depth + 1u) &&
+                       _visit_expr(e->rhs(), depth + 1u);
+            }
+            case Expression::Tag::MEMBER:
+                return _visit_expr(
+                    static_cast<const MemberExpr *>(expr)->self(), depth + 1u);
+            case Expression::Tag::ACCESS: {
+                auto e = static_cast<const AccessExpr *>(expr);
+                return _visit_expr(e->range(), depth + 1u) &&
+                       _visit_expr(e->index(), depth + 1u);
+            }
+            case Expression::Tag::LITERAL: return true;
+            case Expression::Tag::REF:
+                return _visit_type(
+                    static_cast<const RefExpr *>(expr)->variable().type(), depth + 1u);
+            case Expression::Tag::CONSTANT: {
+                auto data = static_cast<const ConstantExpr *>(expr)->data();
+                return _visit_constant(data, depth + 1u);
+            }
+            case Expression::Tag::CALL: {
+                auto e = static_cast<const CallExpr *>(expr);
+                if (e->is_external()) {
+                    _fail("External AST functions are not supported by remote-safe AST JSON.");
+                    return false;
+                }
+                if (e->is_builtin() && is_atomic_operation(e->op())) {
+                    if (e->arguments().empty() ||
+                        e->arguments().front()->type() == nullptr ||
+                        e->arguments().front()->type()->element() == nullptr) {
+                        _fail("Atomic AST access chains require a typed buffer or array.");
+                        return false;
+                    }
+                }
+                if (e->is_custom() && !_visit_function(e->custom(), depth + 1u, false)) {
+                    return false;
+                }
+                for (auto arg : e->arguments()) {
+                    if (!_visit_expr(arg, depth + 1u)) { return false; }
+                }
+                return true;
+            }
+            case Expression::Tag::CAST:
+                return _visit_expr(
+                    static_cast<const CastExpr *>(expr)->expression(), depth + 1u);
+            case Expression::Tag::TYPE_ID:
+                return _visit_type(
+                    static_cast<const TypeIDExpr *>(expr)->data_type(), depth + 1u);
+            case Expression::Tag::STRING_ID:
+                return _check_string(
+                    static_cast<const StringIDExpr *>(expr)->data());
+            case Expression::Tag::FUNC_REF:
+                return _visit_function(
+                    Function{static_cast<const FuncRefExpr *>(expr)->func()},
+                    depth + 1u, false);
+            case Expression::Tag::CPUCUSTOM:
+                _fail("CPU custom AST operations cannot cross a process boundary.");
+                return false;
+            case Expression::Tag::GPUCUSTOM:
+                _fail("GPU custom AST source cannot cross a remote-safe AST boundary.");
+                return false;
+        }
+        _fail("Unknown AST expression tag.");
+        return false;
+    }
+
+    [[nodiscard]] bool _visit_stmt(const Statement *stmt,
+                                   size_t depth) noexcept {
+        if (stmt == nullptr) {
+            _fail("AST contains a null statement.");
+            return false;
+        }
+        if (!_check_depth(depth) || !_count_node()) { return false; }
+        switch (stmt->tag()) {
+            case Statement::Tag::BREAK:
+            case Statement::Tag::CONTINUE: return true;
+            case Statement::Tag::RETURN:
+                return _visit_expr(
+                    static_cast<const ReturnStmt *>(stmt)->expression(), depth + 1u);
+            case Statement::Tag::SCOPE:
+                for (auto child : static_cast<const ScopeStmt *>(stmt)->statements()) {
+                    if (!_visit_stmt(child, depth + 1u)) { return false; }
+                }
+                return true;
+            case Statement::Tag::IF: {
+                auto s = static_cast<const IfStmt *>(stmt);
+                return _visit_expr(s->condition(), depth + 1u) &&
+                       _visit_stmt(s->true_branch(), depth + 1u) &&
+                       _visit_stmt(s->false_branch(), depth + 1u);
+            }
+            case Statement::Tag::LOOP:
+                return _visit_stmt(
+                    static_cast<const LoopStmt *>(stmt)->body(), depth + 1u);
+            case Statement::Tag::EXPR:
+                return _visit_expr(
+                    static_cast<const ExprStmt *>(stmt)->expression(), depth + 1u);
+            case Statement::Tag::SWITCH: {
+                auto s = static_cast<const SwitchStmt *>(stmt);
+                return _visit_expr(s->expression(), depth + 1u) &&
+                       _visit_stmt(s->body(), depth + 1u);
+            }
+            case Statement::Tag::SWITCH_CASE: {
+                auto s = static_cast<const SwitchCaseStmt *>(stmt);
+                return _visit_expr(s->expression(), depth + 1u) &&
+                       _visit_stmt(s->body(), depth + 1u);
+            }
+            case Statement::Tag::SWITCH_DEFAULT:
+                return _visit_stmt(
+                    static_cast<const SwitchDefaultStmt *>(stmt)->body(), depth + 1u);
+            case Statement::Tag::ASSIGN: {
+                auto s = static_cast<const AssignStmt *>(stmt);
+                if (!is_assignable_expression(s->lhs())) {
+                    _fail("AST assignment left-hand side is not assignable.");
+                    return false;
+                }
+                if (!assignment_types_compatible(
+                        s->lhs()->type(), s->rhs()->type())) {
+                    _fail("AST assignment operand types are incompatible.");
+                    return false;
+                }
+                return _visit_expr(s->lhs(), depth + 1u) &&
+                       _visit_expr(s->rhs(), depth + 1u);
+            }
+            case Statement::Tag::FOR: {
+                auto s = static_cast<const ForStmt *>(stmt);
+                if (!is_assignable_expression(s->variable()) ||
+                    !assignment_types_compatible(
+                        s->variable()->type(), s->step()->type()) ||
+                    s->condition()->type() == nullptr ||
+                    !s->condition()->type()->is_bool()) {
+                    _fail("AST for-loop operands are invalid.");
+                    return false;
+                }
+                return _visit_expr(s->variable(), depth + 1u) &&
+                       _visit_expr(s->condition(), depth + 1u) &&
+                       _visit_expr(s->step(), depth + 1u) &&
+                       _visit_stmt(s->body(), depth + 1u);
+            }
+            case Statement::Tag::COMMENT:
+                return _check_string(
+                    static_cast<const CommentStmt *>(stmt)->comment());
+            case Statement::Tag::RAY_QUERY: {
+                auto s = static_cast<const RayQueryStmt *>(stmt);
+                if (!is_ray_query_type(s->query()->type())) {
+                    _fail("AST ray-query statement has a non-ray-query value.");
+                    return false;
+                }
+                return _visit_expr(s->query(), depth + 1u) &&
+                       _visit_stmt(s->on_triangle_candidate(), depth + 1u) &&
+                       _visit_stmt(s->on_procedural_candidate(), depth + 1u);
+            }
+            case Statement::Tag::AUTO_DIFF:
+                return _visit_stmt(
+                    static_cast<const AutoDiffStmt *>(stmt)->body(), depth + 1u);
+            case Statement::Tag::PRINT: {
+                auto s = static_cast<const PrintStmt *>(stmt);
+                if (!_check_string(s->format())) { return false; }
+                for (auto arg : s->arguments()) {
+                    if (!_visit_expr(arg, depth + 1u)) { return false; }
+                }
+                return true;
+            }
+            case Statement::Tag::SUSPEND:
+                _fail("Coroutine suspend statements are not supported by remote-safe AST JSON.");
+                return false;
+            case Statement::Tag::DEBUG_BREAK:
+                _fail("Debug-break callbacks cannot cross a process boundary.");
+                return false;
+        }
+        _fail("Unknown AST statement tag.");
+        return false;
+    }
+
+    [[nodiscard]] bool _visit_function(Function function, size_t depth,
+                                       bool entry) noexcept {
+        if (!function) {
+            _fail("Cannot serialize an empty AST function.");
+            return false;
+        }
+        auto builder = function.builder();
+        if (_active_functions.contains(builder)) {
+            _fail("Recursive AST callable graphs are not supported by schema v1.");
+            return false;
+        }
+        if (!_visited_functions.emplace(builder).second) { return true; }
+        if (_visited_functions.size() > _limits.max_functions) {
+            _fail("AST JSON function count exceeds the configured limit.");
+            return false;
+        }
+        if (!_check_depth(depth)) { return false; }
+        if ((entry && function.tag() != Function::Tag::KERNEL) ||
+            (!entry && function.tag() != Function::Tag::CALLABLE)) {
+            _fail(entry ?
+                      "Remote-safe AST JSON entry must be a compute kernel." :
+                      "Remote-safe AST JSON dependencies must be callables.");
+            return false;
+        }
+        if (!function.external_callables().empty()) {
+            _fail("External AST functions are not supported by remote-safe AST JSON.");
+            return false;
+        }
+        if (!_check_string(function.name())) { return false; }
+        _active_functions.emplace(builder);
+        for (auto variable : function.arguments()) {
+            if (!_visit_type(variable.type(), depth + 1u) ||
+                !_check_string(function.get_variable_name(variable.uid()))) {
+                _active_functions.erase(builder);
+                return false;
+            }
+        }
+        for (auto variable : function.local_variables()) {
+            if (!_visit_type(variable.type(), depth + 1u) ||
+                !_check_string(function.get_variable_name(variable.uid()))) {
+                _active_functions.erase(builder);
+                return false;
+            }
+        }
+        for (auto variable : function.builtin_variables()) {
+            if (!_visit_type(variable.type(), depth + 1u) ||
+                !_check_string(function.get_variable_name(variable.uid()))) {
+                _active_functions.erase(builder);
+                return false;
+            }
+        }
+        for (auto variable : function.shared_variables()) {
+            if (!_visit_type(variable.type(), depth + 1u) ||
+                !_check_string(function.get_variable_name(variable.uid()))) {
+                _active_functions.erase(builder);
+                return false;
+            }
+        }
+        for (auto constant : function.constants()) {
+            if (!_visit_constant(constant, depth + 1u)) {
+                _active_functions.erase(builder);
+                return false;
+            }
+        }
+        auto ok = _visit_stmt(function.body(), depth + 1u);
+        _active_functions.erase(builder);
+        return ok;
+    }
+
+public:
+    explicit ASTJsonPreflight(const ASTJsonLimits &limits) noexcept
+        : _limits{limits} {}
+
+    [[nodiscard]] bool run(Function function) noexcept {
+        return _visit_function(function, 0u, true);
+    }
+
+    [[nodiscard]] luisa::string take_error() noexcept {
+        return std::move(_error);
+    }
+};
+
+class ASTJsonDecoder {
+
+private:
+    yyjson_val *_root;
+    const ASTJsonLimits &_limits;
+    const ASTJsonBindingResolver &_binding_resolver;
+    luisa::vector<const Type *> _types;
+    luisa::vector<ConstantData> _constants;
+    luisa::vector<luisa::shared_ptr<const detail::FunctionBuilder>> _functions;
+    luisa::string _error;
+    size_t _node_count{};
+    size_t _constant_bytes{};
+
+private:
+    void _fail(luisa::string_view path, luisa::string message) noexcept {
+        if (_error.empty()) {
+            _error = luisa::format("AST JSON error at {}: {}", path, message);
+        }
+    }
+
+    [[nodiscard]] bool _check_keys(
+        yyjson_val *object,
+        std::initializer_list<luisa::string_view> allowed,
+        luisa::string_view path) noexcept {
+        if (!yyjson_is_obj(object)) {
+            _fail(path, "expected an object.");
+            return false;
+        }
+        std::unordered_set<std::string_view> seen;
+        yyjson_obj_iter iter = yyjson_obj_iter_with(object);
+        while (auto key = yyjson_obj_iter_next(&iter)) {
+            auto key_view = std::string_view{
+                yyjson_get_str(key), yyjson_get_len(key)};
+            if (!seen.emplace(key_view).second) {
+                _fail(path, luisa::format("duplicate member '{}'.", key_view));
+                return false;
+            }
+            auto known = std::any_of(
+                allowed.begin(), allowed.end(),
+                [key_view](auto candidate) noexcept {
+                    return candidate == key_view;
+                });
+            if (!known) {
+                _fail(path, luisa::format("unknown member '{}'.", key_view));
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] yyjson_val *_member(
+        yyjson_val *object, const char *key,
+        luisa::string_view path, bool required = true) noexcept {
+        if (!yyjson_is_obj(object)) {
+            _fail(path, "expected an object.");
+            return nullptr;
+        }
+        auto value = yyjson_obj_get(object, key);
+        if (required && value == nullptr) {
+            _fail(path, luisa::format("missing required member '{}'.", key));
+        }
+        return value;
+    }
+
+    [[nodiscard]] bool _string(
+        yyjson_val *value, luisa::string_view &result,
+        luisa::string_view path) noexcept {
+        if (!yyjson_is_str(value)) {
+            _fail(path, "expected a string.");
+            return false;
+        }
+        auto size = yyjson_get_len(value);
+        if (size > _limits.max_string_bytes) {
+            _fail(path, "string exceeds the configured byte limit.");
+            return false;
+        }
+        result = {yyjson_get_str(value), size};
+        return true;
+    }
+
+    [[nodiscard]] bool _uint64(
+        yyjson_val *value, uint64_t &result,
+        luisa::string_view path) noexcept {
+        if (!yyjson_is_uint(value)) {
+            _fail(path, "expected an unsigned integer.");
+            return false;
+        }
+        result = yyjson_get_uint(value);
+        return true;
+    }
+
+    [[nodiscard]] bool _uint32(
+        yyjson_val *value, uint32_t &result,
+        luisa::string_view path) noexcept {
+        uint64_t wide{};
+        if (!_uint64(value, wide, path)) { return false; }
+        if (wide > std::numeric_limits<uint32_t>::max()) {
+            _fail(path, "integer is outside the uint32 range.");
+            return false;
+        }
+        result = static_cast<uint32_t>(wide);
+        return true;
+    }
+
+    [[nodiscard]] bool _size(
+        yyjson_val *value, size_t &result,
+        luisa::string_view path) noexcept {
+        uint64_t wide{};
+        if (!_uint64(value, wide, path)) { return false; }
+        if (wide > std::numeric_limits<size_t>::max()) {
+            _fail(path, "integer is outside the host size range.");
+            return false;
+        }
+        result = static_cast<size_t>(wide);
+        return true;
+    }
+
+    [[nodiscard]] bool _decimal_uint64(
+        yyjson_val *value, uint64_t &result,
+        luisa::string_view path) noexcept {
+        luisa::string_view text;
+        if (!_string(value, text, path)) { return false; }
+        auto parsed = std::from_chars(
+            text.data(), text.data() + text.size(), result);
+        if (parsed.ec != std::errc{} ||
+            parsed.ptr != text.data() + text.size() || text.empty()) {
+            _fail(path, "expected a canonical decimal uint64 string.");
+            return false;
+        }
+        return true;
+    }
+
+    template<typename E>
+    [[nodiscard]] bool _enum(
+        yyjson_val *value, E &result,
+        luisa::string_view path) noexcept {
+        luisa::string_view text;
+        if (!_string(value, text, path)) { return false; }
+        auto parsed = magic_enum::enum_cast<E>(
+            std::string_view{text.data(), text.size()});
+        if (!parsed) {
+            _fail(path, luisa::format("unknown enum value '{}'.", text));
+            return false;
+        }
+        result = *parsed;
+        return true;
+    }
+
+    [[nodiscard]] bool _array(
+        yyjson_val *value, size_t limit,
+        luisa::string_view path) noexcept {
+        if (!yyjson_is_arr(value)) {
+            _fail(path, "expected an array.");
+            return false;
+        }
+        if (yyjson_arr_size(value) > limit) {
+            _fail(path, "array exceeds the configured element limit.");
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _count_node(size_t depth,
+                                   luisa::string_view path) noexcept {
+        if (depth > _limits.max_depth) {
+            _fail(path, "nesting exceeds the configured depth limit.");
+            return false;
+        }
+        if (++_node_count > _limits.max_nodes) {
+            _fail(path, "node count exceeds the configured limit.");
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _type_index(
+        yyjson_val *value, size_t upper_bound,
+        const Type *&type, luisa::string_view path) noexcept {
+        uint64_t index{};
+        if (!_uint64(value, index, path)) { return false; }
+        if (index >= upper_bound || index >= _types.size()) {
+            _fail(path, "type index is out of range or not topologically ordered.");
+            return false;
+        }
+        type = _types[static_cast<size_t>(index)];
+        return true;
+    }
+
+    [[nodiscard]] static const Type *_scalar_type(Type::Tag tag) noexcept {
+        switch (tag) {
+            case Type::Tag::BOOL: return Type::from("bool");
+            case Type::Tag::INT8: return Type::from("byte");
+            case Type::Tag::UINT8: return Type::from("ubyte");
+            case Type::Tag::INT16: return Type::from("short");
+            case Type::Tag::UINT16: return Type::from("ushort");
+            case Type::Tag::INT32: return Type::from("int");
+            case Type::Tag::UINT32: return Type::from("uint");
+            case Type::Tag::INT64: return Type::from("long");
+            case Type::Tag::UINT64: return Type::from("ulong");
+            case Type::Tag::FLOAT16: return Type::from("half");
+            case Type::Tag::FLOAT32: return Type::from("float");
+            case Type::Tag::FLOAT64: return Type::from("double");
+            case Type::Tag::FLOAT8_E4M3: return Type::from("float8e4m3");
+            case Type::Tag::FLOAT8_E5M2: return Type::from("float8e5m2");
+            case Type::Tag::INT4: return Type::from("int4");
+            case Type::Tag::FP4_E2M1: return Type::from("fp4e2m1");
+            default: return nullptr;
+        }
+    }
+
+    [[nodiscard]] bool _decode_types(yyjson_val *array) noexcept {
+        if (!_array(array, _limits.max_types, "$.types")) { return false; }
+        _types.reserve(yyjson_arr_size(array));
+        auto count = yyjson_arr_size(array);
+        for (size_t i = 0u; i < count; i++) {
+            auto item = yyjson_arr_get(array, i);
+            auto path = luisa::format("$.types[{}]", i);
+            if (yyjson_is_null(item)) {
+                _types.emplace_back(nullptr);
+                continue;
+            }
+            if (!yyjson_is_obj(item)) {
+                _fail(path, "expected an object or null.");
+                return false;
+            }
+            Type::Tag tag{};
+            if (!_enum(_member(item, "tag", path), tag,
+                       luisa::format("{}.tag", path))) {
+                return false;
+            }
+            if (auto scalar = _scalar_type(tag)) {
+                if (!_check_keys(item, {"tag"}, path)) { return false; }
+                _types.emplace_back(scalar);
+                continue;
+            }
+            switch (tag) {
+                case Type::Tag::VECTOR:
+                case Type::Tag::MATRIX:
+                case Type::Tag::ARRAY:
+                case Type::Tag::TEXTURE: {
+                    if (!_check_keys(item, {"tag", "element", "dimension"}, path)) {
+                        return false;
+                    }
+                    const Type *element{};
+                    uint32_t dimension{};
+                    if (!_type_index(
+                            _member(item, "element", path), i, element,
+                            luisa::format("{}.element", path)) ||
+                        !_uint32(
+                            _member(item, "dimension", path), dimension,
+                            luisa::format("{}.dimension", path))) {
+                        return false;
+                    }
+                    if (element == nullptr) {
+                        _fail(path, "composite type element must not be null.");
+                        return false;
+                    }
+                    const Type *type{};
+                    if (tag == Type::Tag::VECTOR) {
+                        if (!element->is_scalar() || dimension < 2u || dimension > 4u) {
+                            _fail(path, "invalid vector element or dimension.");
+                            return false;
+                        }
+                        type = Type::vector(element, dimension);
+                    } else if (tag == Type::Tag::MATRIX) {
+                        if (!element->is_float32() || dimension < 2u || dimension > 4u) {
+                            _fail(path, "matrix must be float32 with dimension 2, 3, or 4.");
+                            return false;
+                        }
+                        type = Type::matrix(dimension);
+                    } else if (tag == Type::Tag::ARRAY) {
+                        if (dimension == 0u || element->is_resource() ||
+                            element->is_custom() ||
+                            element->size() > std::numeric_limits<uint32_t>::max() / dimension) {
+                            _fail(path, "invalid or overflowing array type.");
+                            return false;
+                        }
+                        type = Type::array(element, dimension);
+                    } else {
+                        if ((dimension != 2u && dimension != 3u) ||
+                            !(element->is_int32() || element->is_uint32() ||
+                              element->is_float32())) {
+                            _fail(path, "invalid texture element or dimension.");
+                            return false;
+                        }
+                        type = Type::texture(element, dimension);
+                    }
+                    _types.emplace_back(type);
+                    break;
+                }
+                case Type::Tag::STRUCTURE: {
+                    if (!_check_keys(item, {"tag", "alignment", "members"}, path)) {
+                        return false;
+                    }
+                    uint32_t alignment{};
+                    auto members_value = _member(item, "members", path);
+                    if (!_uint32(
+                            _member(item, "alignment", path), alignment,
+                            luisa::format("{}.alignment", path)) ||
+                        !_array(members_value, _limits.max_types,
+                                luisa::format("{}.members", path))) {
+                        return false;
+                    }
+                    if (alignment != 1u && alignment != 4u &&
+                        alignment != 8u && alignment != 16u) {
+                        _fail(path, "structure alignment must be 1, 4, 8, or 16.");
+                        return false;
+                    }
+                    luisa::vector<const Type *> members;
+                    members.reserve(yyjson_arr_size(members_value));
+                    size_t layout_size{};
+                    size_t max_member_alignment{1u};
+                    for (size_t j = 0u; j < yyjson_arr_size(members_value); j++) {
+                        const Type *member{};
+                        if (!_type_index(
+                                yyjson_arr_get(members_value, j), i, member,
+                                luisa::format("{}.members[{}]", path, j))) {
+                            return false;
+                        }
+                        if (member == nullptr || member->is_resource() ||
+                            member->is_custom()) {
+                            _fail(path, "structure members must be portable data types.");
+                            return false;
+                        }
+                        auto member_alignment = member->alignment();
+                        max_member_alignment = std::max(
+                            max_member_alignment, member_alignment);
+                        if (layout_size > std::numeric_limits<uint32_t>::max() -
+                                              (member_alignment - 1u)) {
+                            _fail(path, "structure layout overflows uint32.");
+                            return false;
+                        }
+                        layout_size = (layout_size + member_alignment - 1u) /
+                                      member_alignment * member_alignment;
+                        if (member->size() >
+                            std::numeric_limits<uint32_t>::max() - layout_size) {
+                            _fail(path, "structure layout overflows uint32.");
+                            return false;
+                        }
+                        layout_size += member->size();
+                        members.emplace_back(member);
+                    }
+                    if (alignment < max_member_alignment) {
+                        _fail(path, "structure alignment is smaller than a member alignment.");
+                        return false;
+                    }
+                    if (layout_size > std::numeric_limits<uint32_t>::max() -
+                                          (alignment - 1u)) {
+                        _fail(path, "structure final alignment overflows uint32.");
+                        return false;
+                    }
+                    _types.emplace_back(Type::structure(alignment, members));
+                    break;
+                }
+                case Type::Tag::BUFFER: {
+                    if (!_check_keys(item, {"tag", "element"}, path)) { return false; }
+                    const Type *element{};
+                    if (!_type_index(
+                            _member(item, "element", path), i, element,
+                            luisa::format("{}.element", path))) {
+                        return false;
+                    }
+                    if (element != nullptr &&
+                        (element->is_resource() || element->is_custom())) {
+                        _fail(path, "buffer element must be a portable data type.");
+                        return false;
+                    }
+                    _types.emplace_back(Type::buffer(element));
+                    break;
+                }
+                case Type::Tag::BINDLESS_ARRAY:
+                    if (!_check_keys(item, {"tag"}, path)) { return false; }
+                    _types.emplace_back(Type::from("bindless_array"));
+                    break;
+                case Type::Tag::ACCEL:
+                    if (!_check_keys(item, {"tag"}, path)) { return false; }
+                    _types.emplace_back(Type::from("accel"));
+                    break;
+                case Type::Tag::CUSTOM: {
+                    if (!_check_keys(item, {"tag", "id"}, path)) {
+                        return false;
+                    }
+                    luisa::string_view id;
+                    if (!_string(
+                            _member(item, "id", path), id,
+                            luisa::format("{}.id", path))) {
+                        return false;
+                    }
+                    if (id != ast_json_indirect_dispatch_buffer_type_name &&
+                        id != ast_json_ray_query_all_type_name &&
+                        id != ast_json_ray_query_any_type_name) {
+                        _fail(path, "custom type is not on the remote-safe allowlist.");
+                        return false;
+                    }
+                    _types.emplace_back(Type::custom(id));
+                    break;
+                }
+                case Type::Tag::COOPERATIVE_VECTOR:
+                case Type::Tag::COOPERATIVE_VECTOR_REF:
+                case Type::Tag::COOPERATIVE_MATRIX_REF:
+                    _fail(path, "type is not supported by AST JSON schema v1.");
+                    return false;
+                default:
+                    _fail(path, "unknown or unsupported type tag.");
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] static bool _constant_type_supported(
+        const Type *type) noexcept {
+        if (type == nullptr || type->is_resource() || type->is_custom()) {
+            return false;
+        }
+        switch (type->tag()) {
+            case Type::Tag::BOOL:
+            case Type::Tag::INT8:
+            case Type::Tag::UINT8:
+            case Type::Tag::INT16:
+            case Type::Tag::UINT16:
+            case Type::Tag::INT32:
+            case Type::Tag::UINT32:
+            case Type::Tag::INT64:
+            case Type::Tag::UINT64:
+            case Type::Tag::FLOAT16:
+            case Type::Tag::FLOAT32:
+            case Type::Tag::FLOAT64: return true;
+            case Type::Tag::VECTOR:
+            case Type::Tag::MATRIX:
+            case Type::Tag::ARRAY:
+                return _constant_type_supported(type->element());
+            case Type::Tag::STRUCTURE:
+                return std::all_of(
+                    type->members().begin(), type->members().end(),
+                    [](auto member) noexcept {
+                        return _constant_type_supported(member);
+                    });
+            default: return false;
+        }
+    }
+
+    [[nodiscard]] bool _decode_base64(
+        yyjson_val *value, size_t expected_size,
+        luisa::vector<std::byte> &bytes,
+        luisa::string_view path) noexcept {
+        luisa::string_view text;
+        if (!_string(value, text, path)) { return false; }
+        if (text.size() % 4u != 0u) {
+            _fail(path, "Base64 length must be divisible by four.");
+            return false;
+        }
+        auto padding = size_t{0u};
+        if (!text.empty() && text.back() == '=') { padding++; }
+        if (text.size() > 1u && text[text.size() - 2u] == '=') { padding++; }
+        auto decoded_size = text.size() / 4u * 3u - padding;
+        if (decoded_size != expected_size) {
+            _fail(path, luisa::format(
+                            "decoded byte length {} does not match expected {}.",
+                            decoded_size, expected_size));
+            return false;
+        }
+        auto decode_char = [](char c) noexcept -> int {
+            if (c >= 'A' && c <= 'Z') { return c - 'A'; }
+            if (c >= 'a' && c <= 'z') { return c - 'a' + 26; }
+            if (c >= '0' && c <= '9') { return c - '0' + 52; }
+            if (c == '+') { return 62; }
+            if (c == '/') { return 63; }
+            return -1;
+        };
+        bytes.clear();
+        bytes.reserve(expected_size);
+        for (size_t i = 0u; i < text.size(); i += 4u) {
+            uint32_t packed{};
+            for (size_t j = 0u; j < 4u; j++) {
+                auto c = text[i + j];
+                if (c == '=') {
+                    if (i + 4u != text.size() || j < 2u) {
+                        _fail(path, "invalid Base64 padding.");
+                        return false;
+                    }
+                    packed <<= 6u;
+                } else {
+                    if (padding != 0u && i + j >= text.size() - padding) {
+                        _fail(path, "invalid Base64 padding placement.");
+                        return false;
+                    }
+                    auto digit = decode_char(c);
+                    if (digit < 0) {
+                        _fail(path, "invalid Base64 character.");
+                        return false;
+                    }
+                    packed = packed << 6u | static_cast<uint32_t>(digit);
+                }
+            }
+            for (size_t j = 0u; j < 3u && bytes.size() < expected_size; j++) {
+                bytes.emplace_back(static_cast<std::byte>(
+                    (packed >> (16u - static_cast<uint32_t>(j) * 8u)) & 0xffu));
+            }
+        }
+        return bytes.size() == expected_size;
+    }
+
+    [[nodiscard]] bool _decode_constants(yyjson_val *array) noexcept {
+        if (array == nullptr) { return true; }
+        if (!_array(array, _limits.max_nodes, "$.constants")) { return false; }
+        _constants.reserve(yyjson_arr_size(array));
+        for (size_t i = 0u; i < yyjson_arr_size(array); i++) {
+            auto item = yyjson_arr_get(array, i);
+            auto path = luisa::format("$.constants[{}]", i);
+            if (!_check_keys(item, {"type", "raw"}, path)) { return false; }
+            const Type *type{};
+            if (!_type_index(
+                    _member(item, "type", path), _types.size(), type,
+                    luisa::format("{}.type", path))) {
+                return false;
+            }
+            if (!_constant_type_supported(type)) {
+                _fail(path, "constant uses a type unsupported by schema v1.");
+                return false;
+            }
+            auto size = type->size();
+            if (size > _limits.max_constant_bytes -
+                           std::min(_constant_bytes, _limits.max_constant_bytes)) {
+                _fail(path, "constants exceed the configured byte limit.");
+                return false;
+            }
+            luisa::vector<std::byte> bytes;
+            if (!_decode_base64(
+                    _member(item, "raw", path), size, bytes,
+                    luisa::format("{}.raw", path))) {
+                return false;
+            }
+            _constant_bytes += size;
+            _constants.emplace_back(ConstantData::create(type, bytes.data(), bytes.size()));
+        }
+        return true;
+    }
+
+    struct FunctionContext {
+        detail::FunctionBuilder *builder{};
+        luisa::vector<const RefExpr *> variables;
+        const Type *declared_return_type{};
+        size_t function_index{};
+        Function::Tag tag{};
+    };
+
+    [[nodiscard]] bool _curve_bases(
+        yyjson_val *value, CurveBasisSet &set,
+        luisa::string_view path) noexcept {
+        if (value == nullptr) { return true; }
+        if (!_array(value, curve_basis_count, path)) { return false; }
+        for (size_t i = 0u; i < yyjson_arr_size(value); i++) {
+            CurveBasis basis{};
+            if (!_enum(yyjson_arr_get(value, i), basis,
+                       luisa::format("{}[{}]", path, i))) {
+                return false;
+            }
+            if (set.test(basis)) {
+                _fail(path, "duplicate curve basis.");
+                return false;
+            }
+            set.mark(basis);
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _usage(
+        yyjson_val *value, Usage &usage,
+        luisa::string_view path) noexcept {
+        if (!_enum(value, usage, path)) { return false; }
+        switch (usage) {
+            case Usage::NONE:
+            case Usage::READ:
+            case Usage::WRITE:
+            case Usage::READ_WRITE: return true;
+        }
+        _fail(path, "invalid variable usage mask.");
+        return false;
+    }
+
+    [[nodiscard]] bool _int32(
+        yyjson_val *value, int32_t &result,
+        luisa::string_view path) noexcept {
+        if (yyjson_is_sint(value)) {
+            auto v = yyjson_get_sint(value);
+            if (v < std::numeric_limits<int32_t>::min() ||
+                v > std::numeric_limits<int32_t>::max()) {
+                _fail(path, "integer is outside the int32 range.");
+                return false;
+            }
+            result = static_cast<int32_t>(v);
+            return true;
+        }
+        if (yyjson_is_uint(value)) {
+            auto v = yyjson_get_uint(value);
+            if (v > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+                _fail(path, "integer is outside the int32 range.");
+                return false;
+            }
+            result = static_cast<int32_t>(v);
+            return true;
+        }
+        _fail(path, "expected an int32 integer.");
+        return false;
+    }
+
+    [[nodiscard]] bool _constant_index(
+        yyjson_val *value, ConstantData &constant,
+        luisa::string_view path) noexcept {
+        uint64_t index{};
+        if (!_uint64(value, index, path)) { return false; }
+        if (index >= _constants.size()) {
+            _fail(path, "constant index is out of range.");
+            return false;
+        }
+        constant = _constants[static_cast<size_t>(index)];
+        return true;
+    }
+
+    template<size_t index = 0u>
+    [[nodiscard]] const LiteralExpr *_make_literal(
+        FunctionContext &context, const Type *type,
+        luisa::span<const std::byte> bytes,
+        luisa::string_view path) noexcept {
+        using Variant = LiteralExpr::Value::variant_type;
+        if constexpr (index < luisa::variant_size_v<Variant>) {
+            using T = luisa::variant_alternative_t<index, Variant>;
+            if (Type::of<T>() == type) {
+                if (bytes.size() != sizeof(T)) {
+                    _fail(path, "literal byte size does not match its C++ value type.");
+                    return nullptr;
+                }
+                T value{};
+                std::memcpy(&value, bytes.data(), sizeof(T));
+                if constexpr (std::is_same_v<T, bool>) {
+                    auto raw = std::to_integer<uint8_t>(bytes.front());
+                    if (raw > 1u) {
+                        _fail(path, "boolean literal must have value zero or one.");
+                        return nullptr;
+                    }
+                }
+                return context.builder->literal(
+                    type, LiteralExpr::Value{value});
+            }
+            return _make_literal<index + 1u>(context, type, bytes, path);
+        } else {
+            _fail(path, luisa::format(
+                            "type '{}' is not a supported literal type.",
+                            type == nullptr ? "void" : type->description()));
+            return nullptr;
+        }
+    }
+
+    [[nodiscard]] bool _builtin_call_arity(
+        CallOp op, luisa::span<const Expression *const> arguments,
+        luisa::string_view path) noexcept {
+        auto require = [&](size_t count, bool exact = false) noexcept {
+            if ((exact && arguments.size() != count) ||
+                (!exact && arguments.size() < count)) {
+                _fail(path, luisa::format(
+                                "operation {} requires {}{} argument(s), got {}.",
+                                luisa::to_string(op), exact ? "exactly " : "at least ",
+                                count, arguments.size()));
+                return false;
+            }
+            return true;
+        };
+        if (op == CallOp::PACK) { return require(3u, true); }
+        if (op == CallOp::CLUSTER_LAUNCH_CONTROL_TRY_CANCEL ||
+            op == CallOp::CLUSTER_LAUNCH_CONTROL_TRY_CANCEL_MULTICAST) {
+            return require(2u, true);
+        }
+        if (op == CallOp::ASYNC_COPY) { return require(7u, true); }
+        if (op == CallOp::INDIRECT_SET_DISPATCH_COUNT) {
+            return require(2u, true);
+        }
+        if (op == CallOp::INDIRECT_SET_DISPATCH_KERNEL) {
+            return require(5u, true);
+        }
+        if (op == CallOp::MBARRIER_INIT ||
+            op == CallOp::MBARRIER_ARRIVE_EXPECT_TX ||
+            op == CallOp::MBARRIER_TRY_WAIT_PARITY) {
+            return require(2u, true);
+        }
+        switch (op) {
+            case CallOp::BUFFER_VOLATILE_WRITE:
+            case CallOp::BUFFER_WRITE:
+            case CallOp::BINDLESS_BUFFER_WRITE:
+            case CallOp::UNIFORM_BINDLESS_BUFFER_WRITE:
+            case CallOp::TYPED_UNIFORM_BINDLESS_BUFFER_WRITE:
+            case CallOp::TYPED_BINDLESS_BUFFER_WRITE:
+            case CallOp::BYTE_BUFFER_VOLATILE_WRITE:
+            case CallOp::BYTE_BUFFER_WRITE:
+            case CallOp::TEXTURE_WRITE:
+            case CallOp::RAY_TRACING_SET_INSTANCE_TRANSFORM:
+            case CallOp::RAY_TRACING_SET_INSTANCE_VISIBILITY:
+            case CallOp::RAY_TRACING_SET_INSTANCE_OPACITY:
+            case CallOp::RAY_TRACING_SET_INSTANCE_USER_ID:
+            case CallOp::RAY_TRACING_SET_INSTANCE_MOTION_MATRIX:
+            case CallOp::RAY_TRACING_SET_INSTANCE_MOTION_SRT:
+            case CallOp::RAY_QUERY_COMMIT_TRIANGLE:
+            case CallOp::RAY_QUERY_COMMIT_PROCEDURAL:
+            case CallOp::RAY_QUERY_TERMINATE:
+            case CallOp::RAY_QUERY_PROCEED:
+            case CallOp::GRADIENT_MARKER:
+            case CallOp::ACCUMULATE_GRADIENT:
+            case CallOp::COOPERATIVE_OUTER_PRODUCT_ACCUMULATE:
+            case CallOp::COOPERATIVE_VECTOR_ACCUMULATE:
+            case CallOp::COOPERATIVE_VECTOR_STORE:
+            case CallOp::BINDLESS_COOPERATIVE_VECTOR_STORE:
+            case CallOp::TYPED_BINDLESS_COOPERATIVE_VECTOR_STORE:
+            case CallOp::COOPERATIVE_VECTOR_WORKGROUP_STORE:
+                return require(1u);
+            default: break;
+        }
+        if (is_atomic_operation(op)) {
+            if (!require(op == CallOp::ATOMIC_COMPARE_EXCHANGE ? 3u : 2u)) {
+                return false;
+            }
+            auto type = arguments.front()->type();
+            if (type == nullptr || (!type->is_buffer() && !type->is_array()) ||
+                type->element() == nullptr) {
+                _fail(path, "atomic access chain must begin with a typed buffer or array.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] const Expression *_decode_expr(
+        yyjson_val *object, FunctionContext &context,
+        size_t depth, luisa::string_view path,
+        bool allow_null = false, bool allow_void_call = false) noexcept {
+        if (yyjson_is_null(object)) {
+            if (allow_null) { return nullptr; }
+            _fail(path, "null expression is not allowed here.");
+            return nullptr;
+        }
+        if (!_count_node(depth, path) || !yyjson_is_obj(object)) {
+            if (_error.empty()) { _fail(path, "expected an expression object."); }
+            return nullptr;
+        }
+        Expression::Tag tag{};
+        const Type *type{};
+        if (!_enum(_member(object, "tag", path), tag,
+                   luisa::format("{}.tag", path)) ||
+            !_type_index(
+                _member(object, "type", path), _types.size(), type,
+                luisa::format("{}.type", path))) {
+            return nullptr;
+        }
+        if (type == nullptr && !(tag == Expression::Tag::CALL && allow_void_call)) {
+            _fail(path, "only a top-level call expression may have void type.");
+            return nullptr;
+        }
+        switch (tag) {
+            case Expression::Tag::UNARY: {
+                if (!_check_keys(object, {"tag", "type", "op", "operand"}, path)) {
+                    return nullptr;
+                }
+                UnaryOp op{};
+                auto operand = _decode_expr(
+                    _member(object, "operand", path), context, depth + 1u,
+                    luisa::format("{}.operand", path));
+                if (!_error.empty() ||
+                    !_enum(_member(object, "op", path), op,
+                           luisa::format("{}.op", path))) {
+                    return nullptr;
+                }
+                return context.builder->unary(type, op, operand);
+            }
+            case Expression::Tag::BINARY: {
+                if (!_check_keys(object, {"tag", "type", "op", "lhs", "rhs"}, path)) {
+                    return nullptr;
+                }
+                BinaryOp op{};
+                auto lhs = _decode_expr(
+                    _member(object, "lhs", path), context, depth + 1u,
+                    luisa::format("{}.lhs", path));
+                auto rhs = _decode_expr(
+                    _member(object, "rhs", path), context, depth + 1u,
+                    luisa::format("{}.rhs", path));
+                if (!_error.empty() ||
+                    !_enum(_member(object, "op", path), op,
+                           luisa::format("{}.op", path))) {
+                    return nullptr;
+                }
+                return context.builder->binary(type, op, lhs, rhs);
+            }
+            case Expression::Tag::MEMBER: {
+                auto swizzle = _member(object, "swizzle", path, false);
+                auto member = _member(object, "member", path, false);
+                if ((swizzle == nullptr) == (member == nullptr)) {
+                    _fail(path, "member expression requires exactly one of member or swizzle.");
+                    return nullptr;
+                }
+                if (!_check_keys(
+                        object,
+                        swizzle == nullptr ?
+                            std::initializer_list<luisa::string_view>{"tag", "type", "self", "member"} :
+                            std::initializer_list<luisa::string_view>{"tag", "type", "self", "swizzle"},
+                        path)) {
+                    return nullptr;
+                }
+                auto self = _decode_expr(
+                    _member(object, "self", path), context, depth + 1u,
+                    luisa::format("{}.self", path));
+                if (!_error.empty()) { return nullptr; }
+                if (member != nullptr) {
+                    uint32_t index{};
+                    if (!_uint32(member, index, luisa::format("{}.member", path))) {
+                        return nullptr;
+                    }
+                    if (self->type() == nullptr || !self->type()->is_structure() ||
+                        index >= self->type()->members().size() ||
+                        self->type()->members()[index] != type) {
+                        _fail(path, "invalid structure member access.");
+                        return nullptr;
+                    }
+                    return context.builder->member(type, self, index);
+                }
+                luisa::string_view text;
+                if (!_string(swizzle, text, luisa::format("{}.swizzle", path)) ||
+                    text.empty() || text.size() > 4u ||
+                    self->type() == nullptr || !self->type()->is_vector()) {
+                    if (_error.empty()) { _fail(path, "invalid vector swizzle."); }
+                    return nullptr;
+                }
+                uint64_t code{};
+                for (size_t i = 0u; i < text.size(); i++) {
+                    auto component = std::string_view{"xyzw"}.find(text[i]);
+                    if (component == std::string_view::npos ||
+                        component >= self->type()->dimension()) {
+                        _fail(path, "swizzle component is outside the source vector.");
+                        return nullptr;
+                    }
+                    code |= static_cast<uint64_t>(component) << (i * 4u);
+                }
+                return context.builder->swizzle(type, self, text.size(), code);
+            }
+            case Expression::Tag::ACCESS: {
+                if (!_check_keys(object, {"tag", "type", "range", "index"}, path)) {
+                    return nullptr;
+                }
+                auto range = _decode_expr(
+                    _member(object, "range", path), context, depth + 1u,
+                    luisa::format("{}.range", path));
+                auto index = _decode_expr(
+                    _member(object, "index", path), context, depth + 1u,
+                    luisa::format("{}.index", path));
+                if (!_error.empty()) { return nullptr; }
+                return context.builder->access(type, range, index);
+            }
+            case Expression::Tag::LITERAL: {
+                if (!_check_keys(object, {"tag", "type", "value"}, path)) {
+                    return nullptr;
+                }
+                luisa::vector<std::byte> bytes;
+                if (!_decode_base64(
+                        _member(object, "value", path), type->size(), bytes,
+                        luisa::format("{}.value", path))) {
+                    return nullptr;
+                }
+                return _make_literal(context, type, bytes,
+                                     luisa::format("{}.value", path));
+            }
+            case Expression::Tag::REF: {
+                if (!_check_keys(object, {"tag", "type", "variable"}, path)) {
+                    return nullptr;
+                }
+                uint64_t index{};
+                if (!_uint64(
+                        _member(object, "variable", path), index,
+                        luisa::format("{}.variable", path))) {
+                    return nullptr;
+                }
+                if (index >= context.variables.size()) {
+                    _fail(path, "variable index is out of range.");
+                    return nullptr;
+                }
+                auto ref = context.variables[static_cast<size_t>(index)];
+                if (ref->type() != type) {
+                    _fail(path, "reference type does not match its variable.");
+                    return nullptr;
+                }
+                return ref;
+            }
+            case Expression::Tag::CONSTANT: {
+                if (!_check_keys(object, {"tag", "type", "data"}, path)) {
+                    return nullptr;
+                }
+                ConstantData data;
+                if (!_constant_index(
+                        _member(object, "data", path), data,
+                        luisa::format("{}.data", path))) {
+                    return nullptr;
+                }
+                if (data.type() != type) {
+                    _fail(path, "constant type does not match its table entry.");
+                    return nullptr;
+                }
+                return context.builder->constant(data);
+            }
+            case Expression::Tag::CALL: {
+                auto args_value = _member(object, "arguments", path);
+                if (!_array(args_value, _limits.max_nodes,
+                            luisa::format("{}.arguments", path))) {
+                    return nullptr;
+                }
+                CallOp op{};
+                if (!_enum(_member(object, "op", path), op,
+                           luisa::format("{}.op", path))) {
+                    return nullptr;
+                }
+                luisa::vector<const Expression *> arguments;
+                arguments.reserve(yyjson_arr_size(args_value));
+                for (size_t i = 0u; i < yyjson_arr_size(args_value); i++) {
+                    auto argument = _decode_expr(
+                        yyjson_arr_get(args_value, i), context, depth + 1u,
+                        luisa::format("{}.arguments[{}]", path, i));
+                    if (!_error.empty() || argument == nullptr) { return nullptr; }
+                    arguments.emplace_back(argument);
+                }
+                if (op == CallOp::EXTERNAL ||
+                    _member(object, "external", path, false) != nullptr) {
+                    _fail(path, "external calls are not supported by schema v1.");
+                    return nullptr;
+                }
+                if (op == CallOp::CUSTOM) {
+                    if (!_check_keys(
+                            object, {"tag", "type", "op", "custom", "arguments"}, path)) {
+                        return nullptr;
+                    }
+                    uint64_t index{};
+                    if (!_uint64(
+                            _member(object, "custom", path), index,
+                            luisa::format("{}.custom", path))) {
+                        return nullptr;
+                    }
+                    if (index >= context.function_index || index >= _functions.size()) {
+                        _fail(path, "custom callable index is not topologically ordered.");
+                        return nullptr;
+                    }
+                    Function callable{_functions[static_cast<size_t>(index)].get()};
+                    if (callable.return_type() != type ||
+                        callable.arguments().size() != arguments.size()) {
+                        _fail(path, "custom callable signature does not match the call.");
+                        return nullptr;
+                    }
+                    for (size_t i = 0u; i < arguments.size(); i++) {
+                        if (callable.arguments()[i].type() != arguments[i]->type()) {
+                            _fail(path, "custom callable argument type mismatch.");
+                            return nullptr;
+                        }
+                    }
+                    return context.builder->call(type, callable, arguments);
+                }
+                if (!_check_keys(
+                        object,
+                        _member(object, "curve_bases", path, false) == nullptr ?
+                            std::initializer_list<luisa::string_view>{"tag", "type", "op", "arguments"} :
+                            std::initializer_list<luisa::string_view>{"tag", "type", "op", "arguments", "curve_bases"},
+                        path)) {
+                    return nullptr;
+                }
+                if (!is_builtin_operation(op)) {
+                    _fail(path, "call operation is neither builtin nor custom.");
+                    return nullptr;
+                }
+                CurveBasisSet curve_bases;
+                if (!_curve_bases(
+                        _member(object, "curve_bases", path, false), curve_bases,
+                        luisa::format("{}.curve_bases", path)) ||
+                    !_builtin_call_arity(op, arguments, path)) {
+                    return nullptr;
+                }
+                return context.builder->call(type, op, arguments, curve_bases);
+            }
+            case Expression::Tag::CAST: {
+                if (!_check_keys(object, {"tag", "type", "op", "expression"}, path)) {
+                    return nullptr;
+                }
+                CastOp op{};
+                auto expression = _decode_expr(
+                    _member(object, "expression", path), context, depth + 1u,
+                    luisa::format("{}.expression", path));
+                if (!_error.empty() ||
+                    !_enum(_member(object, "op", path), op,
+                           luisa::format("{}.op", path))) {
+                    return nullptr;
+                }
+                return context.builder->cast(type, op, expression);
+            }
+            case Expression::Tag::TYPE_ID: {
+                if (!_check_keys(object, {"tag", "type", "data_type"}, path)) {
+                    return nullptr;
+                }
+                const Type *data_type{};
+                if (!_type_index(
+                        _member(object, "data_type", path), _types.size(), data_type,
+                        luisa::format("{}.data_type", path)) ||
+                    type != Type::of<ulong>()) {
+                    if (_error.empty()) { _fail(path, "invalid type-id result type."); }
+                    return nullptr;
+                }
+                return context.builder->type_id(data_type);
+            }
+            case Expression::Tag::STRING_ID: {
+                if (!_check_keys(object, {"tag", "type", "data"}, path)) {
+                    return nullptr;
+                }
+                luisa::string_view text;
+                if (!_string(
+                        _member(object, "data", path), text,
+                        luisa::format("{}.data", path)) ||
+                    type != Type::of<ulong>()) {
+                    if (_error.empty()) { _fail(path, "invalid string-id result type."); }
+                    return nullptr;
+                }
+                return context.builder->string_id(luisa::string{text});
+            }
+            case Expression::Tag::FUNC_REF: {
+                if (!_check_keys(object, {"tag", "type", "func"}, path)) {
+                    return nullptr;
+                }
+                uint64_t index{};
+                if (!_uint64(
+                        _member(object, "func", path), index,
+                        luisa::format("{}.func", path))) {
+                    return nullptr;
+                }
+                if (index >= context.function_index || index >= _functions.size() ||
+                    type != Type::of<uint64_t>()) {
+                    _fail(path, "invalid function-reference target or result type.");
+                    return nullptr;
+                }
+                return context.builder->func_ref(
+                    Function{_functions[static_cast<size_t>(index)].get()});
+            }
+            case Expression::Tag::CPUCUSTOM:
+            case Expression::Tag::GPUCUSTOM:
+                _fail(path, "custom operation is not supported by remote-safe AST JSON.");
+                return nullptr;
+        }
+        _fail(path, "unknown expression tag.");
+        return nullptr;
+    }
+
+    [[nodiscard]] bool _decode_scope(
+        yyjson_val *object, FunctionContext &context,
+        ScopeStmt *scope, size_t depth,
+        luisa::string_view path) noexcept {
+        if (!_count_node(depth, path) ||
+            !_check_keys(object, {"tag", "statements"}, path)) {
+            return false;
+        }
+        Statement::Tag tag{};
+        if (!_enum(_member(object, "tag", path), tag,
+                   luisa::format("{}.tag", path)) ||
+            tag != Statement::Tag::SCOPE) {
+            if (_error.empty()) { _fail(path, "expected a scope statement."); }
+            return false;
+        }
+        auto statements = _member(object, "statements", path);
+        if (!_array(statements, _limits.max_nodes,
+                    luisa::format("{}.statements", path))) {
+            return false;
+        }
+        auto decode_children = [&] {
+            for (size_t i = 0u; i < yyjson_arr_size(statements); i++) {
+                if (!_decode_statement(
+                        yyjson_arr_get(statements, i), context, depth + 1u,
+                        luisa::format("{}.statements[{}]", path, i))) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        return context.builder->with(scope, decode_children);
+    }
+
+    [[nodiscard]] bool _decode_statement(
+        yyjson_val *object, FunctionContext &context,
+        size_t depth, luisa::string_view path) noexcept {
+        if (!_count_node(depth, path) || !yyjson_is_obj(object)) {
+            if (_error.empty()) { _fail(path, "expected a statement object."); }
+            return false;
+        }
+        Statement::Tag tag{};
+        if (!_enum(_member(object, "tag", path), tag,
+                   luisa::format("{}.tag", path))) {
+            return false;
+        }
+        switch (tag) {
+            case Statement::Tag::BREAK:
+                if (!_check_keys(object, {"tag"}, path)) { return false; }
+                context.builder->break_();
+                return true;
+            case Statement::Tag::CONTINUE:
+                if (!_check_keys(object, {"tag"}, path)) { return false; }
+                context.builder->continue_();
+                return true;
+            case Statement::Tag::RETURN: {
+                if (!_check_keys(object, {"tag", "expression"}, path)) { return false; }
+                auto expression_value = _member(object, "expression", path);
+                auto expression = _decode_expr(
+                    expression_value, context, depth + 1u,
+                    luisa::format("{}.expression", path), true);
+                if (!_error.empty()) { return false; }
+                if (context.tag == Function::Tag::KERNEL && expression != nullptr) {
+                    _fail(path, "compute kernels cannot return a value.");
+                    return false;
+                }
+                if (context.tag == Function::Tag::CALLABLE &&
+                    ((expression == nullptr) != (context.declared_return_type == nullptr) ||
+                     (expression != nullptr &&
+                      expression->type() != context.declared_return_type))) {
+                    _fail(path, "return expression does not match the declared return type.");
+                    return false;
+                }
+                context.builder->return_(expression);
+                return true;
+            }
+            case Statement::Tag::SCOPE:
+                _fail(path, "standalone nested scopes are not supported by schema v1.");
+                return false;
+            case Statement::Tag::IF: {
+                if (!_check_keys(object, {"tag", "condition", "true_branch", "false_branch"}, path)) {
+                    return false;
+                }
+                auto condition = _decode_expr(
+                    _member(object, "condition", path), context, depth + 1u,
+                    luisa::format("{}.condition", path));
+                if (_error.empty() &&
+                    (condition->type() == nullptr || !condition->type()->is_bool())) {
+                    _fail(path, "if condition must be boolean.");
+                }
+                if (!_error.empty()) { return false; }
+                auto statement = context.builder->if_(condition);
+                return _decode_scope(
+                           _member(object, "true_branch", path), context,
+                           statement->true_branch(), depth + 1u,
+                           luisa::format("{}.true_branch", path)) &&
+                       _decode_scope(
+                           _member(object, "false_branch", path), context,
+                           statement->false_branch(), depth + 1u,
+                           luisa::format("{}.false_branch", path));
+            }
+            case Statement::Tag::LOOP: {
+                if (!_check_keys(object, {"tag", "body"}, path)) { return false; }
+                auto statement = context.builder->loop_();
+                return _decode_scope(
+                    _member(object, "body", path), context,
+                    statement->body(), depth + 1u,
+                    luisa::format("{}.body", path));
+            }
+            case Statement::Tag::EXPR: {
+                if (!_check_keys(object, {"tag", "expression"}, path)) { return false; }
+                auto expression = _decode_expr(
+                    _member(object, "expression", path), context, depth + 1u,
+                    luisa::format("{}.expression", path), false, true);
+                if (!_error.empty()) { return false; }
+                if (expression != nullptr) {
+                    context.builder->expression_statement(expression);
+                }
+                return true;
+            }
+            case Statement::Tag::SWITCH: {
+                if (!_check_keys(object, {"tag", "expression", "body"}, path)) {
+                    return false;
+                }
+                auto expression = _decode_expr(
+                    _member(object, "expression", path), context, depth + 1u,
+                    luisa::format("{}.expression", path));
+                if (_error.empty() &&
+                    !(expression->type()->is_int32() || expression->type()->is_uint32())) {
+                    _fail(path, "switch expression must be int32 or uint32.");
+                }
+                if (!_error.empty()) { return false; }
+                auto statement = context.builder->switch_(expression);
+                return _decode_scope(
+                    _member(object, "body", path), context,
+                    statement->body(), depth + 1u,
+                    luisa::format("{}.body", path));
+            }
+            case Statement::Tag::SWITCH_CASE: {
+                if (!_check_keys(object, {"tag", "value", "body"}, path)) { return false; }
+                int32_t value{};
+                if (!_int32(
+                        _member(object, "value", path), value,
+                        luisa::format("{}.value", path))) {
+                    return false;
+                }
+                auto literal = context.builder->literal(Type::of<int>(), value);
+                auto statement = context.builder->case_(literal);
+                return _decode_scope(
+                    _member(object, "body", path), context,
+                    statement->body(), depth + 1u,
+                    luisa::format("{}.body", path));
+            }
+            case Statement::Tag::SWITCH_DEFAULT: {
+                if (!_check_keys(object, {"tag", "body"}, path)) { return false; }
+                auto statement = context.builder->default_();
+                return _decode_scope(
+                    _member(object, "body", path), context,
+                    statement->body(), depth + 1u,
+                    luisa::format("{}.body", path));
+            }
+            case Statement::Tag::ASSIGN: {
+                if (!_check_keys(object, {"tag", "lhs", "rhs"}, path)) { return false; }
+                auto lhs = _decode_expr(
+                    _member(object, "lhs", path), context, depth + 1u,
+                    luisa::format("{}.lhs", path));
+                auto rhs = _decode_expr(
+                    _member(object, "rhs", path), context, depth + 1u,
+                    luisa::format("{}.rhs", path));
+                if (_error.empty() && !is_assignable_expression(lhs)) {
+                    _fail(path, "assignment left-hand side is not assignable.");
+                }
+                if (_error.empty() &&
+                    !assignment_types_compatible(
+                        lhs->type(), rhs->type())) {
+                    _fail(path, luisa::format(
+                                    "assignment operand types do not match ('{}' vs '{}').",
+                                    lhs->type()->description(),
+                                    rhs->type()->description()));
+                }
+                if (!_error.empty()) { return false; }
+                context.builder->assign(lhs, rhs);
+                return true;
+            }
+            case Statement::Tag::FOR: {
+                if (!_check_keys(object, {"tag", "variable", "condition", "step", "body"}, path)) {
+                    return false;
+                }
+                auto variable = _decode_expr(
+                    _member(object, "variable", path), context, depth + 1u,
+                    luisa::format("{}.variable", path));
+                auto condition = _decode_expr(
+                    _member(object, "condition", path), context, depth + 1u,
+                    luisa::format("{}.condition", path));
+                auto step = _decode_expr(
+                    _member(object, "step", path), context, depth + 1u,
+                    luisa::format("{}.step", path));
+                if (_error.empty() &&
+                    (!is_assignable_expression(variable) ||
+                     !assignment_types_compatible(
+                         variable->type(), step->type()) ||
+                     !condition->type()->is_bool())) {
+                    _fail(path, "for-loop operands are invalid.");
+                }
+                if (!_error.empty()) { return false; }
+                auto statement = context.builder->for_(variable, condition, step);
+                return _decode_scope(
+                    _member(object, "body", path), context,
+                    statement->body(), depth + 1u,
+                    luisa::format("{}.body", path));
+            }
+            case Statement::Tag::COMMENT: {
+                if (!_check_keys(object, {"tag", "comment"}, path)) { return false; }
+                luisa::string_view comment;
+                if (!_string(
+                        _member(object, "comment", path), comment,
+                        luisa::format("{}.comment", path))) {
+                    return false;
+                }
+                context.builder->comment_(luisa::string{comment});
+                return true;
+            }
+            case Statement::Tag::RAY_QUERY: {
+                if (!_check_keys(
+                        object, {"tag", "query", "on_triangle_candidate", "on_procedural_candidate"}, path)) {
+                    return false;
+                }
+                auto query = _decode_expr(
+                    _member(object, "query", path), context, depth + 1u,
+                    luisa::format("{}.query", path));
+                if (_error.empty() &&
+                    (query->tag() != Expression::Tag::REF ||
+                     !is_ray_query_type(query->type()))) {
+                    _fail(path, "ray-query value must be a ray-query reference expression.");
+                }
+                if (!_error.empty()) { return false; }
+                auto statement = context.builder->ray_query_(
+                    static_cast<const RefExpr *>(query));
+                return _decode_scope(
+                           _member(object, "on_triangle_candidate", path), context,
+                           statement->on_triangle_candidate(), depth + 1u,
+                           luisa::format("{}.on_triangle_candidate", path)) &&
+                       _decode_scope(
+                           _member(object, "on_procedural_candidate", path), context,
+                           statement->on_procedural_candidate(), depth + 1u,
+                           luisa::format("{}.on_procedural_candidate", path));
+            }
+            case Statement::Tag::AUTO_DIFF: {
+                if (!_check_keys(object, {"tag", "body"}, path)) { return false; }
+                auto statement = context.builder->autodiff_();
+                return _decode_scope(
+                    _member(object, "body", path), context,
+                    statement->body(), depth + 1u,
+                    luisa::format("{}.body", path));
+            }
+            case Statement::Tag::PRINT: {
+                if (!_check_keys(object, {"tag", "format", "arguments"}, path)) {
+                    return false;
+                }
+                luisa::string_view format;
+                auto args_value = _member(object, "arguments", path);
+                if (!_string(
+                        _member(object, "format", path), format,
+                        luisa::format("{}.format", path)) ||
+                    !_array(args_value, _limits.max_nodes,
+                            luisa::format("{}.arguments", path))) {
+                    return false;
+                }
+                luisa::vector<const Expression *> arguments;
+                arguments.reserve(yyjson_arr_size(args_value));
+                for (size_t i = 0u; i < yyjson_arr_size(args_value); i++) {
+                    auto argument = _decode_expr(
+                        yyjson_arr_get(args_value, i), context, depth + 1u,
+                        luisa::format("{}.arguments[{}]", path, i));
+                    if (!_error.empty()) { return false; }
+                    arguments.emplace_back(argument);
+                }
+                context.builder->print_(luisa::string{format}, arguments);
+                return true;
+            }
+            case Statement::Tag::SUSPEND:
+                _fail(path, "coroutine suspend is not supported by schema v1.");
+                return false;
+            case Statement::Tag::DEBUG_BREAK:
+                _fail(path, "debug-break callbacks are not portable.");
+                return false;
+        }
+        _fail(path, "unknown statement tag.");
+        return false;
+    }
+
+    [[nodiscard]] const RefExpr *_decode_variable(
+        yyjson_val *object, yyjson_val *binding_value,
+        FunctionContext &context, bool is_argument,
+        size_t index, luisa::string_view path) noexcept {
+        if (!_check_keys(
+                object,
+                _member(object, "name", path, false) == nullptr ?
+                    std::initializer_list<luisa::string_view>{"tag", "type", "usage"} :
+                    std::initializer_list<luisa::string_view>{"tag", "type", "usage", "name"},
+                path)) {
+            return nullptr;
+        }
+        luisa::string_view tag_name;
+        const Type *type{};
+        Usage usage{};
+        if (!_string(
+                _member(object, "tag", path), tag_name,
+                luisa::format("{}.tag", path)) ||
+            !_type_index(
+                _member(object, "type", path), _types.size(), type,
+                luisa::format("{}.type", path)) ||
+            !_usage(
+                _member(object, "usage", path), usage,
+                luisa::format("{}.usage", path))) {
+            return nullptr;
+        }
+        if (type == nullptr) {
+            _fail(path, "variable type must not be void.");
+            return nullptr;
+        }
+        auto parse_variable_tag = [&]() noexcept -> luisa::optional<Variable::Tag> {
+            if (tag_name == "ARGUMENT") { return luisa::nullopt; }
+            return magic_enum::enum_cast<Variable::Tag>(
+                std::string_view{tag_name.data(), tag_name.size()});
+        };
+        auto tag = parse_variable_tag();
+        if (tag_name != "ARGUMENT" && !tag) {
+            _fail(path, luisa::format("unknown variable tag '{}'.", tag_name));
+            return nullptr;
+        }
+
+        const RefExpr *ref{};
+        if (binding_value != nullptr) {
+            if (!is_argument || context.tag != Function::Tag::KERNEL) {
+                _fail(path, "only kernel arguments may carry resource bindings.");
+                return nullptr;
+            }
+            luisa::string_view binding_tag;
+            if (!_string(
+                    _member(binding_value, "tag", path), binding_tag,
+                    luisa::format("{}.binding.tag", path))) {
+                return nullptr;
+            }
+            uint64_t serialized_handle{};
+            if (!_decimal_uint64(
+                    _member(binding_value, "handle", path), serialized_handle,
+                    luisa::format("{}.binding.handle", path))) {
+                return nullptr;
+            }
+            luisa::string resolver_error;
+            if (binding_tag == "BUFFER") {
+                if (!tag || *tag != Variable::Tag::BUFFER ||
+                    !is_buffer_variable_type(type) ||
+                    !_check_keys(binding_value, {"tag", "handle", "offset", "size"},
+                                 luisa::format("{}.binding", path))) {
+                    if (_error.empty()) { _fail(path, "buffer binding does not match its variable."); }
+                    return nullptr;
+                }
+                uint64_t offset_u64{};
+                uint64_t size_u64{};
+                if (!_decimal_uint64(
+                        _member(binding_value, "offset", path), offset_u64,
+                        luisa::format("{}.binding.offset", path)) ||
+                    !_decimal_uint64(
+                        _member(binding_value, "size", path), size_u64,
+                        luisa::format("{}.binding.size", path)) ||
+                    offset_u64 > std::numeric_limits<size_t>::max() ||
+                    size_u64 > std::numeric_limits<size_t>::max()) {
+                    if (_error.empty()) { _fail(path, "buffer binding range exceeds host size_t."); }
+                    return nullptr;
+                }
+                Function::BufferBinding binding;
+                if (!_binding_resolver.resolve_buffer(
+                        type, serialized_handle,
+                        static_cast<size_t>(offset_u64),
+                        static_cast<size_t>(size_u64), binding, resolver_error)) {
+                    _fail(path, resolver_error.empty() ?
+                                    "buffer binding resolver rejected the handle." :
+                                    std::move(resolver_error));
+                    return nullptr;
+                }
+                ref = context.builder->buffer_binding(
+                    type, binding.handle, binding.offset, binding.size);
+            } else if (binding_tag == "TEXTURE") {
+                if (!tag || *tag != Variable::Tag::TEXTURE || !type->is_texture() ||
+                    !_check_keys(binding_value, {"tag", "handle", "level"},
+                                 luisa::format("{}.binding", path))) {
+                    if (_error.empty()) { _fail(path, "texture binding does not match its variable."); }
+                    return nullptr;
+                }
+                uint64_t level_u64{};
+                if (!_decimal_uint64(
+                        _member(binding_value, "level", path), level_u64,
+                        luisa::format("{}.binding.level", path)) ||
+                    level_u64 > std::numeric_limits<uint32_t>::max()) {
+                    if (_error.empty()) { _fail(path, "texture level exceeds uint32."); }
+                    return nullptr;
+                }
+                Function::TextureBinding binding;
+                if (!_binding_resolver.resolve_texture(
+                        serialized_handle, static_cast<uint32_t>(level_u64),
+                        binding, resolver_error)) {
+                    _fail(path, resolver_error.empty() ?
+                                    "texture binding resolver rejected the handle." :
+                                    std::move(resolver_error));
+                    return nullptr;
+                }
+                ref = context.builder->texture_binding(
+                    type, binding.handle, binding.level);
+            } else if (binding_tag == "BINDLESS_ARRAY") {
+                if (!tag || *tag != Variable::Tag::BINDLESS_ARRAY ||
+                    !type->is_bindless_array() ||
+                    !_check_keys(binding_value, {"tag", "handle"},
+                                 luisa::format("{}.binding", path))) {
+                    if (_error.empty()) { _fail(path, "bindless binding does not match its variable."); }
+                    return nullptr;
+                }
+                Function::BindlessArrayBinding binding;
+                if (!_binding_resolver.resolve_bindless_array(
+                        serialized_handle, binding, resolver_error)) {
+                    _fail(path, resolver_error.empty() ?
+                                    "bindless binding resolver rejected the handle." :
+                                    std::move(resolver_error));
+                    return nullptr;
+                }
+                ref = context.builder->bindless_array_binding(binding.handle);
+            } else if (binding_tag == "ACCEL") {
+                if (!tag || *tag != Variable::Tag::ACCEL || !type->is_accel() ||
+                    !_check_keys(binding_value, {"tag", "handle"},
+                                 luisa::format("{}.binding", path))) {
+                    if (_error.empty()) { _fail(path, "accel binding does not match its variable."); }
+                    return nullptr;
+                }
+                Function::AccelBinding binding;
+                if (!_binding_resolver.resolve_accel(
+                        serialized_handle, binding, resolver_error)) {
+                    _fail(path, resolver_error.empty() ?
+                                    "accel binding resolver rejected the handle." :
+                                    std::move(resolver_error));
+                    return nullptr;
+                }
+                ref = context.builder->accel_binding(binding.handle);
+            } else {
+                _fail(path, luisa::format("unknown binding tag '{}'.", binding_tag));
+                return nullptr;
+            }
+        } else if (is_argument) {
+            if (tag_name == "ARGUMENT") {
+                if (type->is_resource() || type->is_custom()) {
+                    _fail(path, "ordinary argument cannot have a resource type.");
+                    return nullptr;
+                }
+                ref = context.builder->argument(type);
+            } else {
+                switch (*tag) {
+                    case Variable::Tag::REFERENCE:
+                        ref = context.builder->reference(type);
+                        break;
+                    case Variable::Tag::BUFFER:
+                        if (!is_buffer_variable_type(type)) {
+                            _fail(path, "buffer variable must have buffer type.");
+                            return nullptr;
+                        }
+                        ref = context.builder->buffer(type);
+                        break;
+                    case Variable::Tag::TEXTURE:
+                        if (!type->is_texture()) {
+                            _fail(path, "texture variable must have texture type.");
+                            return nullptr;
+                        }
+                        ref = context.builder->texture(type);
+                        break;
+                    case Variable::Tag::BINDLESS_ARRAY:
+                        if (!type->is_bindless_array()) {
+                            _fail(path, "bindless variable has the wrong type.");
+                            return nullptr;
+                        }
+                        ref = context.builder->bindless_array();
+                        break;
+                    case Variable::Tag::ACCEL:
+                        if (!type->is_accel()) {
+                            _fail(path, "accel variable has the wrong type.");
+                            return nullptr;
+                        }
+                        ref = context.builder->accel();
+                        break;
+                    default:
+                        _fail(path, "invalid function-argument variable tag.");
+                        return nullptr;
+                }
+            }
+        } else {
+            if (tag_name == "ARGUMENT" || !tag) {
+                _fail(path, "non-argument variable cannot use ARGUMENT tag.");
+                return nullptr;
+            }
+            if (type->is_custom() &&
+                (!is_ray_query_type(type) || *tag != Variable::Tag::LOCAL)) {
+                _fail(path, "only allowlisted ray-query custom types may be local variables.");
+                return nullptr;
+            }
+            switch (*tag) {
+                case Variable::Tag::LOCAL: ref = context.builder->local(type); break;
+                case Variable::Tag::SHARED: ref = context.builder->shared(type); break;
+                case Variable::Tag::THREAD_ID: ref = context.builder->thread_id(); break;
+                case Variable::Tag::BLOCK_ID: ref = context.builder->block_id(); break;
+                case Variable::Tag::DISPATCH_ID: ref = context.builder->dispatch_id(); break;
+                case Variable::Tag::DISPATCH_SIZE: ref = context.builder->dispatch_size(); break;
+                case Variable::Tag::KERNEL_ID: ref = context.builder->kernel_id(); break;
+                case Variable::Tag::WARP_LANE_COUNT: ref = context.builder->warp_lane_count(); break;
+                case Variable::Tag::WARP_LANE_ID: ref = context.builder->warp_lane_id(); break;
+                case Variable::Tag::RASTER_OBJECT_ID:
+                case Variable::Tag::RASTER_BARYCENTRICS:
+                case Variable::Tag::RASTER_FRONT_FACING:
+                case Variable::Tag::RASTER_BASE_INSTANCE:
+                    _fail(path, "raster builtin is not valid in a compute AST.");
+                    return nullptr;
+                default:
+                    _fail(path, "invalid non-argument variable tag.");
+                    return nullptr;
+            }
+        }
+        if (ref == nullptr || ref->type() != type ||
+            ref->variable().uid() != index) {
+            _fail(path, "variable order, type, or binding is not canonical.");
+            return nullptr;
+        }
+        context.builder->mark_variable_usage(ref->variable().uid(), usage);
+        if (auto name_value = _member(object, "name", path, false)) {
+            luisa::string_view name;
+            if (!_string(name_value, name, luisa::format("{}.name", path))) {
+                return nullptr;
+            }
+            context.builder->set_variable_name(ref->variable().uid(), name);
+        }
+        return ref;
+    }
+
+    [[nodiscard]] bool _decode_variables(
+        yyjson_val *function, FunctionContext &context,
+        luisa::string_view path) noexcept {
+        auto variables = _member(function, "variables", path);
+        auto arguments = _member(function, "arguments", path);
+        if (!_array(variables, _limits.max_nodes, luisa::format("{}.variables", path)) ||
+            !_array(arguments, _limits.max_nodes, luisa::format("{}.arguments", path))) {
+            return false;
+        }
+        auto argument_count = yyjson_arr_size(arguments);
+        if (argument_count > yyjson_arr_size(variables)) {
+            _fail(path, "argument count exceeds variable count.");
+            return false;
+        }
+        for (size_t i = 0u; i < argument_count; i++) {
+            uint64_t index{};
+            if (!_uint64(
+                    yyjson_arr_get(arguments, i), index,
+                    luisa::format("{}.arguments[{}]", path, i)) ||
+                index != i) {
+                if (_error.empty()) {
+                    _fail(path, "arguments must be a canonical zero-based variable prefix.");
+                }
+                return false;
+            }
+        }
+        auto bindings = _member(function, "bound_arguments", path, false);
+        auto binding_count = size_t{0u};
+        if (bindings != nullptr) {
+            if (context.tag != Function::Tag::KERNEL ||
+                !_array(bindings, argument_count,
+                        luisa::format("{}.bound_arguments", path))) {
+                if (_error.empty()) { _fail(path, "only kernels may have bound arguments."); }
+                return false;
+            }
+            binding_count = yyjson_arr_size(bindings);
+        }
+        context.variables.reserve(yyjson_arr_size(variables));
+        for (size_t i = 0u; i < yyjson_arr_size(variables); i++) {
+            auto binding = i < binding_count ? yyjson_arr_get(bindings, i) : nullptr;
+            auto ref = _decode_variable(
+                yyjson_arr_get(variables, i), binding, context,
+                i < argument_count, i,
+                luisa::format("{}.variables[{}]", path, i));
+            if (ref == nullptr) { return false; }
+            context.variables.emplace_back(ref);
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _decode_function(
+        yyjson_val *object, size_t index, size_t entry) noexcept {
+        auto path = luisa::format("$.functions[{}]", index);
+        if (!_check_keys(
+                object,
+                {"tag", "name", "allowed_warp_size", "curve_bases",
+                 "variables", "arguments", "bound_arguments", "block_size",
+                 "return_type", "body", "constants"},
+                path)) {
+            return false;
+        }
+        Function::Tag tag{};
+        if (!_enum(_member(object, "tag", path), tag,
+                   luisa::format("{}.tag", path))) {
+            return false;
+        }
+        auto expected_tag = index == entry ?
+                                Function::Tag::KERNEL :
+                                Function::Tag::CALLABLE;
+        if (tag != expected_tag) {
+            _fail(path, index == entry ?
+                            "entry function must be a compute kernel." :
+                            "non-entry functions must be callables.");
+            return false;
+        }
+        const Type *declared_return_type{};
+        if (tag == Function::Tag::CALLABLE) {
+            auto return_value = _member(object, "return_type", path);
+            if (!_type_index(
+                    return_value, _types.size(), declared_return_type,
+                    luisa::format("{}.return_type", path)) ||
+                _member(object, "block_size", path, false) != nullptr ||
+                _member(object, "bound_arguments", path, false) != nullptr) {
+                if (_error.empty()) { _fail(path, "callable has kernel-only metadata."); }
+                return false;
+            }
+        } else if (_member(object, "return_type", path, false) != nullptr) {
+            _fail(path, "kernel must not declare a return type.");
+            return false;
+        }
+
+        auto builder = luisa::make_shared<detail::FunctionBuilder>(tag);
+        auto success = true;
+        {
+            detail::FunctionBuilder::FunctionStackGuard guard{builder.get()};
+            if (auto name_value = _member(object, "name", path, false)) {
+                luisa::string_view name;
+                success = _string(name_value, name, luisa::format("{}.name", path));
+                if (success) { builder->set_name(name); }
+            }
+            if (success) {
+                if (auto warp_value = _member(object, "allowed_warp_size", path, false)) {
+                    uint32_t warp{};
+                    success = _uint32(
+                        warp_value, warp,
+                        luisa::format("{}.allowed_warp_size", path));
+                    if (success && warp != 1u && warp != 2u && warp != 4u &&
+                        warp != 8u && warp != 16u && warp != 32u &&
+                        warp != 64u && warp != 128u) {
+                        _fail(path, "invalid allowed warp size.");
+                        success = false;
+                    }
+                    if (success) { builder->set_allowed_warp_size(static_cast<uint8_t>(warp)); }
+                }
+            }
+            if (success && tag == Function::Tag::KERNEL) {
+                auto block = _member(object, "block_size", path);
+                success = _array(block, 3u, luisa::format("{}.block_size", path)) &&
+                          yyjson_arr_size(block) == 3u;
+                uint32_t dimensions[3]{};
+                for (size_t i = 0u; success && i < 3u; i++) {
+                    success = _uint32(
+                        yyjson_arr_get(block, i), dimensions[i],
+                        luisa::format("{}.block_size[{}]", path, i));
+                }
+                auto product = static_cast<uint64_t>(dimensions[0]) *
+                               dimensions[1] * dimensions[2];
+                if (success && (product == 0u || product > 1024u ||
+                                dimensions[2] > 64u)) {
+                    _fail(path, "invalid compute block size.");
+                    success = false;
+                }
+                if (success) {
+                    builder->set_block_size(
+                        uint3{dimensions[0], dimensions[1], dimensions[2]});
+                }
+            }
+            FunctionContext context{
+                .builder = builder.get(),
+                .declared_return_type = declared_return_type,
+                .function_index = index,
+                .tag = tag};
+            if (success) { success = _decode_variables(object, context, path); }
+            if (success) {
+                CurveBasisSet bases;
+                success = _curve_bases(
+                    _member(object, "curve_bases", path), bases,
+                    luisa::format("{}.curve_bases", path));
+                if (success) { builder->mark_required_curve_basis_set(bases); }
+            }
+            if (success) {
+                auto constants = _member(object, "constants", path);
+                success = _array(constants, _constants.size(),
+                                 luisa::format("{}.constants", path));
+                for (size_t i = 0u; success && i < yyjson_arr_size(constants); i++) {
+                    ConstantData ignored;
+                    success = _constant_index(
+                        yyjson_arr_get(constants, i), ignored,
+                        luisa::format("{}.constants[{}]", path, i));
+                }
+            }
+            if (success) {
+                success = _decode_scope(
+                    _member(object, "body", path), context,
+                    builder->body(), 1u,
+                    luisa::format("{}.body", path));
+            }
+        }
+        if (!success) { return false; }
+        auto function = Function{builder.get()};
+        if (tag == Function::Tag::CALLABLE &&
+            function.return_type() != declared_return_type) {
+            _fail(path, "reconstructed callable return type does not match its declaration.");
+            return false;
+        }
+        _functions.emplace_back(
+            luisa::const_pointer_cast<const detail::FunctionBuilder>(builder));
+        return true;
+    }
+
+    [[nodiscard]] bool _decode_functions(
+        yyjson_val *array, size_t entry) noexcept {
+        if (!_array(array, _limits.max_functions, "$.functions")) { return false; }
+        auto count = yyjson_arr_size(array);
+        if (count == 0u || entry >= count || entry + 1u != count) {
+            _fail("$.entry", "entry must name the final function in a non-empty table.");
+            return false;
+        }
+        _functions.reserve(count);
+        for (size_t i = 0u; i < count; i++) {
+            if (!_decode_function(yyjson_arr_get(array, i), i, entry)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+public:
+    ASTJsonDecoder(yyjson_val *root, const ASTJsonLimits &limits,
+                   const ASTJsonBindingResolver &binding_resolver) noexcept
+        : _root{root}, _limits{limits},
+          _binding_resolver{binding_resolver} {}
+
+    [[nodiscard]] ASTJsonDecodeResult decode() noexcept;
+};
+
+ASTJsonDecodeResult ASTJsonDecoder::decode() noexcept {
+    if (!_check_keys(
+            _root,
+            {"schema", "version", "entry", "types", "constants",
+             "external_functions", "functions"},
+            "$")) {
+        return {.error = std::move(_error)};
+    }
+    luisa::string_view schema;
+    uint32_t version{};
+    uint64_t entry_u64{};
+    if (!_string(_member(_root, "schema", "$"), schema, "$.schema") ||
+        schema != "luisa.compute.ast") {
+        if (_error.empty()) { _fail("$.schema", "unsupported AST JSON schema."); }
+        return {.error = std::move(_error)};
+    }
+    if (!_uint32(_member(_root, "version", "$"), version, "$.version") ||
+        version != ast_json_schema_version) {
+        if (_error.empty()) {
+            _fail("$.version", luisa::format(
+                                   "unsupported schema version {} (expected {}).",
+                                   version, ast_json_schema_version));
+        }
+        return {.error = std::move(_error)};
+    }
+    if (!_uint64(_member(_root, "entry", "$"), entry_u64, "$.entry") ||
+        entry_u64 > std::numeric_limits<size_t>::max()) {
+        if (_error.empty()) { _fail("$.entry", "entry index exceeds host size_t."); }
+        return {.error = std::move(_error)};
+    }
+    if (auto external = _member(_root, "external_functions", "$", false)) {
+        if (!_array(external, 0u, "$.external_functions") ||
+            yyjson_arr_size(external) != 0u) {
+            if (_error.empty()) {
+                _fail("$.external_functions",
+                      "external functions are not supported by schema v1.");
+            }
+            return {.error = std::move(_error)};
+        }
+    }
+    if (!_decode_types(_member(_root, "types", "$")) ||
+        !_decode_constants(_member(_root, "constants", "$", false)) ||
+        !_decode_functions(
+            _member(_root, "functions", "$"),
+            static_cast<size_t>(entry_u64))) {
+        return {.error = std::move(_error)};
+    }
+    return {.function = _functions[static_cast<size_t>(entry_u64)]};
+}
+
+struct YYJsonBudget {
+    size_t used{};
+    size_t limit{};
+};
+
+[[nodiscard]] void *yyjson_budget_malloc(void *context, size_t size) noexcept {
+    auto budget = static_cast<YYJsonBudget *>(context);
+    if (size > budget->limit - std::min(budget->used, budget->limit)) {
+        return nullptr;
+    }
+    auto pointer = std::malloc(size);
+    if (pointer != nullptr) { budget->used += size; }
+    return pointer;
+}
+
+[[nodiscard]] void *yyjson_budget_realloc(
+    void *context, void *pointer, size_t old_size, size_t size) noexcept {
+    auto budget = static_cast<YYJsonBudget *>(context);
+    auto retained = budget->used >= old_size ? budget->used - old_size : 0u;
+    if (size > budget->limit - std::min(retained, budget->limit)) {
+        return nullptr;
+    }
+    auto replacement = std::realloc(pointer, size);
+    if (replacement != nullptr) { budget->used = retained + size; }
+    return replacement;
+}
+
+void yyjson_budget_free(void *, void *pointer) noexcept {
+    std::free(pointer);
+}
+
+}// namespace
+
+ASTJsonEncodeResult try_to_json(Function function,
+                                const ASTJsonLimits &limits) noexcept {
+    ASTJsonPreflight preflight{limits};
+    if (!preflight.run(function)) {
+        return {.error = preflight.take_error()};
+    }
+    auto json = to_json(function);
+    if (json.size() > limits.max_document_bytes) {
+        return {.error = "AST JSON document exceeds the configured byte limit."};
+    }
+    yyjson_read_err parse_error{};
+    auto document = yyjson_read_opts(
+        json.data(), json.size(), YYJSON_READ_NOFLAG, nullptr, &parse_error);
+    if (document == nullptr) {
+        return {.error = luisa::format(
+                    "AST JSON encoder produced invalid JSON at byte {}: {}.",
+                    parse_error.pos,
+                    parse_error.msg == nullptr ? "unknown parse error" : parse_error.msg)};
+    }
+    yyjson_doc_free(document);
+    return {.json = std::move(json)};
+}
+
+ASTJsonDecodeResult from_json(
+    luisa::string_view json, const ASTJsonLimits &limits,
+    const ASTJsonBindingResolver *binding_resolver) noexcept {
+    if (json.empty()) {
+        return {.error = "AST JSON document is empty."};
+    }
+    if (json.size() > limits.max_document_bytes) {
+        return {.error = "AST JSON document exceeds the configured byte limit."};
+    }
+    YYJsonBudget budget{.limit = limits.max_parse_memory_bytes};
+    yyjson_alc allocator{
+        .malloc = yyjson_budget_malloc,
+        .realloc = yyjson_budget_realloc,
+        .free = yyjson_budget_free,
+        .ctx = &budget};
+    yyjson_read_err parse_error{};
+    auto document = yyjson_read_opts(
+        const_cast<char *>(json.data()), json.size(),
+        YYJSON_READ_NOFLAG, &allocator, &parse_error);
+    if (document == nullptr) {
+        return {.error = luisa::format(
+                    "Failed to parse AST JSON at byte {}: {}.",
+                    parse_error.pos,
+                    parse_error.msg == nullptr ?
+                        "memory budget exhausted or unknown parse error" :
+                        parse_error.msg)};
+    }
+    static const ASTJsonBindingResolver identity_resolver;
+    ASTJsonDecoder decoder{
+        yyjson_doc_get_root(document), limits,
+        binding_resolver == nullptr ? identity_resolver : *binding_resolver};
+    auto result = decoder.decode();
+    yyjson_doc_free(document);
+    return result;
+}
+
+}// namespace luisa::compute

--- a/src/backends/CMakeLists.txt
+++ b/src/backends/CMakeLists.txt
@@ -85,5 +85,9 @@ if (LUISA_COMPUTE_ENABLE_SIMD)
     add_subdirectory(simd)
 endif ()
 
+if (LUISA_COMPUTE_ENABLE_REMOTE)
+    add_subdirectory(remote)
+endif ()
+
 install(TARGETS luisa-compute-backends
         EXPORT LuisaComputeTargets)

--- a/src/backends/remote/CMakeLists.txt
+++ b/src/backends/remote/CMakeLists.txt
@@ -1,0 +1,73 @@
+include(FetchContent)
+find_package(Threads REQUIRED)
+
+FetchContent_Declare(luisa_compute_asio
+        URL https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-38-2.tar.gz
+        URL_HASH SHA256=9f2648fa483e58a6bf848d970ee0ea650ca19ed7769dfa520ed4f7b8d27af1db
+        DOWNLOAD_EXTRACT_TIMESTAMP ON)
+FetchContent_MakeAvailable(luisa_compute_asio)
+
+add_library(luisa-compute-ext-asio INTERFACE)
+target_include_directories(luisa-compute-ext-asio SYSTEM INTERFACE
+        ${luisa_compute_asio_SOURCE_DIR}/include)
+target_compile_definitions(luisa-compute-ext-asio INTERFACE
+        ASIO_STANDALONE=1
+        ASIO_NO_DEPRECATED=1)
+target_link_libraries(luisa-compute-ext-asio INTERFACE Threads::Threads)
+
+set(LUISA_COMPUTE_REMOTE_COMMON_SOURCES
+        remote_blob_cache.cpp
+        remote_blob_cache.h
+        remote_protocol.cpp
+        remote_protocol.h
+        remote_transport.cpp
+        remote_transport.h)
+
+add_library(luisa-compute-remote-common STATIC
+        ${LUISA_COMPUTE_REMOTE_COMMON_SOURCES})
+target_link_libraries(luisa-compute-remote-common
+        PUBLIC luisa-compute-core
+        PRIVATE luisa-compute-ext-asio)
+target_include_directories(luisa-compute-remote-common PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(luisa-compute-remote-common PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        UNITY_BUILD ${LUISA_COMPUTE_ENABLE_UNITY_BUILD}
+        FOLDER backends/remote)
+
+add_library(luisa-compute-remote-runtime STATIC
+        remote_command_codec.cpp
+        remote_command_codec.h
+        remote_server.cpp
+        remote_server.h)
+target_link_libraries(luisa-compute-remote-runtime
+        PUBLIC
+        luisa-compute-remote-common
+        luisa-compute-ast
+        luisa-compute-runtime
+        PRIVATE
+        luisa-compute-ext-asio)
+target_include_directories(luisa-compute-remote-runtime PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(luisa-compute-remote-runtime PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        UNITY_BUILD ${LUISA_COMPUTE_ENABLE_UNITY_BUILD}
+        FOLDER backends/remote)
+
+luisa_compute_add_backend(remote SOURCES
+        remote_device.cpp
+        remote_device.h)
+target_link_libraries(luisa-compute-backend-remote PRIVATE
+        luisa-compute-remote-runtime)
+
+add_executable(luisa-remote-server
+        remote_server_main.cpp)
+target_link_libraries(luisa-remote-server PRIVATE
+        luisa-compute-remote-runtime
+        luisa-compute-runtime
+        luisa-compute-ext-asio)
+set_target_properties(luisa-remote-server PROPERTIES
+        OUTPUT_NAME luisa-remote-server
+        FOLDER backends/remote)
+install(TARGETS luisa-remote-server
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/backends/remote/REMOTE_BACKEND_DESIGN.md
+++ b/src/backends/remote/REMOTE_BACKEND_DESIGN.md
@@ -1,0 +1,422 @@
+# LuisaCompute C++ Remote Backend Design
+
+## Status and scope
+
+This document describes protocol version 1.1 of the experimental `remote` backend.
+The implementation is entirely C++ and deliberately does not reuse the legacy
+Rust remote code, `reproc`, `CallableLibrary`, native object images, or
+process-local pointers. The client is a normal LuisaCompute backend plugin; the server is a
+long-lived service that creates a normal native LuisaCompute device for each
+authenticated session and executes work on it.
+
+Version 1 is intended to establish a safe, testable semantic baseline:
+
+- resource handles have connection-local, strongly tagged remote identities;
+- command lists retain LuisaCompute stream ordering and asynchronous completion;
+- kernels and transitive callables cross the network as a versioned AST document;
+- every untrusted frame and AST document is decoded with explicit bounds;
+- no C++ object layout, enum width, pointer, or `size_t` representation is put on
+  the wire;
+- the server never accepts a client-provided native backend handle.
+
+The current wire format is specified only for little-endian 64-bit peers. The
+handshake rejects incompatible protocol versions and machine representations.
+
+## Trust and deployment boundary
+
+The protocol parser treats network bytes as structurally untrusted. Framing,
+message kinds, resource kinds, sizes, offsets, counts, AST node kinds, types,
+bindings, and command regions are checked before native calls. Session resource
+tables and configurable quotas prevent one connection from addressing another
+connection's objects or growing without a bound. Protocol version 1 still treats
+an authenticated client as trusted to originate semantically valid LuisaCompute
+builtin operations; backend-specific semantic validation remains the selected
+native backend's responsibility. The service is not a hostile multi-tenant
+sandbox.
+
+The transport is currently plain TCP. The shared token authenticates a session
+but does not encrypt traffic, provide server identity, or prevent replay by an
+observer. The frame checksum detects accidental corruption; it is not a MAC.
+Version 1 should therefore be bound to loopback or used inside a trusted private
+network, VPN, or SSH tunnel. Exposing the listener directly to an untrusted
+network requires a future TLS transport with certificate verification.
+
+## Architecture
+
+```text
+Luisa application
+      |
+      | DeviceInterface API
+      v
+remote backend plugin
+  - local proxy handles
+  - AST JSON encoder
+  - command encoder
+  - request/completion dispatcher
+  - optional local presentation bridge
+      |
+      | framed TCP, persistent connection
+      v
+remote server session
+  - authentication and capability negotiation
+  - bounded protocol/AST decoders
+  - typed per-session resource tables
+  - command/binding remapper
+      |
+      | normal DeviceInterface calls
+      v
+server-selected native backend and device
+```
+
+The server configures a default non-remote backend and an allowlist of
+client-selectable backends. A session advertises the protocol feature families
+implemented by the service. Native resource or shader creation can still reject
+a feature that the selected backend does not support; protocol version 1 does
+not yet expose exhaustive per-device capability reflection.
+
+## Build and operation
+
+Enable the backend with:
+
+```text
+-DLUISA_COMPUTE_ENABLE_REMOTE=ON
+```
+
+The build produces the `remote` backend module and `luisa-remote-server`.
+Standalone Asio 1.38.2 is fetched by an archive URL with a pinned SHA-256 hash.
+It is used header-only with `ASIO_STANDALONE` and no Boost dependency.
+
+Example server invocation:
+
+```text
+luisa-remote-server --backend metal --allow-backend metal \
+    --listen 127.0.0.1 --port 18080 \
+    --token <shared-token>
+```
+
+A native cross-process smoke test is deliberately two independent commands:
+
+```text
+luisa-remote-server --backend metal --listen 127.0.0.1 --port 18080 \
+    --token test-token
+test_remote_backend_native metal 127.0.0.1 18080 test-token
+```
+
+The token can instead be supplied through `LUISA_REMOTE_TOKEN`. Client endpoint,
+token, request timeouts, in-flight-byte limits, and the upload-cache threshold are
+configured with `RemoteDeviceConfigExt`. The same extension can explicitly select
+the client-side presentation backend; otherwise the client chooses the native
+platform backend (`metal` on macOS, `dx` on Windows, and `vk` on Linux) when a
+swapchain is first requested. It can also request a server backend, device index,
+and validation mode. The server exposes
+`--blob-cache-bytes`, `--blob-cache-entry-bytes`, and
+`--blob-cache-min-bytes`; a zero cache capacity disables the feature. Repeated
+`--allow-backend` arguments form the exact backend allowlist,
+`--allow-client-validation` controls whether a client may enable validation, and
+`--max-sessions` bounds concurrent clients. Process
+supervisors may pass `--print-ready` to receive a flushed, machine-readable
+`LCRP_READY_V1 <bound-port>` line after the service listener and policy are ready.
+This also permits race-free discovery when `--port 0` requests an ephemeral port.
+The service creates each requested full native compute device rather than asking
+for backend "headless" mode: protocol version 1 sends AST and therefore requires
+runtime JIT, which headless mode disables on some native backends.
+`SIGINT` and `SIGTERM` are consumed by an Asio signal loop and translated into
+`Server::stop()`, allowing the accept loop and active sessions to shut down and
+join before the process exits.
+
+## Service lifecycle and device selection
+
+The protocol 1.1 `HELLO` extension carries a backend name, device index, and
+validation request. Empty backend and sentinel device index select the server
+defaults. Protocol 1.0 clients omit these fields and continue to select the
+defaults. Backend names are syntax-checked before they reach a factory and the
+standalone service additionally requires an exact match in its configured
+allowlist. Device indices are checked against the native backend's advertised
+device list. Client-requested validation is rejected unless the service operator
+explicitly enables it.
+
+Every accepted session owns a separately constructed `DeviceInterface` and its
+typed resource tables. An EOF, reset, malformed handshake, rejected device
+request, or client process abort stops only that session: its streams are drained,
+callbacks are detached, resources are destroyed in dependency order, and the
+native device is released. The accept loop remains live, reaps completed workers,
+and admits a fresh reconnect. The session limit rejects excess connections before
+allocating a device. A service shutdown closes the listener and all current
+sessions, then joins their workers.
+
+Reconnect means creating a fresh client `Device` and session. Transparent resume
+of the same client object is intentionally not attempted: connection-local
+resource IDs cannot remain valid after their native resources have been reclaimed.
+`remote.connected` is a client-local query that lets an application detect loss
+and rebuild that device. Resource destruction after a lost connection is
+best-effort and never sends stale handles into a new session. The lower-level TCP
+`Connection` object itself may be reconnected after its reader observes EOF, but
+the new connection has no relationship to the previous resource namespace.
+
+## Local client presentation
+
+Windows and native display handles are process-local and never cross the wire.
+`RemoteDevice::create_swapchain` instead creates a graphics stream, swapchain,
+and mirror image on a lazily created local presentation device. The application
+continues to use the ordinary `Window -> Device::create_swapchain -> present`
+API; only kernels and application resources belong to the remote server.
+
+At each present boundary, the client drains the remote graphics stream, downloads
+the base mip of the presented remote image into bounded client staging storage,
+uploads it to the local mirror image, and presents that image on the local native
+swapchain. A subsequent present or stream synchronization waits for the local
+submission before reusing the staging bytes. The baseline path is intentionally
+synchronous across the network; later protocol versions can add compressed or
+multi-buffered frame transport without exposing native handles or weakening
+stream ordering.
+
+The presented image must match the swapchain extent and backend storage. Raster
+shaders remain outside protocol version 1, but compute-, ray-tracing-, and
+simulation-rendered images can be displayed locally. The selected backend is
+reported by the `remote.local_present_backend` device query.
+
+## Framing and request correlation
+
+Every message begins with a fixed 40-byte little-endian header. Fields are
+encoded individually:
+
+| Field | Width | Meaning |
+| --- | ---: | --- |
+| magic | 4 | `LCRP` protocol discriminator |
+| major/minor | 2 + 2 | negotiated protocol version |
+| kind | 2 | closed message-kind enum |
+| flags | 2 | versioned flags, zero unless specified |
+| reserved | 4 | must be zero in version 1 |
+| request id | 8 | nonzero request/response correlation id |
+| payload size | 8 | checked before allocation or read |
+| payload checksum | 8 | corruption detection for the payload |
+
+The client keeps one persistent connection, allocates monotonically increasing
+request IDs, and has a reader loop that resolves pending requests independently
+of submission order. Responses carry status and an error message. Unsolicited
+notifications are reserved for dispatch completion and stream logging.
+
+Decoders reject unknown enums, malformed booleans, invalid UTF-8-independent
+length prefixes, integer overflow, trailing bytes, oversized frames, strings, or
+arrays. Transport close atomically fails all pending requests. Request and
+connect timeouts cancel the corresponding socket operation.
+
+Servers advertise `Feature::LIMIT_NEGOTIATION`. After `HELLO`, the client reads
+the server's frame, string, and array ceilings through `PROTOCOL_INFO` and uses
+the intersection with its own limits for later bounded encoding and decoding. The
+negotiated values are exposed as `remote.protocol.max_frame_payload`,
+`remote.protocol.max_string_size`, and `remote.protocol.max_array_size`.
+`Feature::DEVICE_SELECTION` and the `remote.device_selection` query report that
+the session was created by a service device factory.
+
+## Remote handles and lifetime
+
+A remote resource ID consists of an 8-bit resource-kind tag and a 56-bit session
+index. Buffer, texture, bindless array, stream, shader, event, mesh, curve,
+procedural primitive, motion instance, and acceleration structure IDs occupy
+separate namespaces. Every lookup verifies the tag as well as existence.
+
+IDs are meaningful only in the session that created them and are never reused
+after index exhaustion. Destroy requests remove the server-side entry. Session
+shutdown releases all remaining entries and closes its streams before the native
+device is released. A client cannot inject a process-local handle into a shader
+or command: all such fields pass through the session resolver.
+
+## Shader transport: versioned AST JSON
+
+`ast2json` now defines schema version 1 and has a matching `from_json` decoder.
+It serializes the complete reachable function graph, including custom callables,
+types, constants, expressions, statements, arguments, resource bindings, block
+size, required curve bases, and variable usage. It does not serialize executable
+code, C++ object representations, function pointers, or `CallableLibrary` data.
+
+The server shader path is:
+
+```text
+client Function -> ast2json schema v1 -> bounded JSON bytes
+                -> yyjson parse and structural preflight
+                -> FunctionBuilder reconstruction with remote binding resolver
+                -> native DeviceInterface::create_shader
+```
+
+The decoder uses yyjson with a quota allocator and enforces document, parse
+memory, function, type, node, recursion-depth, string, array, and deduplicated
+constant-byte limits. It requires exact object keys where ambiguity would be
+dangerous, validates Base64 strictly, rejects duplicate identifiers and unknown
+node kinds, checks expression/statement ownership and type compatibility, and
+rejects unsafe CPU/custom/external operations. Builtin argument counts and the
+reconstruction invariants that could otherwise trigger `FunctionBuilder` or type
+registry assertions are checked through non-terminating decoder errors first.
+The only custom type identifiers accepted at this boundary are the framework's
+`LC_IndirectDispatchBuffer`, `LC_RayQueryAll`, and `LC_RayQueryAny`; arbitrary
+client-defined custom types remain rejected. Scalar assignment conversions match
+the DSL's implicit scalar rules, while composite assignments require identical
+types.
+
+Serialized buffer, texture, bindless-array, and acceleration-structure bindings
+are remapped through `ASTJsonBindingResolver`. The server resolver verifies the
+remote resource kind, session ownership, buffer slice, and texture mip before it
+returns a native binding. Native shader include blobs and AOT shader loading are
+not part of protocol version 1.
+
+The original `to_json(Type)` and `to_json(Function)` entry points remain for
+source compatibility. New network-facing code uses `try_to_json` and checks its
+structured error result. `from_json` is the only supported reverse path.
+
+## Command lists and data movement
+
+Command payloads contain a command tag followed by explicitly encoded fields.
+Version 1 supports:
+
+- buffer upload, download, and buffer-to-buffer copy;
+- texture upload, download, texture-to-texture copy, buffer-to-texture copy, and
+  texture-to-buffer copy;
+- content-addressed buffer and texture uploads negotiated through the blob cache;
+- direct, multiple-dispatch, and indirect shader dispatch;
+- bindless-array updates;
+- mesh, curve, procedural primitive, motion instance, and top-level acceleration
+  structure build commands;
+- stream signal/wait, event query/synchronization, resource naming, and stream
+  logging.
+
+The server validates all buffer ranges with overflow-safe arithmetic. Texture
+commands are checked against the recorded storage format, base extent, mip
+count, selected mip extent, copy region, and required byte footprint. Uniform
+arguments are padded to the alignment expected by `CommandEncoder`. Transforms
+and other floating-point structural fields that must be finite are checked before
+native dispatch.
+
+Downloads use server-owned staging memory whose lifetime extends through native
+completion. Data is returned in the completion notification, not in the initial
+dispatch acknowledgement. The client copies it into the application destination
+before invoking the command-list completion callbacks.
+
+## Stream ordering and asynchronous completion
+
+Submitting a command list performs only bounded encoding, in-flight admission,
+and a dispatch request. The acknowledgement means that the server accepted the
+submission; it does not mean the native device finished it. The server appends a
+native command-list callback and sends `DISPATCH_COMPLETE` only from that callback.
+
+The client associates completion state, readback destinations, callbacks, and
+the encoded byte footprint with a monotonically increasing submission ID. Its
+reader/completion path applies readbacks in command order, invokes callbacks,
+and releases in-flight capacity. `synchronize_stream` first synchronizes the
+server stream and then drains all client-side completion work for that stream.
+Event operations map directly to native timeline events.
+
+An in-flight byte budget supplies client-side backpressure. The budget covers
+encoded command bytes plus retained readback state and prevents an unbounded
+queue when the network or native device is slower than the producer. Missing
+blob bodies are transferred synchronously before dispatch admission completes;
+the server pins their immutable cache storage through native completion.
+
+## Failure model
+
+- A malformed request receives a typed error when a response can still be sent.
+- Authentication or version failure closes the session after the handshake.
+- A dispatch decode or admission failure is reported against its request ID;
+  the current `DeviceInterface::dispatch` API has no native asynchronous error
+  return channel after admission.
+- Socket failure wakes pending synchronous requests and stream-drain waiters.
+- Client disconnect, abort, or rejected device selection tears down only that
+  session; the accept loop remains available for a fresh connection.
+- A completion callback is never reported before its readback data is installed.
+- Resource limits fail creation without allocating a native resource.
+- Server stop closes the acceptor and active sessions so their worker threads can
+  join without relying on another incoming connection.
+
+## Version 1 boundaries
+
+The following are intentionally not represented yet:
+
+- general GUI/native interop and imported process-local resources beyond the
+  isolated local swapchain presentation bridge;
+- raster shaders and raster command lists;
+- sparse resources, DirectStorage, and native extension handles;
+- AOT shader names or backend-native shader binaries;
+- transport encryption, certificate-based identity, or transparent session resume;
+- heterogeneous endian/word-size peers;
+- automatic load balancing or migration between devices after session creation.
+
+Unsupported methods fail explicitly or return an invalid creation result. They
+must not silently fall back to a local device because that would break resource
+ownership and ordering.
+
+## Content-addressed upload cache
+
+`Feature::BLOB_CACHE` adds a compatible cached path while preserving the inline
+version-1 commands for older clients and small uploads. For each submission the
+client deduplicates eligible buffer and texture upload bodies, computes a SHA-256
+digest, and sends ordered `(size, digest)` descriptors with `PREPARE_BLOBS`. The
+server returns the missing descriptor indices. One or more bounded
+`UPLOAD_BLOBS` requests then carry only those bodies, repeating the index, size,
+and digest so each record is self-validating. Buffer and texture commands refer
+to the prepared slot instead of embedding the bytes.
+
+Preparation is a submission-scoped lease, not merely a speculative cache query.
+It pins hits across the prepare/upload/dispatch interval, eliminating an eviction
+race between a reported hit and command decoding. The decoded command list owns
+immutable shared blob references through its native completion callback. Every
+prepared descriptor must be filled and referenced by the matching submission;
+duplicate descriptors, missing bodies, wrong sizes, digest mismatches, stale
+submission IDs, and unused slots are rejected.
+
+The server cache is shared across its authenticated sessions and uses a
+byte-budgeted LRU. Only entries without active leases or submissions may be
+evicted; inability to make space produces `RESOURCE_LIMIT` rather than silently
+falling back to the wrong bytes. SHA-256 is computed before an uploaded body is
+published, and an existing key is byte-compared when concurrent publication
+races occur. Small or one-shot uploads stay inline because an extra negotiation
+round trip would cost more than the saved bandwidth.
+
+All sessions accepted by one server currently share the same configured token
+and cache trust domain. A future multi-tenant authentication scheme must
+partition cache keys and accounting by authenticated identity; otherwise a
+client that knows another tenant's digest could reuse its bytes. TLS remains
+required on an untrusted network regardless of the digest algorithm.
+
+Operational counters use the `remote.blob_cache.` prefix with the properties
+`hits`, `misses`, `stores`, `evictions`, `uploaded_bytes`, `resident_bytes`, and
+`resident_entries`, plus `capacity_bytes` and `enabled`.
+
+## Validation strategy
+
+The implementation has four focused layers of tests:
+
+- AST serde tests cover kernels, custom callables, control flow, binding remap,
+  malformed documents, duplicate keys, invalid Base64, builtin arity,
+  reconstruction-safety guards, and representative decoder quotas;
+- protocol and transport tests cover framing, checksums, protocol 1.0/1.1 minor
+  compatibility, limits, request correlation, timeout/cancellation, connection
+  failure, same-object reconnect, and asynchronous notifications;
+- blob-cache tests cover SHA-256 vectors, digest rejection, LRU pinning and
+  eviction, duplicate-content planning, cached command encoding, hit reuse, and
+  inline fallback when the server does not advertise the feature;
+- an end-to-end test dynamically loads the `remote` backend against a localhost
+  server and a mock native device, then exercises buffers, every texture-copy
+  direction, AST shader creation with callable/bound-resource remapping, bindless
+  updates, timeline events, stream callbacks/logs, and all ray-tracing resource
+  build/remap paths. It also force-closes a client without `GOODBYE`, verifies
+  resource reclamation and reconnect, rejects out-of-range shader metadata
+  queries without losing the session, permits client resources to destruct after
+  service loss, isolates a throwing device factory, rejects one device request
+  without stopping the service, and creates two simultaneous sessions using
+  distinct requested backend names and device indices;
+- a two-command cross-process native test runs `luisa-remote-server` and the
+  native remote client test as independent executables. The client drives a real
+  Metal device through TCP and checks AST JIT and callable reconstruction, bound
+  resources, GPU buffer/texture execution and readback, asynchronous completion,
+  timeline events, and cold/hot upload-cache accounting;
+- a separate local-presentation test executes a remote image kernel, downloads
+  each present boundary, and displays three frames through a client-owned Metal
+  swapchain; and
+- the GUI-enabled rendering sweep runs 17 finite offline examples through a
+  persistent Metal service, including path tracing variants, AST/XIR-to-AST,
+  ray masks, ray-query cutout, spectrum, photon mapping, SDF, procedural,
+  blackhole, voxel, and shader-toy workloads. Gallery-backed examples are also
+  checked at their reference sample counts using PSNR and structural metrics.
+
+The mock test verifies the boundary and ordering without requiring a particular
+GPU. Other native backends and performance tests remain deployment-specific and
+should be run in addition before enabling the backend in production.

--- a/src/backends/remote/remote_blob_cache.cpp
+++ b/src/backends/remote/remote_blob_cache.cpp
@@ -1,0 +1,271 @@
+#include "remote_blob_cache.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+#include <luisa/core/stl/hash.h>
+
+namespace luisa::compute::remote {
+
+namespace {
+
+[[nodiscard]] constexpr uint32_t rotate_right(
+    uint32_t value, uint32_t amount) noexcept {
+    return (value >> amount) | (value << (32u - amount));
+}
+
+[[nodiscard]] std::array<std::byte, blob_digest_size> sha256(
+    luisa::span<const std::byte> data) noexcept {
+
+    static constexpr std::array<uint32_t, 64u> constants{
+        0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+        0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u,
+        0xd807aa98u, 0x12835b01u, 0x243185beu, 0x550c7dc3u,
+        0x72be5d74u, 0x80deb1feu, 0x9bdc06a7u, 0xc19bf174u,
+        0xe49b69c1u, 0xefbe4786u, 0x0fc19dc6u, 0x240ca1ccu,
+        0x2de92c6fu, 0x4a7484aau, 0x5cb0a9dcu, 0x76f988dau,
+        0x983e5152u, 0xa831c66du, 0xb00327c8u, 0xbf597fc7u,
+        0xc6e00bf3u, 0xd5a79147u, 0x06ca6351u, 0x14292967u,
+        0x27b70a85u, 0x2e1b2138u, 0x4d2c6dfcu, 0x53380d13u,
+        0x650a7354u, 0x766a0abbu, 0x81c2c92eu, 0x92722c85u,
+        0xa2bfe8a1u, 0xa81a664bu, 0xc24b8b70u, 0xc76c51a3u,
+        0xd192e819u, 0xd6990624u, 0xf40e3585u, 0x106aa070u,
+        0x19a4c116u, 0x1e376c08u, 0x2748774cu, 0x34b0bcb5u,
+        0x391c0cb3u, 0x4ed8aa4au, 0x5b9cca4fu, 0x682e6ff3u,
+        0x748f82eeu, 0x78a5636fu, 0x84c87814u, 0x8cc70208u,
+        0x90befffau, 0xa4506cebu, 0xbef9a3f7u, 0xc67178f2u};
+
+    std::array<uint32_t, 8u> state{
+        0x6a09e667u, 0xbb67ae85u, 0x3c6ef372u, 0xa54ff53au,
+        0x510e527fu, 0x9b05688cu, 0x1f83d9abu, 0x5be0cd19u};
+
+    auto process_block = [&](const std::byte *block) noexcept {
+        std::array<uint32_t, 64u> words{};
+        for (auto i = 0u; i < 16u; i++) {
+            auto offset = i * 4u;
+            words[i] =
+                static_cast<uint32_t>(
+                    std::to_integer<uint8_t>(block[offset]))
+                    << 24u |
+                static_cast<uint32_t>(
+                    std::to_integer<uint8_t>(block[offset + 1u]))
+                    << 16u |
+                static_cast<uint32_t>(
+                    std::to_integer<uint8_t>(block[offset + 2u]))
+                    << 8u |
+                static_cast<uint32_t>(
+                    std::to_integer<uint8_t>(block[offset + 3u]));
+        }
+        for (auto i = 16u; i < 64u; i++) {
+            auto x = words[i - 15u];
+            auto y = words[i - 2u];
+            auto s0 = rotate_right(x, 7u) ^
+                      rotate_right(x, 18u) ^ (x >> 3u);
+            auto s1 = rotate_right(y, 17u) ^
+                      rotate_right(y, 19u) ^ (y >> 10u);
+            words[i] = words[i - 16u] + s0 +
+                       words[i - 7u] + s1;
+        }
+
+        auto a = state[0u];
+        auto b = state[1u];
+        auto c = state[2u];
+        auto d = state[3u];
+        auto e = state[4u];
+        auto f = state[5u];
+        auto g = state[6u];
+        auto h = state[7u];
+        for (auto i = 0u; i < 64u; i++) {
+            auto s1 = rotate_right(e, 6u) ^
+                      rotate_right(e, 11u) ^
+                      rotate_right(e, 25u);
+            auto choice = (e & f) ^ (~e & g);
+            auto temp1 = h + s1 + choice +
+                         constants[i] + words[i];
+            auto s0 = rotate_right(a, 2u) ^
+                      rotate_right(a, 13u) ^
+                      rotate_right(a, 22u);
+            auto majority = (a & b) ^ (a & c) ^ (b & c);
+            auto temp2 = s0 + majority;
+            h = g;
+            g = f;
+            f = e;
+            e = d + temp1;
+            d = c;
+            c = b;
+            b = a;
+            a = temp1 + temp2;
+        }
+        state[0u] += a;
+        state[1u] += b;
+        state[2u] += c;
+        state[3u] += d;
+        state[4u] += e;
+        state[5u] += f;
+        state[6u] += g;
+        state[7u] += h;
+    };
+
+    auto full_block_count = data.size() / 64u;
+    for (auto i = 0u; i < full_block_count; i++) {
+        process_block(data.data() + i * 64u);
+    }
+
+    std::array<std::byte, 128u> tail{};
+    auto remaining = data.size() % 64u;
+    if (remaining != 0u) {
+        std::copy_n(
+            data.data() + full_block_count * 64u,
+            remaining, tail.data());
+    }
+    tail[remaining] = std::byte{0x80u};
+    auto tail_size = remaining < 56u ? 64u : 128u;
+    auto bit_count = static_cast<uint64_t>(data.size()) * 8u;
+    for (auto i = 0u; i < 8u; i++) {
+        tail[tail_size - 1u - i] =
+            static_cast<std::byte>(bit_count >> (i * 8u));
+    }
+    process_block(tail.data());
+    if (tail_size == 128u) {
+        process_block(tail.data() + 64u);
+    }
+
+    std::array<std::byte, blob_digest_size> digest{};
+    for (auto i = 0u; i < state.size(); i++) {
+        digest[i * 4u] = static_cast<std::byte>(state[i] >> 24u);
+        digest[i * 4u + 1u] =
+            static_cast<std::byte>(state[i] >> 16u);
+        digest[i * 4u + 2u] =
+            static_cast<std::byte>(state[i] >> 8u);
+        digest[i * 4u + 3u] = static_cast<std::byte>(state[i]);
+    }
+    return digest;
+}
+
+[[nodiscard]] bool equal_bytes(
+    luisa::span<const std::byte> lhs,
+    luisa::span<const std::byte> rhs) noexcept {
+    return lhs.size() == rhs.size() &&
+           (lhs.empty() ||
+            std::memcmp(lhs.data(), rhs.data(), lhs.size()) == 0);
+}
+
+}// namespace
+
+size_t BlobKeyHash::operator()(const BlobKey &key) const noexcept {
+    auto digest_hash = luisa::hash64(
+        key.digest.data(), key.digest.size(),
+        0x4c4352505f424c4full);
+    return static_cast<size_t>(luisa::hash64(
+        &key.size, sizeof(key.size), digest_hash));
+}
+
+BlobKey compute_blob_key(luisa::span<const std::byte> bytes) noexcept {
+    return BlobKey{
+        .digest = sha256(bytes),
+        .size = static_cast<uint64_t>(bytes.size())};
+}
+
+void write_blob_key(Writer &writer, const BlobKey &key) noexcept {
+    writer.write_u64(key.size);
+    writer.write_bytes(key.digest);
+}
+
+bool read_blob_key(Reader &reader, BlobKey &key) noexcept {
+    key.size = reader.read_u64();
+    auto digest = reader.read_bytes(blob_digest_size);
+    if (!reader.ok()) { return false; }
+    std::copy(digest.begin(), digest.end(), key.digest.begin());
+    return true;
+}
+
+BlobCache::BlobCache(uint64_t capacity_bytes) noexcept
+    : _capacity_bytes{capacity_bytes} {}
+
+void BlobCache::_touch(Entry &entry) noexcept {
+    _lru.splice(_lru.begin(), _lru, entry.lru_iterator);
+    entry.lru_iterator = _lru.begin();
+}
+
+bool BlobCache::_make_space(uint64_t size) noexcept {
+    if (size > _capacity_bytes) { return false; }
+    while (_stats.resident_bytes > _capacity_bytes - size) {
+        auto removed = false;
+        for (auto iterator = _lru.end(); iterator != _lru.begin();) {
+            --iterator;
+            auto entry = _entries.find(*iterator);
+            if (entry != _entries.end() &&
+                entry->second.blob.use_count() == 1u) {
+                _stats.resident_bytes -= entry->first.size;
+                _stats.evictions++;
+                _entries.erase(entry);
+                _lru.erase(iterator);
+                removed = true;
+                break;
+            }
+        }
+        if (!removed) { return false; }
+    }
+    return true;
+}
+
+BlobCache::BlobPtr BlobCache::find(const BlobKey &key) noexcept {
+    std::scoped_lock lock{_mutex};
+    if (auto iterator = _entries.find(key);
+        iterator != _entries.end()) {
+        _touch(iterator->second);
+        _stats.hits++;
+        return iterator->second.blob;
+    }
+    _stats.misses++;
+    return {};
+}
+
+BlobCache::BlobPtr BlobCache::publish(
+    const BlobKey &key,
+    luisa::span<const std::byte> bytes,
+    BlobCacheError &cache_error,
+    luisa::string &error) noexcept {
+    cache_error = BlobCacheError::NONE;
+    if (key.size != bytes.size() || compute_blob_key(bytes) != key) {
+        cache_error = BlobCacheError::DIGEST_MISMATCH;
+        error = "Remote blob body does not match its declared digest and size.";
+        return {};
+    }
+    auto storage = luisa::make_shared<Blob>();
+    storage->assign(bytes.begin(), bytes.end());
+    std::scoped_lock lock{_mutex};
+    _stats.uploaded_bytes += key.size;
+    if (auto iterator = _entries.find(key);
+        iterator != _entries.end()) {
+        if (!equal_bytes(*iterator->second.blob, bytes)) {
+            cache_error = BlobCacheError::COLLISION;
+            error = "Remote blob-cache digest collision detected.";
+            return {};
+        }
+        _touch(iterator->second);
+        return iterator->second.blob;
+    }
+    if (!_make_space(key.size)) {
+        cache_error = BlobCacheError::CAPACITY;
+        error = "Remote blob cache has no evictable capacity for this upload.";
+        return {};
+    }
+    _lru.emplace_front(key);
+    BlobPtr blob = storage;
+    _entries.emplace(
+        key, Entry{.blob = blob, .lru_iterator = _lru.begin()});
+    _stats.stores++;
+    _stats.resident_bytes += key.size;
+    return blob;
+}
+
+BlobCacheStats BlobCache::stats() const noexcept {
+    std::scoped_lock lock{_mutex};
+    auto stats = _stats;
+    stats.resident_entries = _entries.size();
+    return stats;
+}
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_blob_cache.h
+++ b/src/backends/remote/remote_blob_cache.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <list>
+#include <mutex>
+#include <unordered_map>
+
+#include <luisa/core/stl/memory.h>
+#include <luisa/core/stl/string.h>
+#include <luisa/core/stl/vector.h>
+
+#include "remote_protocol.h"
+
+namespace luisa::compute::remote {
+
+constexpr size_t blob_digest_size = 32u;
+
+struct BlobKey {
+    std::array<std::byte, blob_digest_size> digest{};
+    uint64_t size{};
+
+    [[nodiscard]] bool operator==(const BlobKey &) const noexcept = default;
+};
+
+struct BlobKeyHash {
+    [[nodiscard]] size_t operator()(const BlobKey &key) const noexcept;
+};
+
+[[nodiscard]] BlobKey compute_blob_key(
+    luisa::span<const std::byte> bytes) noexcept;
+
+void write_blob_key(Writer &writer, const BlobKey &key) noexcept;
+[[nodiscard]] bool read_blob_key(Reader &reader, BlobKey &key) noexcept;
+
+struct BlobCacheStats {
+    uint64_t hits{};
+    uint64_t misses{};
+    uint64_t stores{};
+    uint64_t evictions{};
+    uint64_t uploaded_bytes{};
+    uint64_t resident_bytes{};
+    uint64_t resident_entries{};
+};
+
+enum class BlobCacheError {
+    NONE,
+    DIGEST_MISMATCH,
+    COLLISION,
+    CAPACITY,
+};
+
+class BlobCache {
+
+public:
+    using Blob = luisa::vector<std::byte>;
+    using BlobPtr = luisa::shared_ptr<const Blob>;
+
+private:
+    struct Entry {
+        BlobPtr blob;
+        std::list<BlobKey>::iterator lru_iterator;
+    };
+
+    uint64_t _capacity_bytes{};
+    mutable std::mutex _mutex;
+    std::list<BlobKey> _lru;
+    std::unordered_map<BlobKey, Entry, BlobKeyHash> _entries;
+    BlobCacheStats _stats;
+
+private:
+    void _touch(Entry &entry) noexcept;
+    [[nodiscard]] bool _make_space(uint64_t size) noexcept;
+
+public:
+    explicit BlobCache(uint64_t capacity_bytes) noexcept;
+
+    [[nodiscard]] uint64_t capacity_bytes() const noexcept {
+        return _capacity_bytes;
+    }
+
+    [[nodiscard]] BlobPtr find(const BlobKey &key) noexcept;
+
+    [[nodiscard]] BlobPtr publish(
+        const BlobKey &key,
+        luisa::span<const std::byte> bytes,
+        BlobCacheError &cache_error,
+        luisa::string &error) noexcept;
+
+    [[nodiscard]] BlobCacheStats stats() const noexcept;
+};
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_command_codec.cpp
+++ b/src/backends/remote/remote_command_codec.cpp
@@ -1,0 +1,1334 @@
+#include "remote_command_codec.h"
+
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <new>
+#include <type_traits>
+#include <unordered_map>
+
+#include <luisa/core/mathematics.h>
+#include <luisa/core/stl/optional.h>
+#include <luisa/runtime/rhi/pixel.h>
+
+#include "../common/indirect_dispatch_layout.h"
+
+namespace luisa::compute::remote {
+
+namespace {
+
+void write_uint3(Writer &writer, uint3 value) noexcept {
+    writer.write_u32(value.x);
+    writer.write_u32(value.y);
+    writer.write_u32(value.z);
+}
+
+[[nodiscard]] uint3 read_uint3(Reader &reader) noexcept {
+    return uint3{reader.read_u32(), reader.read_u32(), reader.read_u32()};
+}
+
+[[nodiscard]] bool valid_range(
+    uint64_t offset, uint64_t size, size_t total) noexcept {
+    return offset <= total && size <= static_cast<uint64_t>(total) - offset;
+}
+
+[[nodiscard]] bool valid_storage(uint32_t value) noexcept {
+    return value < pixel_storage_count;
+}
+
+[[nodiscard]] bool texture_byte_size(
+    PixelStorage storage, uint3 size, size_t &bytes) noexcept {
+    auto result = checked_pixel_storage_size(storage, size);
+    if (!result) { return false; }
+    bytes = result.size;
+    return true;
+}
+
+[[nodiscard]] bool valid_texture_region(
+    const ResolvedTexture &texture, PixelStorage storage,
+    uint32_t level, uint3 size, uint3 offset) noexcept {
+    if (storage != texture.storage || level >= texture.mip_levels ||
+        any(size == 0u)) {
+        return false;
+    }
+    auto mip_size = luisa::max(texture.size >> level, 1u);
+    return offset.x <= mip_size.x && size.x <= mip_size.x - offset.x &&
+           offset.y <= mip_size.y && size.y <= mip_size.y - offset.y &&
+           offset.z <= mip_size.z && size.z <= mip_size.z - offset.z;
+}
+
+}// namespace
+
+uint32_t UploadBlobPlan::find(
+    size_t command_index) const noexcept {
+    for (auto &&reference : references) {
+        if (reference.command_index == command_index) {
+            return reference.index;
+        }
+    }
+    return invalid_blob_index;
+}
+
+UploadBlobPlan plan_upload_blobs(
+    luisa::span<const luisa::unique_ptr<Command>> commands,
+    uint64_t minimum_blob_size,
+    uint64_t maximum_blob_size,
+    const ProtocolLimits &limits) noexcept {
+    UploadBlobPlan result;
+    if (maximum_blob_size == 0u ||
+        minimum_blob_size > maximum_blob_size) {
+        return result;
+    }
+    std::unordered_map<BlobKey, uint32_t, BlobKeyHash> indices;
+    for (size_t command_index = 0u;
+         command_index < commands.size(); command_index++) {
+        auto &&command_ptr = commands[command_index];
+        if (command_ptr == nullptr) {
+            result.error = "Remote command list contains a null command.";
+            return result;
+        }
+        const void *data = nullptr;
+        size_t size = 0u;
+        switch (command_ptr->tag()) {
+            case Command::Tag::EBufferUploadCommand: {
+                auto command = static_cast<const BufferUploadCommand *>(
+                    command_ptr.get());
+                data = command->data();
+                size = command->size();
+                break;
+            }
+            case Command::Tag::ETextureUploadCommand: {
+                auto command = static_cast<const TextureUploadCommand *>(
+                    command_ptr.get());
+                if (!texture_byte_size(
+                        command->storage(), command->size(), size)) {
+                    result.error =
+                        "Remote texture upload has an invalid storage or extent.";
+                    return result;
+                }
+                data = command->data();
+                break;
+            }
+            default: continue;
+        }
+        if (size != 0u && data == nullptr) {
+            result.error = "Remote upload has a null source.";
+            return result;
+        }
+        if (size == 0u || size < minimum_blob_size ||
+            size > maximum_blob_size) {
+            continue;
+        }
+        auto bytes = luisa::span{
+            static_cast<const std::byte *>(data), size};
+        auto key = compute_blob_key(bytes);
+        uint32_t index{};
+        if (auto iterator = indices.find(key);
+            iterator != indices.end()) {
+            index = iterator->second;
+            auto existing = result.blobs[index].bytes;
+            if (existing.size() != bytes.size() ||
+                (!bytes.empty() && std::memcmp(
+                                       existing.data(), bytes.data(),
+                                       bytes.size()) != 0)) {
+                result.error =
+                    "Remote upload blob digest collision detected locally.";
+                return result;
+            }
+        } else {
+            if (result.blobs.size() >= limits.max_array_size ||
+                result.blobs.size() >= invalid_blob_index) {
+                result.error =
+                    "Remote upload blob count exceeds the configured limit.";
+                return result;
+            }
+            index = static_cast<uint32_t>(result.blobs.size());
+            indices.emplace(key, index);
+            result.blobs.emplace_back(UploadBlob{key, bytes});
+        }
+        result.references.emplace_back(
+            UploadBlobReference{command_index, index});
+    }
+    constexpr uint64_t prepare_header_size = 16u;
+    constexpr uint64_t descriptor_size =
+        sizeof(uint64_t) + blob_digest_size;
+    if (result.blobs.size() >
+        (limits.max_frame_payload -
+         std::min(prepare_header_size, limits.max_frame_payload)) /
+            descriptor_size) {
+        result.error =
+            "Remote upload blob descriptors exceed the frame limit.";
+    }
+    return result;
+}
+
+EncodedSubmission encode_submission(
+    uint64_t stream_handle, uint64_t submission_id,
+    luisa::span<const luisa::unique_ptr<Command>> commands,
+    const ProtocolLimits &limits,
+    const UploadBlobPlan *blob_plan) noexcept {
+    EncodedSubmission result;
+    if (commands.size() > limits.max_array_size) {
+        result.error = "Remote command count exceeds the configured limit.";
+        return result;
+    }
+    Writer writer;
+    writer.write_u64(stream_handle);
+    writer.write_u64(submission_id);
+    writer.write_u64(commands.size());
+    for (size_t command_index = 0u;
+         command_index < commands.size(); command_index++) {
+        auto &&command_ptr = commands[command_index];
+        if (command_ptr == nullptr) {
+            result.error = "Remote command list contains a null command.";
+            return result;
+        }
+        auto command = command_ptr.get();
+        switch (command->tag()) {
+            case Command::Tag::EBufferUploadCommand: {
+                auto c = static_cast<const BufferUploadCommand *>(command);
+                if (c->size() != 0u && c->data() == nullptr) {
+                    result.error = "Remote buffer upload has a null source.";
+                    return result;
+                }
+                auto blob_index = blob_plan == nullptr ?
+                                      invalid_blob_index :
+                                      blob_plan->find(command_index);
+                writer.write_u16(static_cast<uint16_t>(
+                    blob_index == invalid_blob_index ?
+                        WireCommand::BUFFER_UPLOAD :
+                        WireCommand::BUFFER_UPLOAD_CACHED));
+                writer.write_u64(c->handle());
+                writer.write_u64(c->offset());
+                writer.write_u64(c->size());
+                if (blob_index == invalid_blob_index) {
+                    writer.write_bytes({static_cast<const std::byte *>(c->data()),
+                                        c->size()});
+                } else {
+                    writer.write_u32(blob_index);
+                }
+                break;
+            }
+            case Command::Tag::EBufferDownloadCommand: {
+                auto c = static_cast<const BufferDownloadCommand *>(command);
+                if (c->size() != 0u && c->data() == nullptr) {
+                    result.error = "Remote buffer download has a null destination.";
+                    return result;
+                }
+                if (result.downloads.size() > std::numeric_limits<uint32_t>::max()) {
+                    result.error = "Remote download count exceeds the wire limit.";
+                    return result;
+                }
+                auto index = static_cast<uint32_t>(result.downloads.size());
+                result.downloads.emplace_back(DownloadTarget{c->data(), c->size()});
+                writer.write_u16(static_cast<uint16_t>(WireCommand::BUFFER_DOWNLOAD));
+                writer.write_u32(index);
+                writer.write_u64(c->handle());
+                writer.write_u64(c->offset());
+                writer.write_u64(c->size());
+                break;
+            }
+            case Command::Tag::EBufferCopyCommand: {
+                auto c = static_cast<const BufferCopyCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::BUFFER_COPY));
+                writer.write_u64(c->src_handle());
+                writer.write_u64(c->dst_handle());
+                writer.write_u64(c->src_offset());
+                writer.write_u64(c->dst_offset());
+                writer.write_u64(c->size());
+                break;
+            }
+            case Command::Tag::EBufferToTextureCopyCommand: {
+                auto c = static_cast<const BufferToTextureCopyCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::BUFFER_TO_TEXTURE_COPY));
+                writer.write_u64(c->buffer());
+                writer.write_u64(c->buffer_offset());
+                writer.write_u64(c->texture());
+                writer.write_u32(static_cast<uint32_t>(c->storage()));
+                writer.write_u32(c->level());
+                write_uint3(writer, c->size());
+                write_uint3(writer, c->texture_offset());
+                break;
+            }
+            case Command::Tag::ETextureToBufferCopyCommand: {
+                auto c = static_cast<const TextureToBufferCopyCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::TEXTURE_TO_BUFFER_COPY));
+                writer.write_u64(c->buffer());
+                writer.write_u64(c->buffer_offset());
+                writer.write_u64(c->texture());
+                writer.write_u32(static_cast<uint32_t>(c->storage()));
+                writer.write_u32(c->level());
+                write_uint3(writer, c->size());
+                write_uint3(writer, c->texture_offset());
+                break;
+            }
+            case Command::Tag::ETextureUploadCommand: {
+                auto c = static_cast<const TextureUploadCommand *>(command);
+                size_t size_bytes{};
+                if (!texture_byte_size(c->storage(), c->size(), size_bytes)) {
+                    result.error = "Remote texture upload has an invalid storage or extent.";
+                    return result;
+                }
+                if (size_bytes != 0u && c->data() == nullptr) {
+                    result.error = "Remote texture upload has a null source.";
+                    return result;
+                }
+                auto blob_index = blob_plan == nullptr ?
+                                      invalid_blob_index :
+                                      blob_plan->find(command_index);
+                writer.write_u16(static_cast<uint16_t>(
+                    blob_index == invalid_blob_index ?
+                        WireCommand::TEXTURE_UPLOAD :
+                        WireCommand::TEXTURE_UPLOAD_CACHED));
+                writer.write_u64(c->handle());
+                writer.write_u32(static_cast<uint32_t>(c->storage()));
+                writer.write_u32(c->level());
+                write_uint3(writer, c->size());
+                write_uint3(writer, c->offset());
+                writer.write_u64(size_bytes);
+                if (blob_index == invalid_blob_index) {
+                    writer.write_bytes({static_cast<const std::byte *>(c->data()),
+                                        size_bytes});
+                } else {
+                    writer.write_u32(blob_index);
+                }
+                break;
+            }
+            case Command::Tag::ETextureDownloadCommand: {
+                auto c = static_cast<const TextureDownloadCommand *>(command);
+                size_t size_bytes{};
+                if (!texture_byte_size(c->storage(), c->size(), size_bytes)) {
+                    result.error = "Remote texture download has an invalid storage or extent.";
+                    return result;
+                }
+                if (size_bytes != 0u && c->data() == nullptr) {
+                    result.error = "Remote texture download has a null destination.";
+                    return result;
+                }
+                if (result.downloads.size() > std::numeric_limits<uint32_t>::max()) {
+                    result.error = "Remote download count exceeds the wire limit.";
+                    return result;
+                }
+                auto index = static_cast<uint32_t>(result.downloads.size());
+                result.downloads.emplace_back(DownloadTarget{c->data(), size_bytes});
+                writer.write_u16(static_cast<uint16_t>(WireCommand::TEXTURE_DOWNLOAD));
+                writer.write_u32(index);
+                writer.write_u64(c->handle());
+                writer.write_u32(static_cast<uint32_t>(c->storage()));
+                writer.write_u32(c->level());
+                write_uint3(writer, c->size());
+                write_uint3(writer, c->offset());
+                writer.write_u64(size_bytes);
+                break;
+            }
+            case Command::Tag::ETextureCopyCommand: {
+                auto c = static_cast<const TextureCopyCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::TEXTURE_COPY));
+                writer.write_u32(static_cast<uint32_t>(c->storage()));
+                writer.write_u64(c->src_handle());
+                writer.write_u64(c->dst_handle());
+                writer.write_u32(c->src_level());
+                writer.write_u32(c->dst_level());
+                write_uint3(writer, c->size());
+                write_uint3(writer, c->src_offset());
+                write_uint3(writer, c->dst_offset());
+                break;
+            }
+            case Command::Tag::EShaderDispatchCommand: {
+                auto c = static_cast<const ShaderDispatchCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::SHADER_DISPATCH));
+                writer.write_u64(c->handle());
+                writer.write_u64(c->arguments().size());
+                for (auto &&argument : c->arguments()) {
+                    writer.write_u8(static_cast<uint8_t>(argument.tag));
+                    switch (argument.tag) {
+                        case Argument::Tag::BUFFER:
+                            writer.write_u64(argument.buffer.handle);
+                            writer.write_u64(argument.buffer.offset);
+                            writer.write_u64(argument.buffer.size);
+                            break;
+                        case Argument::Tag::TEXTURE:
+                            writer.write_u64(argument.texture.handle);
+                            writer.write_u32(argument.texture.level);
+                            break;
+                        case Argument::Tag::UNIFORM:
+                            writer.write_u64(argument.uniform.alignment);
+                            writer.write_blob(c->uniform(argument.uniform));
+                            break;
+                        case Argument::Tag::BINDLESS_ARRAY:
+                            writer.write_u64(argument.bindless_array.handle);
+                            break;
+                        case Argument::Tag::ACCEL:
+                            writer.write_u64(argument.accel.handle);
+                            break;
+                    }
+                }
+                if (c->is_indirect()) {
+                    writer.write_u8(1u);
+                    auto indirect = c->indirect_dispatch();
+                    writer.write_u64(indirect.handle);
+                    writer.write_u32(indirect.offset);
+                    writer.write_u32(indirect.max_dispatch_size);
+                } else if (c->is_multiple_dispatch()) {
+                    writer.write_u8(2u);
+                    auto sizes = c->dispatch_sizes();
+                    writer.write_u64(sizes.size());
+                    for (auto size : sizes) { write_uint3(writer, size); }
+                } else {
+                    writer.write_u8(0u);
+                    write_uint3(writer, c->dispatch_size());
+                }
+                break;
+            }
+            case Command::Tag::EBindlessArrayUpdateCommand: {
+                auto c = static_cast<const BindlessArrayUpdateCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::BINDLESS_ARRAY_UPDATE));
+                writer.write_u64(c->handle());
+                auto write_buffer = [&](const BindlessArrayUpdateCommand::ModifiedBuffer &buffer) noexcept {
+                    writer.write_u8(static_cast<uint8_t>(buffer.op));
+                    if (buffer.op == BindlessArrayUpdateCommand::Operation::EMPLACE) {
+                        writer.write_u64(buffer.handle);
+                        writer.write_u64(buffer.offset_bytes);
+                        writer.write_u64(buffer.size_bytes);
+                    }
+                };
+                auto write_texture = [&](const BindlessArrayUpdateCommand::ModifiedTexture &texture) noexcept {
+                    writer.write_u8(static_cast<uint8_t>(texture.op));
+                    if (texture.op == BindlessArrayUpdateCommand::Operation::EMPLACE) {
+                        writer.write_u64(texture.handle);
+                        writer.write_u32(texture.sampler.code());
+                    }
+                };
+                c->visit_modifications([&](auto const &modifications) noexcept {
+                    using Modification = typename std::remove_cvref_t<decltype(modifications)>::value_type;
+                    if constexpr (std::is_same_v<Modification, BindlessArrayUpdateCommand::Modification>) {
+                        writer.write_u8(0u);
+                    } else if constexpr (std::is_same_v<Modification, BindlessArrayUpdateCommand::BufferModification>) {
+                        writer.write_u8(1u);
+                    } else if constexpr (std::is_same_v<Modification, BindlessArrayUpdateCommand::Texture2DModification>) {
+                        writer.write_u8(2u);
+                    } else {
+                        writer.write_u8(3u);
+                    }
+                    writer.write_u64(modifications.size());
+                    for (auto &&modification : modifications) {
+                        writer.write_u64(modification.slot);
+                        if constexpr (std::is_same_v<Modification, BindlessArrayUpdateCommand::Modification>) {
+                            write_buffer(modification.buffer);
+                            write_texture(modification.tex2d);
+                            write_texture(modification.tex3d);
+                        } else if constexpr (std::is_same_v<Modification, BindlessArrayUpdateCommand::BufferModification>) {
+                            write_buffer(modification.buffer);
+                        } else if constexpr (std::is_same_v<Modification, BindlessArrayUpdateCommand::Texture2DModification>) {
+                            write_texture(modification.tex2d);
+                        } else {
+                            write_texture(modification.tex3d);
+                        }
+                    }
+                });
+                break;
+            }
+            case Command::Tag::EMeshBuildCommand: {
+                auto c = static_cast<const MeshBuildCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::MESH_BUILD));
+                writer.write_u64(c->handle());
+                writer.write_u32(static_cast<uint32_t>(c->request()));
+                writer.write_u64(c->vertex_buffer());
+                writer.write_u64(c->vertex_buffer_offset());
+                writer.write_u64(c->vertex_buffer_size());
+                writer.write_u64(c->vertex_stride());
+                writer.write_u64(c->triangle_buffer());
+                writer.write_u64(c->triangle_buffer_offset());
+                writer.write_u64(c->triangle_buffer_size());
+                break;
+            }
+            case Command::Tag::ECurveBuildCommand: {
+                auto c = static_cast<const CurveBuildCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::CURVE_BUILD));
+                writer.write_u64(c->handle());
+                writer.write_u32(static_cast<uint32_t>(c->request()));
+                writer.write_u32(static_cast<uint32_t>(c->basis()));
+                writer.write_u64(c->cp_count());
+                writer.write_u64(c->seg_count());
+                writer.write_u64(c->cp_buffer());
+                writer.write_u64(c->cp_buffer_offset());
+                writer.write_u64(c->cp_stride());
+                writer.write_u64(c->seg_buffer());
+                writer.write_u64(c->seg_buffer_offset());
+                break;
+            }
+            case Command::Tag::EProceduralPrimitiveBuildCommand: {
+                auto c = static_cast<const ProceduralPrimitiveBuildCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::PROCEDURAL_PRIMITIVE_BUILD));
+                writer.write_u64(c->handle());
+                writer.write_u32(static_cast<uint32_t>(c->request()));
+                writer.write_u64(c->aabb_buffer());
+                writer.write_u64(c->aabb_buffer_offset());
+                writer.write_u64(c->aabb_buffer_size());
+                break;
+            }
+            case Command::Tag::EMotionInstanceBuildCommand: {
+                auto c = static_cast<const MotionInstanceBuildCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::MOTION_INSTANCE_BUILD));
+                writer.write_u64(c->handle());
+                writer.write_u64(c->child());
+                writer.write_u64(c->keyframes().size());
+                for (auto &&keyframe : c->keyframes()) {
+                    for (auto value : keyframe.data) { writer.write_f32(value); }
+                }
+                break;
+            }
+            case Command::Tag::EAccelBuildCommand: {
+                auto c = static_cast<const AccelBuildCommand *>(command);
+                writer.write_u16(static_cast<uint16_t>(WireCommand::ACCEL_BUILD));
+                writer.write_u64(c->handle());
+                writer.write_u32(c->instance_count());
+                writer.write_u32(static_cast<uint32_t>(c->request()));
+                writer.write_bool(c->update_instance_buffer_only());
+                writer.write_u64(c->modifications().size());
+                for (auto &&modification : c->modifications()) {
+                    writer.write_u32(modification.index);
+                    writer.write_u32(modification.user_id);
+                    writer.write_u32(modification.flags);
+                    writer.write_u32(modification.vis_mask);
+                    for (auto value : modification.affine) { writer.write_f32(value); }
+                    if ((modification.flags &
+                         AccelBuildCommand::Modification::flag_primitive) != 0u) {
+                        writer.write_u64(modification.primitive);
+                    }
+                }
+                break;
+            }
+            default:
+                result.error = "Remote backend does not support this command type in protocol v1.";
+                return result;
+        }
+        if (writer.bytes().size() > limits.max_frame_payload) {
+            result.error = "Encoded remote submission exceeds the configured frame limit.";
+            return result;
+        }
+    }
+    result.payload = std::move(writer).take();
+    return result;
+}
+
+DecodedSubmission decode_submission(
+    luisa::span<const std::byte> payload,
+    const CommandHandleResolver &resolver,
+    const ProtocolLimits &limits) noexcept {
+    DecodedSubmission result;
+    Reader reader{payload, limits};
+    result.stream_handle = reader.read_u64();
+    result.submission_id = reader.read_u64();
+    auto command_count = reader.read_u64();
+    auto fail = [&](luisa::string error) noexcept -> DecodedSubmission {
+        result.command_list.clear();
+        result.downloads.clear();
+        result.upload_blobs.clear();
+        result.upload_blob_indices.clear();
+        result.error = std::move(error);
+        return std::move(result);
+    };
+    if (!reader.ok()) { return fail(luisa::string{reader.error()}); }
+    if (result.submission_id == 0u) {
+        return fail("Remote submission ID must be nonzero.");
+    }
+    if (command_count > limits.max_array_size ||
+        command_count > std::numeric_limits<size_t>::max()) {
+        return fail("Remote command count exceeds the configured limit.");
+    }
+    uint64_t completion_size = 26u;// id + status + empty message + count
+    auto reserve_download = [&](uint64_t size) noexcept {
+        constexpr uint64_t per_download_overhead = 12u;// index + blob length
+        if (completion_size > limits.max_frame_payload ||
+            size > limits.max_frame_payload - completion_size ||
+            per_download_overhead >
+                limits.max_frame_payload - completion_size - size) {
+            return false;
+        }
+        completion_size += per_download_overhead + size;
+        return true;
+    };
+    result.command_list.reserve(static_cast<size_t>(command_count), 1u);
+    for (uint64_t command_index = 0u; command_index < command_count; command_index++) {
+        auto wire_command = static_cast<WireCommand>(reader.read_u16());
+        if (!reader.ok()) { return fail(luisa::string{reader.error()}); }
+        switch (wire_command) {
+            case WireCommand::BUFFER_UPLOAD:
+            case WireCommand::BUFFER_UPLOAD_CACHED: {
+                auto remote = reader.read_u64();
+                auto offset = reader.read_u64();
+                auto size = reader.read_u64();
+                uint64_t native{};
+                size_t total{};
+                luisa::string error;
+                if (!resolver.resolve_buffer(remote, native, total, error)) {
+                    return fail(std::move(error));
+                }
+                if (!valid_range(offset, size, total) ||
+                    size > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote buffer upload range is out of bounds.");
+                }
+                const std::byte *data{};
+                if (wire_command == WireCommand::BUFFER_UPLOAD_CACHED) {
+                    auto blob_index = reader.read_u32();
+                    BlobCache::BlobPtr blob;
+                    if (!reader.ok()) {
+                        return fail(luisa::string{reader.error()});
+                    }
+                    if (!resolver.resolve_upload_blob(
+                            result.submission_id, blob_index,
+                            static_cast<size_t>(size), blob, error)) {
+                        return fail(std::move(error));
+                    }
+                    data = blob->data();
+                    result.upload_blobs.emplace_back(std::move(blob));
+                    result.upload_blob_indices.emplace_back(blob_index);
+                } else {
+                    auto inline_data = reader.read_bytes(
+                        static_cast<size_t>(size));
+                    if (!reader.ok()) {
+                        return fail(luisa::string{reader.error()});
+                    }
+                    data = inline_data.data();
+                }
+                result.command_list.append(luisa::make_unique<BufferUploadCommand>(
+                    native, static_cast<size_t>(offset),
+                    static_cast<size_t>(size), data));
+                break;
+            }
+            case WireCommand::BUFFER_DOWNLOAD: {
+                auto download_index = reader.read_u32();
+                auto remote = reader.read_u64();
+                auto offset = reader.read_u64();
+                auto size = reader.read_u64();
+                uint64_t native{};
+                size_t total{};
+                luisa::string error;
+                if (!resolver.resolve_buffer(remote, native, total, error)) {
+                    return fail(std::move(error));
+                }
+                if (!valid_range(offset, size, total) ||
+                    size > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote buffer download range is out of bounds.");
+                }
+                if (download_index != result.downloads.size()) {
+                    return fail("Remote download indices must be contiguous and ordered.");
+                }
+                if (!reserve_download(size)) {
+                    return fail("Remote downloads exceed the completion-frame limit.");
+                }
+                auto storage = luisa::make_shared<luisa::vector<std::byte>>();
+                storage->resize(static_cast<size_t>(size));
+                result.command_list.append(luisa::make_unique<BufferDownloadCommand>(
+                    native, static_cast<size_t>(offset), static_cast<size_t>(size), storage->data()));
+                result.downloads.emplace_back(ServerDownload{download_index, std::move(storage)});
+                break;
+            }
+            case WireCommand::BUFFER_COPY: {
+                auto remote_src = reader.read_u64();
+                auto remote_dst = reader.read_u64();
+                auto src_offset = reader.read_u64();
+                auto dst_offset = reader.read_u64();
+                auto size = reader.read_u64();
+                uint64_t src{};
+                uint64_t dst{};
+                size_t src_total{};
+                size_t dst_total{};
+                luisa::string error;
+                if (!resolver.resolve_buffer(remote_src, src, src_total, error) ||
+                    !resolver.resolve_buffer(remote_dst, dst, dst_total, error)) {
+                    return fail(std::move(error));
+                }
+                if (!valid_range(src_offset, size, src_total) ||
+                    !valid_range(dst_offset, size, dst_total) ||
+                    size > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote buffer copy range is out of bounds.");
+                }
+                result.command_list.append(luisa::make_unique<BufferCopyCommand>(
+                    src, dst, static_cast<size_t>(src_offset),
+                    static_cast<size_t>(dst_offset), static_cast<size_t>(size)));
+                break;
+            }
+            case WireCommand::BUFFER_TO_TEXTURE_COPY:
+            case WireCommand::TEXTURE_TO_BUFFER_COPY: {
+                auto remote_buffer = reader.read_u64();
+                auto buffer_offset = reader.read_u64();
+                auto remote_texture = reader.read_u64();
+                auto storage_value = reader.read_u32();
+                auto level = reader.read_u32();
+                auto size = read_uint3(reader);
+                auto texture_offset = read_uint3(reader);
+                uint64_t buffer{};
+                ResolvedTexture texture;
+                size_t buffer_total{};
+                size_t size_bytes{};
+                luisa::string error;
+                if (!valid_storage(storage_value) ||
+                    !texture_byte_size(static_cast<PixelStorage>(storage_value), size, size_bytes)) {
+                    return fail("Remote texture copy has an invalid storage or extent.");
+                }
+                if (!resolver.resolve_buffer(remote_buffer, buffer, buffer_total, error) ||
+                    !resolver.resolve_texture_descriptor(
+                        remote_texture, texture, error)) {
+                    return fail(std::move(error));
+                }
+                auto storage = static_cast<PixelStorage>(storage_value);
+                if (!valid_range(buffer_offset, size_bytes, buffer_total) ||
+                    !valid_texture_region(
+                        texture, storage, level, size, texture_offset)) {
+                    return fail("Remote texture copy range or storage is invalid.");
+                }
+                if (wire_command == WireCommand::BUFFER_TO_TEXTURE_COPY) {
+                    result.command_list.append(luisa::make_unique<BufferToTextureCopyCommand>(
+                        buffer, static_cast<size_t>(buffer_offset), texture.handle,
+                        storage, level, size, texture_offset));
+                } else {
+                    result.command_list.append(luisa::make_unique<TextureToBufferCopyCommand>(
+                        buffer, static_cast<size_t>(buffer_offset), texture.handle,
+                        storage, level, size, texture_offset));
+                }
+                break;
+            }
+            case WireCommand::TEXTURE_UPLOAD:
+            case WireCommand::TEXTURE_UPLOAD_CACHED: {
+                auto remote = reader.read_u64();
+                auto storage_value = reader.read_u32();
+                auto level = reader.read_u32();
+                auto size = read_uint3(reader);
+                auto offset = read_uint3(reader);
+                auto declared_size = reader.read_u64();
+                ResolvedTexture texture;
+                size_t expected_size{};
+                luisa::string error;
+                if (!valid_storage(storage_value) ||
+                    !texture_byte_size(static_cast<PixelStorage>(storage_value), size, expected_size) ||
+                    declared_size != expected_size) {
+                    return fail("Remote texture upload byte size is invalid.");
+                }
+                if (!resolver.resolve_texture_descriptor(remote, texture, error)) {
+                    return fail(std::move(error));
+                }
+                auto transfer_storage = static_cast<PixelStorage>(storage_value);
+                if (!valid_texture_region(
+                        texture, transfer_storage, level, size, offset)) {
+                    return fail("Remote texture upload range or storage is invalid.");
+                }
+                const std::byte *data{};
+                if (wire_command == WireCommand::TEXTURE_UPLOAD_CACHED) {
+                    auto blob_index = reader.read_u32();
+                    BlobCache::BlobPtr blob;
+                    if (!reader.ok()) {
+                        return fail(luisa::string{reader.error()});
+                    }
+                    if (!resolver.resolve_upload_blob(
+                            result.submission_id, blob_index,
+                            expected_size, blob, error)) {
+                        return fail(std::move(error));
+                    }
+                    data = blob->data();
+                    result.upload_blobs.emplace_back(std::move(blob));
+                    result.upload_blob_indices.emplace_back(blob_index);
+                } else {
+                    auto inline_data = reader.read_bytes(expected_size);
+                    if (!reader.ok()) {
+                        return fail(luisa::string{reader.error()});
+                    }
+                    data = inline_data.data();
+                }
+                result.command_list.append(luisa::make_unique<TextureUploadCommand>(
+                    texture.handle, transfer_storage, level,
+                    size, data, offset));
+                break;
+            }
+            case WireCommand::TEXTURE_DOWNLOAD: {
+                auto download_index = reader.read_u32();
+                auto remote = reader.read_u64();
+                auto storage_value = reader.read_u32();
+                auto level = reader.read_u32();
+                auto size = read_uint3(reader);
+                auto offset = read_uint3(reader);
+                auto declared_size = reader.read_u64();
+                ResolvedTexture texture;
+                size_t expected_size{};
+                luisa::string error;
+                if (!valid_storage(storage_value) ||
+                    !texture_byte_size(static_cast<PixelStorage>(storage_value), size, expected_size) ||
+                    declared_size != expected_size) {
+                    return fail("Remote texture download byte size is invalid.");
+                }
+                if (!resolver.resolve_texture_descriptor(remote, texture, error)) {
+                    return fail(std::move(error));
+                }
+                auto transfer_storage = static_cast<PixelStorage>(storage_value);
+                if (!valid_texture_region(
+                        texture, transfer_storage, level, size, offset)) {
+                    return fail("Remote texture download range or storage is invalid.");
+                }
+                if (download_index != result.downloads.size()) {
+                    return fail("Remote download indices must be contiguous and ordered.");
+                }
+                if (!reserve_download(expected_size)) {
+                    return fail("Remote downloads exceed the completion-frame limit.");
+                }
+                auto staging = luisa::make_shared<luisa::vector<std::byte>>();
+                staging->resize(expected_size);
+                result.command_list.append(luisa::make_unique<TextureDownloadCommand>(
+                    texture.handle, transfer_storage, level,
+                    size, staging->data(), offset));
+                result.downloads.emplace_back(ServerDownload{download_index, std::move(staging)});
+                break;
+            }
+            case WireCommand::TEXTURE_COPY: {
+                auto storage_value = reader.read_u32();
+                auto remote_src = reader.read_u64();
+                auto remote_dst = reader.read_u64();
+                auto src_level = reader.read_u32();
+                auto dst_level = reader.read_u32();
+                auto size = read_uint3(reader);
+                auto src_offset = read_uint3(reader);
+                auto dst_offset = read_uint3(reader);
+                ResolvedTexture src;
+                ResolvedTexture dst;
+                size_t unused{};
+                luisa::string error;
+                if (!valid_storage(storage_value) ||
+                    !texture_byte_size(static_cast<PixelStorage>(storage_value), size, unused)) {
+                    return fail("Remote texture copy has an invalid storage or extent.");
+                }
+                if (!resolver.resolve_texture_descriptor(remote_src, src, error) ||
+                    !resolver.resolve_texture_descriptor(remote_dst, dst, error)) {
+                    return fail(std::move(error));
+                }
+                auto storage = static_cast<PixelStorage>(storage_value);
+                if (!valid_texture_region(
+                        src, storage, src_level, size, src_offset) ||
+                    !valid_texture_region(
+                        dst, storage, dst_level, size, dst_offset)) {
+                    return fail("Remote texture copy range or storage is invalid.");
+                }
+                result.command_list.append(luisa::make_unique<TextureCopyCommand>(
+                    storage, src.handle, dst.handle,
+                    src_level, dst_level, size, src_offset, dst_offset));
+                break;
+            }
+            case WireCommand::SHADER_DISPATCH: {
+                auto remote_shader = reader.read_u64();
+                auto argument_count = reader.read_u64();
+                ResolvedShader resolved_shader;
+                luisa::string error;
+                if (!resolver.resolve_shader(
+                        remote_shader, resolved_shader, error)) {
+                    return fail(std::move(error));
+                }
+                if (argument_count > limits.max_array_size ||
+                    argument_count >
+                        std::numeric_limits<size_t>::max() / sizeof(Argument) ||
+                    argument_count != resolved_shader.arguments.size()) {
+                    return fail("Remote shader argument count does not match the shader signature.");
+                }
+                auto argument_count_size = static_cast<size_t>(argument_count);
+                luisa::vector<std::byte> argument_buffer;
+                argument_buffer.resize(argument_count_size * sizeof(Argument));
+                for (size_t i = 0u; i < argument_count_size; i++) {
+                    Argument argument{};
+                    argument.tag = static_cast<Argument::Tag>(reader.read_u8());
+                    auto expected = resolved_shader.arguments[i];
+                    if (argument.tag != expected.tag) {
+                        return fail("Remote shader argument tag does not match the shader signature.");
+                    }
+                    switch (argument.tag) {
+                        case Argument::Tag::BUFFER: {
+                            auto remote = reader.read_u64();
+                            auto offset = reader.read_u64();
+                            auto size = reader.read_u64();
+                            ResolvedBuffer buffer;
+                            if (!resolver.resolve_buffer_descriptor(
+                                    remote, buffer, error)) {
+                                return fail(std::move(error));
+                            }
+                            if (buffer.is_indirect_dispatch !=
+                                expected.indirect_dispatch_buffer) {
+                                return fail("Remote shader buffer kind does not match the shader signature.");
+                            }
+                            auto total = buffer.is_indirect_dispatch ?
+                                             buffer.indirect_dispatch_capacity :
+                                             buffer.size_bytes;
+                            if (!valid_range(offset, size, total) ||
+                                offset > std::numeric_limits<size_t>::max() ||
+                                size > std::numeric_limits<size_t>::max()) {
+                                return fail("Remote shader buffer argument is out of bounds.");
+                            }
+                            argument.buffer.handle = buffer.handle;
+                            argument.buffer.offset = static_cast<size_t>(offset);
+                            argument.buffer.size = static_cast<size_t>(size);
+                            break;
+                        }
+                        case Argument::Tag::TEXTURE: {
+                            ResolvedTexture texture;
+                            if (!resolver.resolve_texture_descriptor(
+                                    reader.read_u64(), texture, error)) {
+                                return fail(std::move(error));
+                            }
+                            argument.texture.level = reader.read_u32();
+                            if (argument.texture.level >= texture.mip_levels) {
+                                return fail("Remote shader texture level is out of bounds.");
+                            }
+                            argument.texture.handle = texture.handle;
+                            break;
+                        }
+                        case Argument::Tag::UNIFORM: {
+                            auto alignment = reader.read_u64();
+                            auto value = reader.read_blob();
+                            if (alignment == 0u || alignment > 16u ||
+                                (alignment & (alignment - 1u)) != 0u ||
+                                alignment != expected.uniform_alignment ||
+                                value.size() != expected.uniform_size) {
+                                return fail("Remote shader uniform layout does not match the shader signature.");
+                            }
+                            auto mask = static_cast<size_t>(alignment - 1u);
+                            auto aligned_offset =
+                                (argument_buffer.size() + mask) & ~mask;
+                            argument_buffer.resize(aligned_offset);
+                            argument.uniform.offset = argument_buffer.size();
+                            argument.uniform.size = value.size();
+                            argument.uniform.alignment = static_cast<size_t>(alignment);
+                            argument_buffer.insert(
+                                argument_buffer.end(), value.begin(), value.end());
+                            break;
+                        }
+                        case Argument::Tag::BINDLESS_ARRAY:
+                            if (!resolver.resolve_bindless_array(
+                                    reader.read_u64(), argument.bindless_array.handle, error)) {
+                                return fail(std::move(error));
+                            }
+                            break;
+                        case Argument::Tag::ACCEL:
+                            if (!resolver.resolve_accel(
+                                    reader.read_u64(), argument.accel.handle, error)) {
+                                return fail(std::move(error));
+                            }
+                            break;
+                        default:
+                            return fail("Remote shader argument tag is invalid.");
+                    }
+                    if (!reader.ok()) { return fail(luisa::string{reader.error()}); }
+                    std::memcpy(argument_buffer.data() + i * sizeof(Argument),
+                                &argument, sizeof(Argument));
+                }
+                auto dispatch_kind = reader.read_u8();
+                if (dispatch_kind == 0u) {
+                    result.command_list.append(luisa::make_unique<ShaderDispatchCommand>(
+                        resolved_shader.handle, std::move(argument_buffer), argument_count_size,
+                        read_uint3(reader)));
+                } else if (dispatch_kind == 1u) {
+                    auto remote_indirect = reader.read_u64();
+                    IndirectDispatchArg indirect{};
+                    ResolvedBuffer buffer;
+                    if (!resolver.resolve_buffer_descriptor(
+                            remote_indirect, buffer, error)) {
+                        return fail(std::move(error));
+                    }
+                    indirect.offset = reader.read_u32();
+                    indirect.max_dispatch_size = reader.read_u32();
+                    auto plan = lc::plan_indirect_dispatch(
+                        buffer.indirect_dispatch_capacity,
+                        indirect.offset, indirect.max_dispatch_size);
+                    if (!buffer.is_indirect_dispatch || !plan) {
+                        return fail("Remote indirect dispatch requires a valid indirect-dispatch buffer range.");
+                    }
+                    indirect.handle = buffer.handle;
+                    result.command_list.append(luisa::make_unique<ShaderDispatchCommand>(
+                        resolved_shader.handle, std::move(argument_buffer),
+                        argument_count_size, indirect));
+                } else if (dispatch_kind == 2u) {
+                    auto dispatch_count = reader.read_u64();
+                    if (dispatch_count > limits.max_array_size ||
+                        dispatch_count > std::numeric_limits<size_t>::max()) {
+                        return fail("Remote dispatch count exceeds the configured limit.");
+                    }
+                    luisa::vector<uint3> dispatches;
+                    dispatches.reserve(static_cast<size_t>(dispatch_count));
+                    for (uint64_t i = 0u; i < dispatch_count; i++) {
+                        dispatches.emplace_back(read_uint3(reader));
+                    }
+                    result.command_list.append(luisa::make_unique<ShaderDispatchCommand>(
+                        resolved_shader.handle, std::move(argument_buffer), argument_count_size,
+                        std::move(dispatches)));
+                } else {
+                    return fail("Remote shader dispatch kind is invalid.");
+                }
+                break;
+            }
+            case WireCommand::BINDLESS_ARRAY_UPDATE: {
+                auto remote_array = reader.read_u64();
+                auto variant = reader.read_u8();
+                auto modification_count = reader.read_u64();
+                uint64_t native_array{};
+                size_t slot_count{};
+                BindlessSlotType slot_type{};
+                luisa::string error;
+                if (!resolver.resolve_bindless_array_for_update(
+                        remote_array, native_array, slot_count,
+                        slot_type, error)) {
+                    return fail(std::move(error));
+                }
+                if (variant > 3u ||
+                    variant != static_cast<uint8_t>(slot_type) ||
+                    modification_count > limits.max_array_size ||
+                    modification_count > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote bindless update variant or count is invalid.");
+                }
+                auto read_buffer = [&](BindlessArrayUpdateCommand::ModifiedBuffer &buffer) noexcept {
+                    auto operation = static_cast<BindlessArrayUpdateCommand::Operation>(reader.read_u8());
+                    if (operation == BindlessArrayUpdateCommand::Operation::NONE) {
+                        buffer = {};
+                        return true;
+                    }
+                    if (operation == BindlessArrayUpdateCommand::Operation::REMOVE) {
+                        buffer = BindlessArrayUpdateCommand::ModifiedBuffer::remove();
+                        return true;
+                    }
+                    if (operation != BindlessArrayUpdateCommand::Operation::EMPLACE) {
+                        error = "Remote bindless buffer operation is invalid.";
+                        return false;
+                    }
+                    auto remote = reader.read_u64();
+                    auto offset = reader.read_u64();
+                    auto size = reader.read_u64();
+                    uint64_t native{};
+                    size_t total{};
+                    if (!resolver.resolve_buffer(remote, native, total, error)) {
+                        return false;
+                    }
+                    auto whole = BindlessArrayUpdateCommand::ModifiedBuffer::whole_buffer_size;
+                    if (offset > std::numeric_limits<size_t>::max() ||
+                        size > std::numeric_limits<size_t>::max() ||
+                        (size == whole ? offset > total :
+                                         !valid_range(offset, size, total))) {
+                        error = "Remote bindless buffer range is out of bounds.";
+                        return false;
+                    }
+                    buffer = BindlessArrayUpdateCommand::ModifiedBuffer::emplace(
+                        native, static_cast<size_t>(offset), static_cast<size_t>(size));
+                    return true;
+                };
+                auto read_texture = [&](BindlessArrayUpdateCommand::ModifiedTexture &texture) noexcept {
+                    auto operation = static_cast<BindlessArrayUpdateCommand::Operation>(reader.read_u8());
+                    if (operation == BindlessArrayUpdateCommand::Operation::NONE) {
+                        texture = {};
+                        return true;
+                    }
+                    if (operation == BindlessArrayUpdateCommand::Operation::REMOVE) {
+                        texture = BindlessArrayUpdateCommand::ModifiedTexture::remove();
+                        return true;
+                    }
+                    if (operation != BindlessArrayUpdateCommand::Operation::EMPLACE) {
+                        error = "Remote bindless texture operation is invalid.";
+                        return false;
+                    }
+                    uint64_t native{};
+                    if (!resolver.resolve_texture(reader.read_u64(), native, error)) {
+                        return false;
+                    }
+                    auto sampler_code = reader.read_u32();
+                    if (sampler_code > 15u) {
+                        error = "Remote bindless sampler code is invalid.";
+                        return false;
+                    }
+                    texture = BindlessArrayUpdateCommand::ModifiedTexture::emplace(
+                        native, Sampler::decode(sampler_code));
+                    return true;
+                };
+                auto read_slot = [&]() noexcept -> luisa::optional<size_t> {
+                    auto slot = reader.read_u64();
+                    if (slot >= slot_count || slot > std::numeric_limits<size_t>::max()) {
+                        error = "Remote bindless slot is out of bounds.";
+                        return luisa::nullopt;
+                    }
+                    return static_cast<size_t>(slot);
+                };
+                auto count = static_cast<size_t>(modification_count);
+                if (variant == 0u) {
+                    luisa::vector<BindlessArrayUpdateCommand::Modification> modifications;
+                    modifications.reserve(count);
+                    for (size_t i = 0u; i < count; i++) {
+                        auto slot = read_slot();
+                        BindlessArrayUpdateCommand::ModifiedBuffer buffer;
+                        BindlessArrayUpdateCommand::ModifiedTexture tex2d;
+                        BindlessArrayUpdateCommand::ModifiedTexture tex3d;
+                        if (!slot || !read_buffer(buffer) ||
+                            !read_texture(tex2d) || !read_texture(tex3d)) {
+                            return fail(error.empty() ? luisa::string{reader.error()} : std::move(error));
+                        }
+                        modifications.emplace_back(*slot, buffer, tex2d, tex3d);
+                    }
+                    result.command_list.append(luisa::make_unique<BindlessArrayUpdateCommand>(
+                        native_array, std::move(modifications)));
+                } else if (variant == 1u) {
+                    luisa::vector<BindlessArrayUpdateCommand::BufferModification> modifications;
+                    modifications.reserve(count);
+                    for (size_t i = 0u; i < count; i++) {
+                        auto slot = read_slot();
+                        BindlessArrayUpdateCommand::ModifiedBuffer buffer;
+                        if (!slot || !read_buffer(buffer)) {
+                            return fail(error.empty() ? luisa::string{reader.error()} : std::move(error));
+                        }
+                        modifications.emplace_back(*slot, buffer);
+                    }
+                    result.command_list.append(luisa::make_unique<BindlessArrayUpdateCommand>(
+                        native_array, std::move(modifications)));
+                } else if (variant == 2u) {
+                    luisa::vector<BindlessArrayUpdateCommand::Texture2DModification> modifications;
+                    modifications.reserve(count);
+                    for (size_t i = 0u; i < count; i++) {
+                        auto slot = read_slot();
+                        BindlessArrayUpdateCommand::ModifiedTexture texture;
+                        if (!slot || !read_texture(texture)) {
+                            return fail(error.empty() ? luisa::string{reader.error()} : std::move(error));
+                        }
+                        modifications.emplace_back(*slot, texture);
+                    }
+                    result.command_list.append(luisa::make_unique<BindlessArrayUpdateCommand>(
+                        native_array, std::move(modifications)));
+                } else {
+                    luisa::vector<BindlessArrayUpdateCommand::Texture3DModification> modifications;
+                    modifications.reserve(count);
+                    for (size_t i = 0u; i < count; i++) {
+                        auto slot = read_slot();
+                        BindlessArrayUpdateCommand::ModifiedTexture texture;
+                        if (!slot || !read_texture(texture)) {
+                            return fail(error.empty() ? luisa::string{reader.error()} : std::move(error));
+                        }
+                        modifications.emplace_back(*slot, texture);
+                    }
+                    result.command_list.append(luisa::make_unique<BindlessArrayUpdateCommand>(
+                        native_array, std::move(modifications)));
+                }
+                break;
+            }
+            case WireCommand::MESH_BUILD: {
+                auto remote_mesh = reader.read_u64();
+                auto request_value = reader.read_u32();
+                auto remote_vertex_buffer = reader.read_u64();
+                auto vertex_offset = reader.read_u64();
+                auto vertex_size = reader.read_u64();
+                auto vertex_stride = reader.read_u64();
+                auto remote_triangle_buffer = reader.read_u64();
+                auto triangle_offset = reader.read_u64();
+                auto triangle_size = reader.read_u64();
+                uint64_t mesh{};
+                uint64_t vertex_buffer{};
+                uint64_t triangle_buffer{};
+                size_t vertex_total{};
+                size_t triangle_total{};
+                luisa::string error;
+                if (request_value > static_cast<uint32_t>(AccelBuildRequest::FORCE_BUILD) ||
+                    vertex_stride == 0u ||
+                    vertex_stride > std::numeric_limits<size_t>::max() ||
+                    !resolver.resolve_mesh(remote_mesh, mesh, error) ||
+                    !resolver.resolve_buffer(
+                        remote_vertex_buffer, vertex_buffer, vertex_total, error) ||
+                    !resolver.resolve_buffer(
+                        remote_triangle_buffer, triangle_buffer, triangle_total, error)) {
+                    return fail(error.empty() ? "Remote mesh-build descriptor is invalid." : std::move(error));
+                }
+                if (!valid_range(vertex_offset, vertex_size, vertex_total) ||
+                    !valid_range(triangle_offset, triangle_size, triangle_total) ||
+                    vertex_offset > std::numeric_limits<size_t>::max() ||
+                    vertex_size > std::numeric_limits<size_t>::max() ||
+                    triangle_offset > std::numeric_limits<size_t>::max() ||
+                    triangle_size > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote mesh-build buffer range is out of bounds.");
+                }
+                result.command_list.append(luisa::make_unique<MeshBuildCommand>(
+                    mesh, static_cast<AccelBuildRequest>(request_value),
+                    vertex_buffer, static_cast<size_t>(vertex_offset),
+                    static_cast<size_t>(vertex_size), static_cast<size_t>(vertex_stride),
+                    triangle_buffer, static_cast<size_t>(triangle_offset),
+                    static_cast<size_t>(triangle_size)));
+                break;
+            }
+            case WireCommand::CURVE_BUILD: {
+                auto remote_curve = reader.read_u64();
+                auto request_value = reader.read_u32();
+                auto basis_value = reader.read_u32();
+                auto cp_count = reader.read_u64();
+                auto seg_count = reader.read_u64();
+                auto remote_cp_buffer = reader.read_u64();
+                auto cp_offset = reader.read_u64();
+                auto cp_stride = reader.read_u64();
+                auto remote_seg_buffer = reader.read_u64();
+                auto seg_offset = reader.read_u64();
+                uint64_t curve{};
+                uint64_t cp_buffer{};
+                uint64_t seg_buffer{};
+                size_t cp_total{};
+                size_t seg_total{};
+                luisa::string error;
+                if (request_value > static_cast<uint32_t>(AccelBuildRequest::FORCE_BUILD) ||
+                    basis_value >= curve_basis_count || cp_stride == 0u ||
+                    cp_count > limits.max_array_size ||
+                    seg_count > limits.max_array_size ||
+                    cp_count > std::numeric_limits<size_t>::max() ||
+                    seg_count > std::numeric_limits<size_t>::max() ||
+                    cp_stride > std::numeric_limits<size_t>::max() ||
+                    !resolver.resolve_curve(remote_curve, curve, error) ||
+                    !resolver.resolve_buffer(remote_cp_buffer, cp_buffer, cp_total, error) ||
+                    !resolver.resolve_buffer(remote_seg_buffer, seg_buffer, seg_total, error)) {
+                    return fail(error.empty() ? "Remote curve-build descriptor is invalid." : std::move(error));
+                }
+                if (cp_count > std::numeric_limits<uint64_t>::max() / cp_stride ||
+                    seg_count > std::numeric_limits<uint64_t>::max() / sizeof(uint)) {
+                    return fail("Remote curve-build byte-size overflow.");
+                }
+                auto cp_size = cp_count * cp_stride;
+                auto seg_size = seg_count * sizeof(uint);
+                if (!valid_range(cp_offset, cp_size, cp_total) ||
+                    !valid_range(seg_offset, seg_size, seg_total) ||
+                    cp_offset > std::numeric_limits<size_t>::max() ||
+                    seg_offset > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote curve-build buffer range is out of bounds.");
+                }
+                result.command_list.append(luisa::make_unique<CurveBuildCommand>(
+                    curve, static_cast<AccelBuildRequest>(request_value),
+                    static_cast<CurveBasis>(basis_value),
+                    static_cast<size_t>(cp_count), static_cast<size_t>(seg_count),
+                    cp_buffer, static_cast<size_t>(cp_offset),
+                    static_cast<size_t>(cp_stride), seg_buffer,
+                    static_cast<size_t>(seg_offset)));
+                break;
+            }
+            case WireCommand::PROCEDURAL_PRIMITIVE_BUILD: {
+                auto remote_primitive = reader.read_u64();
+                auto request_value = reader.read_u32();
+                auto remote_buffer = reader.read_u64();
+                auto offset = reader.read_u64();
+                auto size = reader.read_u64();
+                uint64_t primitive{};
+                uint64_t buffer{};
+                size_t total{};
+                luisa::string error;
+                if (request_value > static_cast<uint32_t>(AccelBuildRequest::FORCE_BUILD) ||
+                    !resolver.resolve_procedural_primitive(
+                        remote_primitive, primitive, error) ||
+                    !resolver.resolve_buffer(remote_buffer, buffer, total, error)) {
+                    return fail(error.empty() ? "Remote procedural-build descriptor is invalid." : std::move(error));
+                }
+                if (!valid_range(offset, size, total) ||
+                    offset > std::numeric_limits<size_t>::max() ||
+                    size > std::numeric_limits<size_t>::max()) {
+                    return fail("Remote procedural-build buffer range is out of bounds.");
+                }
+                result.command_list.append(
+                    luisa::make_unique<ProceduralPrimitiveBuildCommand>(
+                        primitive, static_cast<AccelBuildRequest>(request_value),
+                        buffer, static_cast<size_t>(offset), static_cast<size_t>(size)));
+                break;
+            }
+            case WireCommand::MOTION_INSTANCE_BUILD: {
+                auto remote_instance = reader.read_u64();
+                auto remote_child = reader.read_u64();
+                auto keyframe_count = reader.read_u64();
+                uint64_t instance{};
+                uint64_t child{};
+                size_t expected_keyframes{};
+                luisa::string error;
+                if (!resolver.resolve_motion_instance(
+                        remote_instance, instance, expected_keyframes, error) ||
+                    !resolver.resolve_primitive(remote_child, child, error)) {
+                    return fail(std::move(error));
+                }
+                if (keyframe_count != expected_keyframes ||
+                    keyframe_count > limits.max_array_size) {
+                    return fail("Remote motion-instance keyframe count is invalid.");
+                }
+                luisa::vector<MotionInstanceTransform> keyframes;
+                keyframes.resize(expected_keyframes);
+                for (auto &keyframe : keyframes) {
+                    for (auto &value : keyframe.data) {
+                        value = reader.read_f32();
+                        if (!std::isfinite(value)) {
+                            return fail("Remote motion-instance transform is not finite.");
+                        }
+                    }
+                }
+                result.command_list.append(
+                    luisa::make_unique<MotionInstanceBuildCommand>(
+                        instance, child, std::move(keyframes)));
+                break;
+            }
+            case WireCommand::ACCEL_BUILD: {
+                auto remote_accel = reader.read_u64();
+                auto instance_count = reader.read_u32();
+                auto request_value = reader.read_u32();
+                auto update_instance_buffer_only = reader.read_bool();
+                auto modification_count = reader.read_u64();
+                uint64_t accel{};
+                luisa::string error;
+                if (request_value > static_cast<uint32_t>(AccelBuildRequest::FORCE_BUILD) ||
+                    instance_count > limits.max_array_size ||
+                    modification_count > limits.max_array_size ||
+                    modification_count > std::numeric_limits<size_t>::max() ||
+                    !resolver.resolve_accel_resource(remote_accel, accel, error)) {
+                    return fail(error.empty() ? "Remote accel-build descriptor is invalid." : std::move(error));
+                }
+                constexpr auto allowed_flags =
+                    AccelBuildCommand::Modification::flag_primitive |
+                    AccelBuildCommand::Modification::flag_transform |
+                    AccelBuildCommand::Modification::flag_opaque |
+                    AccelBuildCommand::Modification::flag_visibility |
+                    AccelBuildCommand::Modification::flag_user_id;
+                luisa::vector<AccelBuildCommand::Modification> modifications;
+                modifications.reserve(static_cast<size_t>(modification_count));
+                for (uint64_t i = 0u; i < modification_count; i++) {
+                    AccelBuildCommand::Modification modification;
+                    modification.index = reader.read_u32();
+                    modification.user_id = reader.read_u32();
+                    modification.flags = reader.read_u32();
+                    modification.vis_mask = reader.read_u32();
+                    for (auto &value : modification.affine) {
+                        value = reader.read_f32();
+                        if (!std::isfinite(value)) {
+                            return fail("Remote accel-build transform is not finite.");
+                        }
+                    }
+                    if ((modification.flags & ~allowed_flags) != 0u ||
+                        (modification.flags & AccelBuildCommand::Modification::flag_opaque) ==
+                            AccelBuildCommand::Modification::flag_opaque ||
+                        modification.vis_mask > 0xffu ||
+                        modification.index >= instance_count) {
+                        return fail("Remote accel-build modification is invalid.");
+                    }
+                    if ((modification.flags &
+                         AccelBuildCommand::Modification::flag_primitive) != 0u) {
+                        if (!resolver.resolve_primitive(
+                                reader.read_u64(), modification.primitive, error)) {
+                            return fail(std::move(error));
+                        }
+                    }
+                    modifications.emplace_back(modification);
+                }
+                result.command_list.append(luisa::make_unique<AccelBuildCommand>(
+                    accel, instance_count,
+                    static_cast<AccelBuildRequest>(request_value),
+                    std::move(modifications), update_instance_buffer_only));
+                break;
+            }
+            default:
+                return fail("Remote command kind is unsupported.");
+        }
+        if (!reader.ok()) { return fail(luisa::string{reader.error()}); }
+    }
+    if (!reader.finish()) { return fail(luisa::string{reader.error()}); }
+    auto committed = std::move(result.command_list.commit()).command_list();
+    return DecodedSubmission{
+        .stream_handle = result.stream_handle,
+        .submission_id = result.submission_id,
+        .command_list = std::move(committed),
+        .downloads = std::move(result.downloads),
+        .upload_blobs = std::move(result.upload_blobs),
+        .upload_blob_indices = std::move(result.upload_blob_indices)};
+}
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_command_codec.h
+++ b/src/backends/remote/remote_command_codec.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <luisa/core/stl/memory.h>
+#include <luisa/core/stl/string.h>
+#include <luisa/core/stl/vector.h>
+#include <luisa/runtime/command_list.h>
+#include <luisa/runtime/rhi/device_interface.h>
+
+#include "remote_blob_cache.h"
+#include "remote_protocol.h"
+
+namespace luisa::compute::remote {
+
+enum class WireCommand : uint16_t {
+    BUFFER_UPLOAD = 1u,
+    BUFFER_DOWNLOAD = 2u,
+    BUFFER_COPY = 3u,
+    BUFFER_TO_TEXTURE_COPY = 4u,
+    TEXTURE_TO_BUFFER_COPY = 5u,
+    TEXTURE_UPLOAD = 6u,
+    TEXTURE_DOWNLOAD = 7u,
+    TEXTURE_COPY = 8u,
+    SHADER_DISPATCH = 9u,
+    BINDLESS_ARRAY_UPDATE = 10u,
+    MESH_BUILD = 11u,
+    CURVE_BUILD = 12u,
+    PROCEDURAL_PRIMITIVE_BUILD = 13u,
+    MOTION_INSTANCE_BUILD = 14u,
+    ACCEL_BUILD = 15u,
+    BUFFER_UPLOAD_CACHED = 16u,
+    TEXTURE_UPLOAD_CACHED = 17u,
+};
+
+struct DownloadTarget {
+    void *data{};
+    size_t size{};
+};
+
+struct ResolvedTexture {
+    uint64_t handle{};
+    PixelStorage storage{};
+    uint3 size{};
+    uint32_t mip_levels{};
+};
+
+struct ResolvedBuffer {
+    uint64_t handle{};
+    size_t size_bytes{};
+    bool is_indirect_dispatch{};
+    size_t indirect_dispatch_capacity{};
+};
+
+struct ShaderArgumentDesc {
+    Argument::Tag tag{};
+    size_t uniform_size{};
+    size_t uniform_alignment{};
+    bool indirect_dispatch_buffer{};
+};
+
+constexpr uint32_t invalid_blob_index = ~0u;
+
+struct UploadBlob {
+    BlobKey key;
+    luisa::span<const std::byte> bytes;
+};
+
+struct UploadBlobReference {
+    size_t command_index{};
+    uint32_t index{invalid_blob_index};
+};
+
+struct UploadBlobPlan {
+    luisa::vector<UploadBlob> blobs;
+    luisa::vector<UploadBlobReference> references;
+    luisa::string error;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error.empty();
+    }
+
+    [[nodiscard]] uint32_t find(
+        size_t command_index) const noexcept;
+};
+
+struct ResolvedShader {
+    uint64_t handle{};
+    luisa::span<const ShaderArgumentDesc> arguments;
+};
+
+struct EncodedSubmission {
+    luisa::vector<std::byte> payload;
+    luisa::vector<DownloadTarget> downloads;
+    luisa::string error;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error.empty();
+    }
+};
+
+class CommandHandleResolver {
+
+public:
+    virtual ~CommandHandleResolver() noexcept = default;
+
+    [[nodiscard]] virtual bool resolve_buffer(
+        uint64_t remote_handle, uint64_t &native_handle,
+        size_t &size_bytes, luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_buffer_descriptor(
+        uint64_t remote_handle, ResolvedBuffer &buffer,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_texture(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_texture_descriptor(
+        uint64_t remote_handle, ResolvedTexture &texture,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_bindless_array(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_bindless_array_for_update(
+        uint64_t remote_handle, uint64_t &native_handle,
+        size_t &slot_count, BindlessSlotType &slot_type,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_accel(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_shader(
+        uint64_t remote_handle, ResolvedShader &shader,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_mesh(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_curve(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_procedural_primitive(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_motion_instance(
+        uint64_t remote_handle, uint64_t &native_handle,
+        size_t &keyframe_count,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_accel_resource(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_primitive(
+        uint64_t remote_handle, uint64_t &native_handle,
+        luisa::string &error) const noexcept = 0;
+    [[nodiscard]] virtual bool resolve_upload_blob(
+        uint64_t submission_id, uint32_t blob_index,
+        size_t expected_size, BlobCache::BlobPtr &blob,
+        luisa::string &error) const noexcept = 0;
+};
+
+struct ServerDownload {
+    uint32_t index{};
+    luisa::shared_ptr<luisa::vector<std::byte>> storage;
+};
+
+struct DecodedSubmission {
+    uint64_t stream_handle{};
+    uint64_t submission_id{};
+    CommandList command_list;
+    luisa::vector<ServerDownload> downloads;
+    luisa::vector<BlobCache::BlobPtr> upload_blobs;
+    luisa::vector<uint32_t> upload_blob_indices;
+    luisa::string error;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return error.empty();
+    }
+};
+
+[[nodiscard]] UploadBlobPlan plan_upload_blobs(
+    luisa::span<const luisa::unique_ptr<Command>> commands,
+    uint64_t minimum_blob_size,
+    uint64_t maximum_blob_size,
+    const ProtocolLimits &limits = {}) noexcept;
+
+[[nodiscard]] EncodedSubmission encode_submission(
+    uint64_t stream_handle, uint64_t submission_id,
+    luisa::span<const luisa::unique_ptr<Command>> commands,
+    const ProtocolLimits &limits = {},
+    const UploadBlobPlan *blob_plan = nullptr) noexcept;
+
+[[nodiscard]] DecodedSubmission decode_submission(
+    luisa::span<const std::byte> payload,
+    const CommandHandleResolver &resolver,
+    const ProtocolLimits &limits = {}) noexcept;
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_device.cpp
+++ b/src/backends/remote/remote_device.cpp
@@ -1,0 +1,1492 @@
+#include "remote_device.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <bit>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <deque>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+#include <luisa/ast/ast2json.h>
+#include <luisa/backends/ext/remote_config_ext.h>
+#include <luisa/core/logging.h>
+#include <luisa/core/stl/format.h>
+#include <luisa/runtime/context.h>
+#include <luisa/runtime/device.h>
+#include <luisa/runtime/dispatch_buffer.h>
+#include <luisa/runtime/swapchain.h>
+
+#include "remote_command_codec.h"
+#include "remote_transport.h"
+
+namespace luisa::compute::remote {
+
+namespace {
+
+using namespace std::chrono_literals;
+
+struct ClientOptions {
+    luisa::string host{"127.0.0.1"};
+    uint16_t port{18080u};
+    luisa::string token;
+    std::chrono::milliseconds connect_timeout{10s};
+    std::chrono::milliseconds request_timeout{60s};
+    uint64_t max_in_flight_bytes{256ull * 1024ull * 1024ull};
+    bool enable_blob_cache{true};
+    uint64_t blob_cache_min_size{64ull * 1024ull};
+    luisa::string local_present_backend;
+    luisa::string server_backend;
+    size_t server_device_index{std::numeric_limits<size_t>::max()};
+    bool server_enable_validation{false};
+};
+
+[[nodiscard]] ClientOptions client_options(
+    const DeviceConfig *config) noexcept {
+    ClientOptions options;
+    if (config != nullptr && config->extension != nullptr) {
+        auto extension = static_cast<const RemoteDeviceConfigExt *>(
+            config->extension.get());
+        options.host = extension->host();
+        options.port = extension->port();
+        options.token = extension->token();
+        options.connect_timeout = std::chrono::milliseconds{
+            extension->connect_timeout_ms()};
+        options.request_timeout = std::chrono::milliseconds{
+            extension->request_timeout_ms()};
+        options.max_in_flight_bytes = extension->max_in_flight_bytes();
+        options.enable_blob_cache = extension->enable_blob_cache();
+        options.blob_cache_min_size = extension->blob_cache_min_size();
+        options.local_present_backend = extension->local_present_backend();
+        options.server_backend = extension->server_backend();
+        options.server_device_index = extension->server_device_index();
+        options.server_enable_validation = extension->server_enable_validation();
+    }
+    return options;
+}
+
+void write_shader_option(Writer &writer,
+                         const ShaderOption &option) noexcept {
+    writer.write_bool(option.enable_cache);
+    writer.write_bool(option.enable_fast_math);
+    writer.write_bool(option.enable_debug_info);
+    writer.write_bool(option.compile_only);
+    writer.write_u32(option.max_registers);
+    writer.write_bool(option.time_trace);
+    writer.write_bool(option.enable_extended_accel_limits);
+    writer.write_bool(option.enable_scalarizer);
+    writer.write_bool(option.enable_ray_query_pipeline);
+    writer.write_bool(option.force_ray_query_pipeline);
+    writer.write_bool(option.enable_driver_optimization);
+    writer.write_string(option.name);
+}
+
+void write_accel_option(Writer &writer,
+                        const AccelOption &option) noexcept {
+    writer.write_u32(static_cast<uint32_t>(option.hint));
+    writer.write_bool(option.allow_compaction);
+    writer.write_bool(option.allow_update);
+    writer.write_u32(option.motion.keyframe_count);
+    writer.write_f32(option.motion.time_start);
+    writer.write_f32(option.motion.time_end);
+    writer.write_bool(option.motion.should_vanish_start);
+    writer.write_bool(option.motion.should_vanish_end);
+    writer.write_u8(static_cast<uint8_t>(option.motion.mode));
+}
+
+}// namespace
+
+class RemoteDevice::Impl {
+
+private:
+    struct TextureDesc {
+        PixelStorage storage{};
+        uint3 size{};
+        uint32_t mip_levels{};
+    };
+
+    struct LocalSwapchain {
+        uint64_t remote_stream{};
+        luisa::shared_ptr<DeviceInterface> device;
+        ResourceCreationInfo stream{};
+        SwapchainCreationInfo swapchain{};
+        ResourceCreationInfo image{};
+        uint2 size{};
+        luisa::vector<std::byte> staging;
+        bool submission_pending{};
+    };
+
+    struct PendingSubmission {
+        uint64_t stream_handle{};
+        luisa::vector<DownloadTarget> downloads;
+        CommandList::CallbackContainer callbacks;
+        uint64_t footprint{};
+    };
+
+    struct WorkItem {
+        MessageKind kind{};
+        uint64_t id{};
+        luisa::vector<std::byte> payload;
+    };
+
+    struct CompletionDownload {
+        uint32_t index{};
+        luisa::span<const std::byte> bytes;
+    };
+
+    ProtocolLimits _limits;
+    Connection _connection{_limits};
+    Context _context;
+    ClientOptions _options;
+    std::chrono::milliseconds _request_timeout;
+    uint64_t _max_in_flight_bytes{};
+    uint _warp_size{};
+    size_t _max_shared_memory{};
+    uint64_t _memory_granularity{};
+    uint64_t _features{};
+    uint64_t _max_blob_entry_size{};
+    uint64_t _blob_cache_min_size{};
+    uint64_t _max_blobs_per_batch{};
+    luisa::string _native_backend;
+    std::atomic_uint64_t _next_submission_id{1u};
+
+    std::mutex _state_mutex;
+    std::condition_variable _state_cv;
+    std::unordered_map<uint64_t, PendingSubmission> _pending;
+    std::unordered_map<uint64_t, luisa::vector<Usage>> _shader_usages;
+    std::unordered_map<uint64_t, DeviceInterface::StreamLogCallback> _log_callbacks;
+    std::unordered_map<uint64_t, TextureDesc> _textures;
+    uint64_t _pending_bytes{};
+    bool _closed{false};
+
+    std::mutex _present_mutex;
+    luisa::shared_ptr<DeviceInterface> _present_device;
+    luisa::string _present_backend;
+    std::unordered_map<uint64_t, luisa::unique_ptr<LocalSwapchain>> _swapchains;
+    uint64_t _next_swapchain_id{1u};
+
+    std::mutex _work_mutex;
+    std::condition_variable _work_cv;
+    std::deque<WorkItem> _work;
+    std::thread _worker;
+    bool _worker_stop{false};
+
+private:
+    [[nodiscard]] luisa::string _select_present_backend() const noexcept {
+        if (!_options.local_present_backend.empty()) {
+            if (_options.local_present_backend == "remote") {
+                LUISA_ERROR("The local presentation backend cannot be 'remote'.");
+            }
+            return _options.local_present_backend;
+        }
+        auto installed = _context.installed_backends();
+        auto has_backend = [installed](luisa::string_view name) noexcept {
+            return std::find(installed.begin(), installed.end(), name) != installed.end();
+        };
+#if defined(__APPLE__)
+        constexpr std::array candidates{"metal", "metal4", "vk", "fallback"};
+#elif defined(_WIN32)
+        constexpr std::array candidates{"dx", "vk", "fallback"};
+#else
+        constexpr std::array candidates{"vk", "fallback"};
+#endif
+        for (auto candidate : candidates) {
+            if (has_backend(candidate)) { return candidate; }
+        }
+        LUISA_ERROR("No local presentation backend is installed. Configure RemoteDeviceConfigExt::local_present_backend explicitly.");
+    }
+
+    void _ensure_present_device_locked() noexcept {
+        if (_present_device != nullptr) { return; }
+        _present_backend = _select_present_backend();
+        DeviceConfig config{};
+        config.headless = false;
+        auto device = _context.create_device(_present_backend, &config, false);
+        _present_device = device.impl_shared();
+        if (_present_device == nullptr) {
+            LUISA_ERROR("Failed to create local '{}' presentation device.", _present_backend);
+        }
+        LUISA_INFO("Remote client presentation uses the local '{}' backend.", _present_backend);
+    }
+
+    static void _destroy_local_swapchain(LocalSwapchain &swapchain) noexcept {
+        if (swapchain.device == nullptr) { return; }
+        if (swapchain.submission_pending && swapchain.stream.valid()) {
+            swapchain.device->synchronize_stream(swapchain.stream.handle);
+        }
+        if (swapchain.image.valid()) {
+            swapchain.device->destroy_texture(swapchain.image.handle);
+            swapchain.image.invalidate();
+        }
+        if (swapchain.swapchain.valid()) {
+            swapchain.device->destroy_swapchain(swapchain.swapchain.handle);
+            swapchain.swapchain.invalidate();
+        }
+        if (swapchain.stream.valid()) {
+            swapchain.device->destroy_stream(swapchain.stream.handle);
+            swapchain.stream.invalidate();
+        }
+    }
+
+    [[nodiscard]] Response _request(
+        MessageKind kind,
+        luisa::span<const std::byte> payload = {}) noexcept {
+        if (payload.size() > _limits.max_frame_payload) {
+            LUISA_ERROR(
+                "Remote request {} requires {} payload bytes, exceeding the negotiated limit {}.",
+                static_cast<uint16_t>(kind), payload.size(),
+                _limits.max_frame_payload);
+        }
+        auto response = _connection.request(kind, payload, _request_timeout);
+        if (!response) {
+            LUISA_ERROR(
+                "Remote request {} failed (status {}): {}",
+                static_cast<uint16_t>(kind),
+                static_cast<uint16_t>(response.status),
+                response.message);
+        }
+        return response;
+    }
+
+    void _protocol_failure(luisa::string_view message) noexcept {
+        LUISA_WARNING("Remote protocol failure: {}", message);
+        _connection.close();
+    }
+
+    void _enqueue_work(
+        MessageKind kind, uint64_t id,
+        luisa::span<const std::byte> payload) noexcept {
+        WorkItem item{.kind = kind, .id = id};
+        item.payload.assign(payload.begin(), payload.end());
+        {
+            std::scoped_lock lock{_work_mutex};
+            if (_worker_stop) { return; }
+            _work.emplace_back(std::move(item));
+        }
+        _work_cv.notify_one();
+    }
+
+    void _process_completion(const WorkItem &item) noexcept {
+        Reader reader{item.payload, _limits};
+        auto submission_id = reader.read_u64();
+        auto status = static_cast<Status>(reader.read_u16());
+        auto message = reader.read_string();
+        auto download_count = reader.read_u64();
+        if (!reader.ok() || submission_id != item.id ||
+            submission_id == 0u ||
+            download_count > _limits.max_array_size ||
+            download_count > std::numeric_limits<size_t>::max()) {
+            _protocol_failure(reader.ok() ?
+                                  "Malformed remote completion header." :
+                                  reader.error());
+            return;
+        }
+        luisa::vector<CompletionDownload> downloads;
+        downloads.reserve(static_cast<size_t>(download_count));
+        for (uint64_t i = 0u; i < download_count; i++) {
+            auto index = reader.read_u32();
+            auto bytes = reader.read_blob();
+            if (!reader.ok()) {
+                _protocol_failure(reader.error());
+                return;
+            }
+            downloads.emplace_back(CompletionDownload{index, bytes});
+        }
+        if (!reader.finish()) {
+            _protocol_failure(reader.error());
+            return;
+        }
+        if (status != Status::OK) {
+            _protocol_failure(luisa::format(
+                "Remote submission {} failed: {}", submission_id, message));
+            return;
+        }
+
+        PendingSubmission pending;
+        {
+            std::unique_lock lock{_state_mutex};
+            auto iter = _pending.find(submission_id);
+            if (iter == _pending.end()) {
+                lock.unlock();
+                _protocol_failure("Completion references an unknown submission ID.");
+                return;
+            }
+            if (downloads.size() != iter->second.downloads.size()) {
+                lock.unlock();
+                _protocol_failure("Completion download count does not match the submission.");
+                return;
+            }
+            for (size_t i = 0u; i < downloads.size(); i++) {
+                if (downloads[i].index != i ||
+                    downloads[i].bytes.size() != iter->second.downloads[i].size) {
+                    lock.unlock();
+                    _protocol_failure("Completion download descriptor does not match the submission.");
+                    return;
+                }
+            }
+            pending = std::move(iter->second);
+            _pending_bytes -= pending.footprint;
+            _pending.erase(iter);
+        }
+        _state_cv.notify_all();
+        for (size_t i = 0u; i < downloads.size(); i++) {
+            if (!downloads[i].bytes.empty()) {
+                std::memcpy(pending.downloads[i].data,
+                            downloads[i].bytes.data(),
+                            downloads[i].bytes.size());
+            }
+        }
+        for (auto &callback : pending.callbacks) { callback(); }
+    }
+
+    void _process_stream_log(const WorkItem &item) noexcept {
+        Reader reader{item.payload, _limits};
+        auto stream = reader.read_u64();
+        auto message = reader.read_string();
+        if (!reader.finish() || stream != item.id) {
+            _protocol_failure(reader.ok() ?
+                                  "Malformed remote stream-log notification." :
+                                  reader.error());
+            return;
+        }
+        DeviceInterface::StreamLogCallback callback;
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (auto iter = _log_callbacks.find(stream);
+                iter != _log_callbacks.end()) {
+                callback = iter->second;
+            }
+        }
+        if (callback) { callback(message); }
+    }
+
+    void _worker_loop() noexcept {
+        while (true) {
+            WorkItem item;
+            {
+                std::unique_lock lock{_work_mutex};
+                _work_cv.wait(lock, [&]() noexcept {
+                    return _worker_stop || !_work.empty();
+                });
+                if (_work.empty()) {
+                    if (_worker_stop) { return; }
+                    continue;
+                }
+                item = std::move(_work.front());
+                _work.pop_front();
+            }
+            if (item.kind == MessageKind::DISPATCH_COMPLETE) {
+                _process_completion(item);
+            } else if (item.kind == MessageKind::STREAM_LOG) {
+                _process_stream_log(item);
+            }
+        }
+    }
+
+    void _handshake() noexcept {
+        if constexpr (std::endian::native != std::endian::little) {
+            LUISA_ERROR(
+                "Remote protocol v1 requires a little-endian client because AST constants use native byte order.");
+        }
+        Writer writer;
+        writer.write_u32(0x01020304u);
+        writer.write_u8(sizeof(void *));
+        writer.write_u8(1u);
+        writer.write_u16(0u);
+        writer.write_string(_options.token);
+        writer.write_string(_options.server_backend);
+        writer.write_u64(_options.server_device_index);
+        writer.write_bool(_options.server_enable_validation);
+        auto response = _request(MessageKind::HELLO, writer.bytes());
+        Reader reader{response.body, _limits};
+        _native_backend = reader.read_string();
+        _warp_size = reader.read_u32();
+        auto max_shared_memory = reader.read_u64();
+        _memory_granularity = reader.read_u64();
+        _features = reader.read_u64();
+        if (!reader.finish() ||
+            max_shared_memory > std::numeric_limits<size_t>::max() ||
+            _warp_size == 0u || _memory_granularity == 0u) {
+            LUISA_ERROR("Remote HELLO response is malformed: {}",
+                        reader.error());
+        }
+        _max_shared_memory = static_cast<size_t>(max_shared_memory);
+        if ((_features & static_cast<uint64_t>(
+                             Feature::LIMIT_NEGOTIATION)) != 0u) {
+            auto protocol_info = _request(MessageKind::PROTOCOL_INFO);
+            Reader protocol_reader{protocol_info.body, _limits};
+            auto max_frame_payload = protocol_reader.read_u64();
+            auto max_string_size = protocol_reader.read_u64();
+            auto max_array_size = protocol_reader.read_u64();
+            if (!protocol_reader.finish() || max_frame_payload == 0u ||
+                max_string_size == 0u || max_array_size == 0u) {
+                LUISA_ERROR("Remote protocol-limit response is malformed: {}",
+                            protocol_reader.error());
+            }
+            _limits.max_frame_payload = std::min(
+                _limits.max_frame_payload, max_frame_payload);
+            _limits.max_string_size = std::min(
+                _limits.max_string_size, max_string_size);
+            _limits.max_array_size = std::min(
+                _limits.max_array_size, max_array_size);
+        }
+        if (!_options.enable_blob_cache ||
+            (_features & static_cast<uint64_t>(Feature::BLOB_CACHE)) == 0u) {
+            _features &= ~static_cast<uint64_t>(Feature::BLOB_CACHE);
+            return;
+        }
+        auto cache_info = _request(MessageKind::BLOB_CACHE_INFO);
+        Reader cache_reader{cache_info.body, _limits};
+        _max_blob_entry_size = cache_reader.read_u64();
+        _blob_cache_min_size = cache_reader.read_u64();
+        _max_blobs_per_batch = cache_reader.read_u64();
+        if (!cache_reader.finish() || _max_blob_entry_size == 0u ||
+            _max_blobs_per_batch == 0u ||
+            _blob_cache_min_size > _max_blob_entry_size) {
+            LUISA_ERROR("Remote blob-cache capability response is malformed: {}",
+                        cache_reader.error());
+        }
+        _blob_cache_min_size = std::max(
+            _blob_cache_min_size,
+            _options.blob_cache_min_size);
+        if (_blob_cache_min_size > _max_blob_entry_size) {
+            _features &= ~static_cast<uint64_t>(Feature::BLOB_CACHE);
+            _max_blob_entry_size = 0u;
+        }
+    }
+
+    void _prepare_blobs(
+        uint64_t submission_id,
+        const UploadBlobPlan &plan) noexcept {
+        if (plan.blobs.empty()) { return; }
+        Writer prepare;
+        prepare.write_u64(submission_id);
+        prepare.write_u64(plan.blobs.size());
+        for (auto &&blob : plan.blobs) {
+            write_blob_key(prepare, blob.key);
+        }
+        auto response = _request(
+            MessageKind::PREPARE_BLOBS, prepare.bytes());
+        Reader reader{response.body, _limits};
+        if (reader.read_u64() != submission_id) {
+            LUISA_ERROR("Remote blob-prepare acknowledgement has the wrong submission ID.");
+        }
+        auto miss_count = reader.read_u64();
+        if (!reader.ok() || miss_count > plan.blobs.size() ||
+            miss_count > std::numeric_limits<size_t>::max()) {
+            LUISA_ERROR("Remote blob-prepare acknowledgement is malformed: {}",
+                        reader.error());
+        }
+        luisa::vector<uint32_t> misses;
+        misses.reserve(static_cast<size_t>(miss_count));
+        luisa::vector<bool> seen(plan.blobs.size(), false);
+        for (uint64_t i = 0u; i < miss_count; i++) {
+            auto index = reader.read_u32();
+            if (!reader.ok() || index >= plan.blobs.size() || seen[index]) {
+                LUISA_ERROR("Remote blob-prepare miss list is malformed.");
+            }
+            seen[index] = true;
+            misses.emplace_back(index);
+        }
+        if (!reader.finish()) {
+            LUISA_ERROR("Remote blob-prepare acknowledgement is malformed: {}",
+                        reader.error());
+        }
+
+        constexpr uint64_t upload_header_size = 16u;
+        constexpr uint64_t upload_record_overhead =
+            sizeof(uint32_t) + sizeof(uint64_t) +
+            blob_digest_size + sizeof(uint64_t);
+        for (size_t begin = 0u; begin < misses.size();) {
+            auto end = begin;
+            auto payload_size = upload_header_size;
+            while (end < misses.size()) {
+                auto blob_size = plan.blobs[misses[end]].key.size;
+                if (blob_size > _limits.max_frame_payload ||
+                    upload_record_overhead >
+                        _limits.max_frame_payload - blob_size ||
+                    payload_size >
+                        _limits.max_frame_payload -
+                            upload_record_overhead - blob_size) {
+                    break;
+                }
+                payload_size += upload_record_overhead + blob_size;
+                end++;
+            }
+            if (end == begin) {
+                LUISA_ERROR("A remote blob upload exceeds the frame limit.");
+            }
+            Writer upload{static_cast<size_t>(payload_size)};
+            upload.write_u64(submission_id);
+            upload.write_u64(end - begin);
+            for (auto i = begin; i < end; i++) {
+                auto index = misses[i];
+                auto &&blob = plan.blobs[index];
+                upload.write_u32(index);
+                write_blob_key(upload, blob.key);
+                upload.write_blob(blob.bytes);
+            }
+            auto uploaded = _request(
+                MessageKind::UPLOAD_BLOBS, upload.bytes());
+            Reader uploaded_reader{uploaded.body, _limits};
+            if (uploaded_reader.read_u64() != submission_id ||
+                !uploaded_reader.finish()) {
+                LUISA_ERROR("Remote blob-upload acknowledgement is malformed.");
+            }
+            begin = end;
+        }
+    }
+
+    [[nodiscard]] uint64_t _create_handle(
+        MessageKind kind, const Writer &writer) noexcept {
+        auto response = _request(kind, writer.bytes());
+        Reader reader{response.body, _limits};
+        auto handle = reader.read_u64();
+        if (!reader.finish() || handle == invalid_resource_handle) {
+            LUISA_ERROR("Remote create response is malformed: {}", reader.error());
+        }
+        return handle;
+    }
+
+    [[nodiscard]] bool _destroy_handle(
+        MessageKind kind, uint64_t handle) noexcept {
+        if (!_connection.connected()) { return false; }
+        Writer writer;
+        writer.write_u64(handle);
+        auto response = _connection.request(
+            kind, writer.bytes(), _request_timeout);
+        if (!response) {
+            if (response.status != Status::CONNECTION_CLOSED) {
+                LUISA_WARNING(
+                    "Failed to destroy remote resource {} with request {}: {}",
+                    handle, static_cast<uint16_t>(kind), response.message);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _try_wait_stream_idle(
+        uint64_t stream_handle) noexcept {
+        std::unique_lock lock{_state_mutex};
+        auto idle = _state_cv.wait_for(
+            lock, _request_timeout, [&]() noexcept {
+                if (_closed) { return true; }
+                for (auto &&[id, submission] : _pending) {
+                    static_cast<void>(id);
+                    if (submission.stream_handle == stream_handle) {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        return idle && !_closed;
+    }
+
+    void _wait_stream_idle(uint64_t stream_handle) noexcept {
+        if (!_try_wait_stream_idle(stream_handle)) {
+            LUISA_ERROR("Timed out draining remote stream completions.");
+        }
+    }
+
+    void _synchronize_remote_stream(uint64_t handle) noexcept {
+        Writer writer;
+        writer.write_u64(handle);
+        static_cast<void>(_request(
+            MessageKind::SYNCHRONIZE_STREAM, writer.bytes()));
+        _wait_stream_idle(handle);
+    }
+
+public:
+    explicit Impl(Context context, ClientOptions options) noexcept
+        : _context{std::move(context)},
+          _options{std::move(options)},
+          _request_timeout{_options.request_timeout},
+          _max_in_flight_bytes{_options.max_in_flight_bytes} {
+        _connection.set_notification_handler(
+            [this](MessageKind kind, uint64_t id,
+                   luisa::span<const std::byte> payload) noexcept {
+                if (kind != MessageKind::DISPATCH_COMPLETE &&
+                    kind != MessageKind::STREAM_LOG) {
+                    _protocol_failure("Received an unknown remote notification.");
+                    return;
+                }
+                _enqueue_work(kind, id, payload);
+            });
+        _connection.set_close_handler(
+            [this](luisa::string_view) noexcept {
+                {
+                    std::scoped_lock lock{_state_mutex};
+                    _closed = true;
+                }
+                _state_cv.notify_all();
+            });
+        luisa::string error;
+        if (!_connection.connect(
+                _options.host, _options.port,
+                _options.connect_timeout, error)) {
+            LUISA_ERROR("Failed to connect to remote backend at {}:{}: {}",
+                        _options.host, _options.port, error);
+        }
+        _handshake();
+        _worker = std::thread{[this]() noexcept { _worker_loop(); }};
+    }
+
+    ~Impl() noexcept {
+        luisa::vector<luisa::unique_ptr<LocalSwapchain>> swapchains;
+        {
+            std::scoped_lock lock{_present_mutex};
+            swapchains.reserve(_swapchains.size());
+            for (auto &[handle, swapchain] : _swapchains) {
+                static_cast<void>(handle);
+                swapchains.emplace_back(std::move(swapchain));
+            }
+            _swapchains.clear();
+        }
+        for (auto &swapchain : swapchains) {
+            _destroy_local_swapchain(*swapchain);
+        }
+        if (_connection.connected()) {
+            static_cast<void>(_connection.request(
+                MessageKind::GOODBYE, {}, _request_timeout));
+        }
+        _connection.close();
+        {
+            std::scoped_lock lock{_work_mutex};
+            _worker_stop = true;
+        }
+        _work_cv.notify_all();
+        if (_worker.joinable()) { _worker.join(); }
+        _connection.set_notification_handler({});
+        _connection.set_close_handler({});
+        std::scoped_lock lock{_state_mutex};
+        if (!_pending.empty()) {
+            LUISA_WARNING("Remote device closed with {} incomplete submissions.",
+                          _pending.size());
+        }
+    }
+
+    [[nodiscard]] uint warp_size() const noexcept { return _warp_size; }
+    [[nodiscard]] size_t max_shared_memory() const noexcept {
+        return _max_shared_memory;
+    }
+    [[nodiscard]] uint64_t memory_granularity() const noexcept {
+        return _memory_granularity;
+    }
+
+    [[nodiscard]] BufferCreationInfo create_buffer(
+        const Type *element, size_t elem_count) noexcept {
+        auto indirect = element == Type::of<IndirectKernelDispatch>();
+        if (element->is_custom() && !indirect) {
+            LUISA_ERROR(
+                "Remote protocol v1 does not support buffer element type '{}'.",
+                element->description());
+        }
+        size_t stride{};
+        if (!indirect) {
+            stride = element == Type::of<void>() ? 1u : element->size();
+            if (elem_count != 0u &&
+                stride > std::numeric_limits<size_t>::max() / elem_count) {
+                LUISA_ERROR("Remote buffer size overflow.");
+            }
+        }
+        auto requested_size = indirect ? 0u : stride * elem_count;
+        Writer writer;
+        writer.write_u8(static_cast<uint8_t>(
+            indirect ? BufferKind::INDIRECT_DISPATCH : BufferKind::BYTE));
+        writer.write_u64(indirect ? elem_count : requested_size);
+        auto response = _request(MessageKind::CREATE_BUFFER, writer.bytes());
+        Reader reader{response.body, _limits};
+        BufferCreationInfo info{};
+        info.handle = reader.read_u64();
+        auto native_stride = reader.read_u64();
+        auto native_size = reader.read_u64();
+        if (!reader.finish() ||
+            info.handle == invalid_resource_handle ||
+            native_stride == 0u ||
+            native_stride > std::numeric_limits<size_t>::max() ||
+            native_size > std::numeric_limits<size_t>::max() ||
+            (!indirect && native_size < requested_size)) {
+            LUISA_ERROR("Remote buffer-create response is malformed: {}",
+                        reader.error());
+        }
+        info.native_handle = nullptr;
+        info.element_stride = indirect ?
+                                  static_cast<size_t>(native_stride) :
+                                  stride;
+        info.total_size_bytes = static_cast<size_t>(native_size);
+        return info;
+    }
+
+    void destroy_buffer(uint64_t handle) noexcept {
+        static_cast<void>(_destroy_handle(
+            MessageKind::DESTROY_BUFFER, handle));
+    }
+
+    [[nodiscard]] uint64_t create_texture(
+        PixelFormat format, uint dimension,
+        uint width, uint height, uint depth, uint mip_levels,
+        bool simultaneous_access, bool allow_raster_target) noexcept {
+        Writer writer;
+        writer.write_u32(static_cast<uint32_t>(format));
+        writer.write_u32(dimension);
+        writer.write_u32(width);
+        writer.write_u32(height);
+        writer.write_u32(depth);
+        writer.write_u32(mip_levels);
+        writer.write_bool(simultaneous_access);
+        writer.write_bool(allow_raster_target);
+        auto handle = _create_handle(MessageKind::CREATE_TEXTURE, writer);
+        {
+            std::scoped_lock lock{_state_mutex};
+            _textures.emplace(handle, TextureDesc{
+                                          .storage = pixel_format_to_storage(format),
+                                          .size = uint3{width, height, depth},
+                                          .mip_levels = mip_levels});
+        }
+        return handle;
+    }
+
+    void destroy_texture(uint64_t handle) noexcept {
+        static_cast<void>(_destroy_handle(
+            MessageKind::DESTROY_TEXTURE, handle));
+        std::scoped_lock lock{_state_mutex};
+        _textures.erase(handle);
+    }
+
+    [[nodiscard]] uint64_t create_bindless_array(
+        size_t slot_count, BindlessSlotType slot_type) noexcept {
+        Writer writer;
+        writer.write_u64(slot_count);
+        writer.write_u32(static_cast<uint32_t>(slot_type));
+        return _create_handle(MessageKind::CREATE_BINDLESS_ARRAY, writer);
+    }
+
+    void destroy_bindless_array(uint64_t handle) noexcept {
+        static_cast<void>(_destroy_handle(
+            MessageKind::DESTROY_BINDLESS_ARRAY, handle));
+    }
+
+    [[nodiscard]] uint64_t create_stream(StreamTag tag) noexcept {
+        Writer writer;
+        writer.write_u32(static_cast<uint32_t>(tag));
+        return _create_handle(MessageKind::CREATE_STREAM, writer);
+    }
+
+    void destroy_stream(uint64_t handle) noexcept {
+        if (_destroy_handle(MessageKind::DESTROY_STREAM, handle) &&
+            !_try_wait_stream_idle(handle)) {
+            LUISA_WARNING(
+                "Remote stream {} disconnected while draining completions during destruction.",
+                handle);
+        }
+        std::scoped_lock lock{_state_mutex};
+        _log_callbacks.erase(handle);
+    }
+
+    void synchronize_stream(uint64_t handle) noexcept {
+        _synchronize_remote_stream(handle);
+        std::scoped_lock lock{_present_mutex};
+        for (auto &[swapchain_handle, swapchain] : _swapchains) {
+            static_cast<void>(swapchain_handle);
+            if (swapchain->remote_stream == handle &&
+                swapchain->submission_pending) {
+                swapchain->device->synchronize_stream(swapchain->stream.handle);
+                swapchain->submission_pending = false;
+            }
+        }
+    }
+
+    void dispatch(uint64_t stream_handle, CommandList &&list) noexcept {
+        auto submission_id = _next_submission_id.fetch_add(
+            1u, std::memory_order_relaxed);
+        if (submission_id == 0u) {
+            LUISA_ERROR("Remote submission-ID space exhausted.");
+        }
+        UploadBlobPlan blob_plan;
+        if ((_features & static_cast<uint64_t>(Feature::BLOB_CACHE)) != 0u) {
+            auto blob_limits = _limits;
+            blob_limits.max_array_size = std::min(
+                blob_limits.max_array_size,
+                _max_blobs_per_batch);
+            blob_plan = plan_upload_blobs(
+                list.commands(), _blob_cache_min_size,
+                _max_blob_entry_size, blob_limits);
+            if (!blob_plan) {
+                LUISA_ERROR("Failed to plan remote upload blobs: {}",
+                            blob_plan.error);
+            }
+        }
+        auto encoded = encode_submission(
+            stream_handle, submission_id, list.commands(), _limits,
+            blob_plan.blobs.empty() ? nullptr : &blob_plan);
+        if (!encoded) {
+            LUISA_ERROR("Failed to encode remote submission: {}", encoded.error);
+        }
+        uint64_t footprint = encoded.payload.size();
+        for (auto download : encoded.downloads) {
+            if (download.size > std::numeric_limits<uint64_t>::max() - footprint) {
+                LUISA_ERROR("Remote submission footprint overflow.");
+            }
+            footprint += download.size;
+        }
+        if (footprint > _max_in_flight_bytes) {
+            LUISA_ERROR(
+                "Remote submission requires {} in-flight bytes, exceeding the configured limit {}.",
+                footprint, _max_in_flight_bytes);
+        }
+        PendingSubmission pending{
+            .stream_handle = stream_handle,
+            .downloads = std::move(encoded.downloads),
+            .callbacks = list.steal_callbacks(),
+            .footprint = footprint};
+        {
+            std::unique_lock lock{_state_mutex};
+            auto ready = _state_cv.wait_for(
+                lock, _request_timeout, [&]() noexcept {
+                    return _closed ||
+                           footprint <= _max_in_flight_bytes - _pending_bytes;
+                });
+            if (!ready || _closed) {
+                LUISA_ERROR("Timed out waiting for remote in-flight capacity.");
+            }
+            _pending_bytes += footprint;
+            _pending.emplace(submission_id, std::move(pending));
+        }
+        _prepare_blobs(submission_id, blob_plan);
+        auto response = _connection.request(
+            MessageKind::DISPATCH, encoded.payload, _request_timeout);
+        if (!response) {
+            {
+                std::scoped_lock lock{_state_mutex};
+                if (auto iter = _pending.find(submission_id);
+                    iter != _pending.end()) {
+                    _pending_bytes -= iter->second.footprint;
+                    _pending.erase(iter);
+                }
+            }
+            _state_cv.notify_all();
+            LUISA_ERROR("Remote dispatch was rejected (status {}): {}",
+                        static_cast<uint16_t>(response.status),
+                        response.message);
+        }
+        Reader reader{response.body, _limits};
+        if (reader.read_u64() != submission_id || !reader.finish()) {
+            LUISA_ERROR("Remote dispatch acknowledgement is malformed.");
+        }
+    }
+
+    void set_stream_log_callback(
+        uint64_t stream_handle,
+        const DeviceInterface::StreamLogCallback &callback) noexcept {
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (callback) {
+                _log_callbacks[stream_handle] = callback;
+            } else {
+                _log_callbacks.erase(stream_handle);
+            }
+        }
+        Writer writer;
+        writer.write_u64(stream_handle);
+        writer.write_bool(static_cast<bool>(callback));
+        static_cast<void>(_request(
+            MessageKind::SET_STREAM_LOG_CALLBACK, writer.bytes()));
+    }
+
+    [[nodiscard]] SwapchainCreationInfo create_swapchain(
+        const SwapchainOption &option,
+        uint64_t remote_stream) noexcept {
+        std::scoped_lock lock{_present_mutex};
+        _ensure_present_device_locked();
+        auto local = luisa::make_unique<LocalSwapchain>();
+        local->remote_stream = remote_stream;
+        local->device = _present_device;
+        local->stream = local->device->create_stream(StreamTag::GRAPHICS);
+        if (!local->stream.valid()) {
+            LUISA_ERROR("The local '{}' backend failed to create a graphics stream for remote presentation.", _present_backend);
+        }
+        local->swapchain = local->device->create_swapchain(
+            option, local->stream.handle);
+        if (!local->swapchain.valid()) {
+            LUISA_ERROR("The local '{}' backend failed to create a swapchain for the remote client.", _present_backend);
+        }
+        local->size = option.size;
+        auto storage_size = checked_pixel_storage_size(
+            local->swapchain.storage,
+            uint3{option.size.x, option.size.y, 1u});
+        if (!storage_size) {
+            LUISA_ERROR("The local swapchain returned an invalid pixel storage.");
+        }
+        local->image = local->device->create_texture(
+            pixel_storage_to_format<float>(local->swapchain.storage),
+            2u, option.size.x, option.size.y, 1u, 1u,
+            nullptr, false, false);
+        if (!local->image.valid()) {
+            LUISA_ERROR("The local '{}' backend failed to create the presentation mirror image.", _present_backend);
+        }
+        local->staging.resize(storage_size.size);
+        auto handle = _next_swapchain_id++;
+        if (handle == 0u || handle == invalid_resource_handle ||
+            _next_swapchain_id == 0u) {
+            LUISA_ERROR("The local remote-swapchain handle space is exhausted.");
+        }
+        auto native_handle = local->swapchain.native_handle;
+        auto storage = local->swapchain.storage;
+        _swapchains.emplace(handle, std::move(local));
+        return SwapchainCreationInfo{
+            ResourceCreationInfo{
+                .handle = handle,
+                .native_handle = native_handle},
+            storage};
+    }
+
+    void destroy_swapchain(uint64_t handle) noexcept {
+        luisa::unique_ptr<LocalSwapchain> swapchain;
+        {
+            std::scoped_lock lock{_present_mutex};
+            auto iter = _swapchains.find(handle);
+            if (iter == _swapchains.end()) {
+                LUISA_WARNING("Ignoring destruction of an unknown remote-client swapchain {}.", handle);
+                return;
+            }
+            swapchain = std::move(iter->second);
+            _swapchains.erase(iter);
+        }
+        _destroy_local_swapchain(*swapchain);
+    }
+
+    void present(uint64_t remote_stream, uint64_t swapchain_handle,
+                 uint64_t texture_handle) noexcept {
+        TextureDesc texture;
+        {
+            std::scoped_lock lock{_state_mutex};
+            auto iter = _textures.find(texture_handle);
+            if (iter == _textures.end()) {
+                LUISA_ERROR("Remote presentation references an unknown texture {}.", texture_handle);
+            }
+            texture = iter->second;
+        }
+        std::scoped_lock lock{_present_mutex};
+        auto iter = _swapchains.find(swapchain_handle);
+        if (iter == _swapchains.end()) {
+            LUISA_ERROR("Remote presentation references an unknown local swapchain {}.", swapchain_handle);
+        }
+        auto &swapchain = *iter->second;
+        if (swapchain.remote_stream != remote_stream) {
+            LUISA_ERROR("A remote-client swapchain must be presented on the stream that created it.");
+        }
+        if (texture.storage != swapchain.swapchain.storage ||
+            any(texture.size !=
+                uint3{swapchain.size.x, swapchain.size.y, 1u})) {
+            LUISA_ERROR(
+                "Remote presentation image does not match the local swapchain: texture {}x{}x{} storage {}, swapchain {}x{} storage {}.",
+                texture.size.x, texture.size.y, texture.size.z,
+                static_cast<uint32_t>(texture.storage),
+                swapchain.size.x, swapchain.size.y,
+                static_cast<uint32_t>(swapchain.swapchain.storage));
+        }
+        if (swapchain.submission_pending) {
+            swapchain.device->synchronize_stream(swapchain.stream.handle);
+            swapchain.submission_pending = false;
+        }
+
+        auto download = CommandList::create(1u);
+        download.append(luisa::make_unique<TextureDownloadCommand>(
+            texture_handle, texture.storage, 0u, texture.size,
+            swapchain.staging.data()));
+        auto download_commit = download.commit();
+        dispatch(remote_stream,
+                 std::move(download_commit).command_list());
+        _synchronize_remote_stream(remote_stream);
+
+        auto upload = CommandList::create(1u);
+        upload.append(luisa::make_unique<TextureUploadCommand>(
+            swapchain.image.handle, swapchain.swapchain.storage,
+            0u, uint3{swapchain.size.x, swapchain.size.y, 1u},
+            swapchain.staging.data()));
+        auto upload_commit = upload.commit();
+        swapchain.device->dispatch(
+            swapchain.stream.handle,
+            std::move(upload_commit).command_list());
+        swapchain.device->present_display_in_stream(
+            swapchain.stream.handle,
+            swapchain.swapchain.handle,
+            swapchain.image.handle);
+        swapchain.submission_pending = true;
+    }
+
+    [[nodiscard]] ShaderCreationInfo create_shader(
+        const ShaderOption &option, Function kernel) noexcept {
+        if (!option.native_include.empty()) {
+            LUISA_ERROR(
+                "Remote AST shaders reject backend-native include text in protocol v1.");
+        }
+        auto ast = try_to_json(kernel);
+        if (!ast) {
+            LUISA_ERROR("Failed to serialize remote shader AST: {}", ast.error);
+        }
+        Writer writer;
+        write_shader_option(writer, option);
+        writer.write_blob({reinterpret_cast<const std::byte *>(ast.json.data()),
+                           ast.json.size()});
+        auto response = _request(MessageKind::CREATE_SHADER, writer.bytes());
+        Reader reader{response.body, _limits};
+        ShaderCreationInfo info{};
+        info.handle = reader.read_u64();
+        info.native_handle = nullptr;
+        info.block_size = uint3{
+            reader.read_u32(), reader.read_u32(), reader.read_u32()};
+        if (!reader.finish() ||
+            (!option.compile_only && !info.valid())) {
+            LUISA_ERROR("Remote shader-create response is malformed: {}",
+                        reader.error());
+        }
+        if (info.valid()) {
+            luisa::vector<Usage> usages;
+            usages.reserve(kernel.unbound_arguments().size());
+            for (auto argument : kernel.unbound_arguments()) {
+                usages.emplace_back(kernel.variable_usage(argument.uid()));
+            }
+            std::scoped_lock lock{_state_mutex};
+            _shader_usages.emplace(info.handle, std::move(usages));
+        }
+        return info;
+    }
+
+    [[nodiscard]] Usage shader_argument_usage(
+        uint64_t handle, size_t index) noexcept {
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (auto iter = _shader_usages.find(handle);
+                iter != _shader_usages.end()) {
+                if (index >= iter->second.size()) {
+                    LUISA_ERROR("Remote shader argument index {} is out of range.", index);
+                }
+                return iter->second[index];
+            }
+        }
+        Writer writer;
+        writer.write_u64(handle);
+        writer.write_u64(index);
+        auto response = _request(
+            MessageKind::SHADER_ARGUMENT_USAGE, writer.bytes());
+        Reader reader{response.body, _limits};
+        auto usage_value = reader.read_u32();
+        if (!reader.finish() ||
+            usage_value > static_cast<uint32_t>(Usage::READ_WRITE)) {
+            LUISA_ERROR("Remote shader-usage response is malformed.");
+        }
+        return static_cast<Usage>(usage_value);
+    }
+
+    void destroy_shader(uint64_t handle) noexcept {
+        static_cast<void>(_destroy_handle(
+            MessageKind::DESTROY_SHADER, handle));
+        std::scoped_lock lock{_state_mutex};
+        _shader_usages.erase(handle);
+    }
+
+    [[nodiscard]] uint64_t create_event() noexcept {
+        Writer writer;
+        return _create_handle(MessageKind::CREATE_EVENT, writer);
+    }
+
+    void destroy_event(uint64_t handle) noexcept {
+        static_cast<void>(_destroy_handle(
+            MessageKind::DESTROY_EVENT, handle));
+    }
+
+    void event_stream_operation(
+        MessageKind kind, uint64_t event, uint64_t stream,
+        uint64_t value) noexcept {
+        Writer writer;
+        writer.write_u64(event);
+        writer.write_u64(stream);
+        writer.write_u64(value);
+        static_cast<void>(_request(kind, writer.bytes()));
+    }
+
+    [[nodiscard]] bool is_event_completed(
+        uint64_t event, uint64_t value) noexcept {
+        Writer writer;
+        writer.write_u64(event);
+        writer.write_u64(value);
+        auto response = _request(
+            MessageKind::IS_EVENT_COMPLETED, writer.bytes());
+        Reader reader{response.body, _limits};
+        auto completed = reader.read_bool();
+        if (!reader.finish()) {
+            LUISA_ERROR("Remote event-query response is malformed: {}",
+                        reader.error());
+        }
+        return completed;
+    }
+
+    void synchronize_event(uint64_t event, uint64_t value) noexcept {
+        Writer writer;
+        writer.write_u64(event);
+        writer.write_u64(value);
+        static_cast<void>(_request(
+            MessageKind::SYNCHRONIZE_EVENT, writer.bytes()));
+    }
+
+    [[nodiscard]] uint64_t create_accel_resource(
+        MessageKind kind, const AccelOption &option) noexcept {
+        if ((_features & static_cast<uint64_t>(Feature::RAY_TRACING)) == 0u) {
+            LUISA_ERROR("The remote server does not advertise ray-tracing support.");
+        }
+        Writer writer;
+        write_accel_option(writer, option);
+        return _create_handle(kind, writer);
+    }
+
+    void destroy_accel_resource(
+        MessageKind kind, uint64_t handle) noexcept {
+        static_cast<void>(_destroy_handle(kind, handle));
+    }
+
+    [[nodiscard]] luisa::string query(
+        luisa::string_view property) noexcept {
+        if (property == "remote.connected") {
+            return _connection.connected() ? "true" : "false";
+        }
+        if (property == "remote.native_backend") { return _native_backend; }
+        if (property == "remote.device_selection") {
+            return (_features & static_cast<uint64_t>(
+                                    Feature::DEVICE_SELECTION)) != 0u ?
+                       "true" :
+                       "false";
+        }
+        if (property == "remote.protocol.max_frame_payload") {
+            return luisa::format("{}", _limits.max_frame_payload);
+        }
+        if (property == "remote.protocol.max_string_size") {
+            return luisa::format("{}", _limits.max_string_size);
+        }
+        if (property == "remote.protocol.max_array_size") {
+            return luisa::format("{}", _limits.max_array_size);
+        }
+        if (property == "remote.local_present_backend") {
+            std::scoped_lock lock{_present_mutex};
+            return _present_backend.empty() ?
+                       _select_present_backend() :
+                       _present_backend;
+        }
+        Writer writer;
+        writer.write_string(property);
+        auto response = _request(MessageKind::QUERY, writer.bytes());
+        Reader reader{response.body, _limits};
+        auto value = reader.read_string();
+        if (!reader.finish()) {
+            LUISA_ERROR("Remote query response is malformed: {}", reader.error());
+        }
+        return value;
+    }
+
+    void set_name(Resource::Tag tag, uint64_t handle,
+                  luisa::string_view name) noexcept {
+        if (tag == Resource::Tag::SWAP_CHAIN) {
+            std::scoped_lock lock{_present_mutex};
+            if (auto iter = _swapchains.find(handle);
+                iter != _swapchains.end()) {
+                iter->second->device->set_name(
+                    tag, iter->second->swapchain.handle, name);
+            }
+            return;
+        }
+        Writer writer;
+        writer.write_u32(static_cast<uint32_t>(tag));
+        writer.write_u64(handle);
+        writer.write_string(name);
+        static_cast<void>(_request(MessageKind::SET_NAME, writer.bytes()));
+    }
+};
+
+RemoteDevice::RemoteDevice(Context &&context,
+                           const DeviceConfig *config) noexcept
+    : DeviceInterface{Context{context}},
+      _impl{std::make_unique<Impl>(
+          std::move(context), client_options(config))} {}
+
+RemoteDevice::~RemoteDevice() noexcept = default;
+
+void *RemoteDevice::native_handle() const noexcept { return nullptr; }
+
+uint RemoteDevice::compute_warp_size() const noexcept {
+    return _impl->warp_size();
+}
+
+size_t RemoteDevice::compute_max_shared_memory_size() const noexcept {
+    return _impl->max_shared_memory();
+}
+
+uint64_t RemoteDevice::memory_granularity() const noexcept {
+    return _impl->memory_granularity();
+}
+
+BufferCreationInfo RemoteDevice::create_buffer(
+    const Type *element, size_t elem_count,
+    void *external_memory) noexcept {
+    if (external_memory != nullptr) {
+        LUISA_WARNING("Remote protocol v1 cannot import process-local buffer memory.");
+        return BufferCreationInfo::make_invalid();
+    }
+    return _impl->create_buffer(element, elem_count);
+}
+
+void RemoteDevice::destroy_buffer(uint64_t handle) noexcept {
+    _impl->destroy_buffer(handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_texture(
+    PixelFormat format, uint dimension,
+    uint width, uint height, uint depth,
+    uint mipmap_levels, void *external_native_handle,
+    bool simultaneous_access,
+    bool allow_raster_target) noexcept {
+    if (external_native_handle != nullptr) {
+        LUISA_WARNING("Remote protocol v1 cannot import process-local textures.");
+        return ResourceCreationInfo::make_invalid();
+    }
+    return ResourceCreationInfo{
+        .handle = _impl->create_texture(
+            format, dimension, width, height, depth, mipmap_levels,
+            simultaneous_access, allow_raster_target),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_texture(uint64_t handle) noexcept {
+    _impl->destroy_texture(handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_bindless_array(
+    size_t size, BindlessSlotType type) noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_bindless_array(size, type),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_bindless_array(uint64_t handle) noexcept {
+    _impl->destroy_bindless_array(handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_stream(StreamTag stream_tag) noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_stream(stream_tag),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_stream(uint64_t handle) noexcept {
+    _impl->destroy_stream(handle);
+}
+
+void RemoteDevice::synchronize_stream(uint64_t stream_handle) noexcept {
+    _impl->synchronize_stream(stream_handle);
+}
+
+void RemoteDevice::dispatch(
+    uint64_t stream_handle, CommandList &&list) noexcept {
+    struct PresentDesc {
+        uint64_t swapchain{};
+        uint64_t texture{};
+    };
+    luisa::vector<PresentDesc> presents;
+    presents.reserve(list.presents().size());
+    for (auto &&present : list.presents()) {
+        if (present.chain == nullptr) {
+            LUISA_ERROR("Remote command list contains a null swapchain presentation.");
+        }
+        presents.emplace_back(PresentDesc{
+            .swapchain = present.chain->handle(),
+            .texture = present.frame.handle()});
+    }
+    _impl->dispatch(stream_handle, std::move(list));
+    for (auto present : presents) {
+        _impl->present(
+            stream_handle, present.swapchain, present.texture);
+    }
+}
+
+void RemoteDevice::set_stream_log_callback(
+    uint64_t stream_handle,
+    const StreamLogCallback &callback) noexcept {
+    _impl->set_stream_log_callback(stream_handle, callback);
+}
+
+SwapchainCreationInfo RemoteDevice::create_swapchain(
+    const SwapchainOption &option, uint64_t stream_handle) noexcept {
+    return _impl->create_swapchain(option, stream_handle);
+}
+
+void RemoteDevice::destroy_swapchain(uint64_t handle) noexcept {
+    _impl->destroy_swapchain(handle);
+}
+
+void RemoteDevice::present_display_in_stream(
+    uint64_t stream_handle, uint64_t swapchain_handle,
+    uint64_t image_handle) noexcept {
+    _impl->present(stream_handle, swapchain_handle, image_handle);
+}
+
+ShaderCreationInfo RemoteDevice::create_shader(
+    const ShaderOption &option, Function kernel) noexcept {
+    return _impl->create_shader(option, kernel);
+}
+
+ShaderCreationInfo RemoteDevice::load_shader(
+    luisa::string_view,
+    luisa::span<const Type *const>) noexcept {
+    LUISA_WARNING("Remote AOT shader loading is not implemented in protocol v1 yet; use AST JIT creation.");
+    return ShaderCreationInfo::make_invalid();
+}
+
+Usage RemoteDevice::shader_argument_usage(
+    uint64_t handle, size_t index) noexcept {
+    return _impl->shader_argument_usage(handle, index);
+}
+
+void RemoteDevice::destroy_shader(uint64_t handle) noexcept {
+    _impl->destroy_shader(handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_event() noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_event(),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_event(uint64_t handle) noexcept {
+    _impl->destroy_event(handle);
+}
+
+void RemoteDevice::signal_event(
+    uint64_t handle, uint64_t stream_handle,
+    uint64_t fence_value) noexcept {
+    _impl->event_stream_operation(
+        MessageKind::SIGNAL_EVENT, handle, stream_handle, fence_value);
+}
+
+void RemoteDevice::wait_event(
+    uint64_t handle, uint64_t stream_handle,
+    uint64_t fence_value) noexcept {
+    _impl->event_stream_operation(
+        MessageKind::WAIT_EVENT, handle, stream_handle, fence_value);
+}
+
+bool RemoteDevice::is_event_completed(
+    uint64_t handle, uint64_t fence_value) const noexcept {
+    return _impl->is_event_completed(handle, fence_value);
+}
+
+void RemoteDevice::synchronize_event(
+    uint64_t handle, uint64_t fence_value) noexcept {
+    _impl->synchronize_event(handle, fence_value);
+}
+
+ResourceCreationInfo RemoteDevice::create_mesh(
+    const AccelOption &option) noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_accel_resource(
+            MessageKind::CREATE_MESH, option),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_mesh(uint64_t handle) noexcept {
+    _impl->destroy_accel_resource(MessageKind::DESTROY_MESH, handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_procedural_primitive(
+    const AccelOption &option) noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_accel_resource(
+            MessageKind::CREATE_PROCEDURAL_PRIMITIVE, option),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_procedural_primitive(uint64_t handle) noexcept {
+    _impl->destroy_accel_resource(
+        MessageKind::DESTROY_PROCEDURAL_PRIMITIVE, handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_curve(
+    const AccelOption &option) noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_accel_resource(
+            MessageKind::CREATE_CURVE, option),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_curve(uint64_t handle) noexcept {
+    _impl->destroy_accel_resource(MessageKind::DESTROY_CURVE, handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_motion_instance(
+    const AccelMotionOption &option) noexcept {
+    AccelOption accel_option;
+    accel_option.motion = option;
+    return ResourceCreationInfo{
+        .handle = _impl->create_accel_resource(
+            MessageKind::CREATE_MOTION_INSTANCE, accel_option),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_motion_instance(uint64_t handle) noexcept {
+    _impl->destroy_accel_resource(
+        MessageKind::DESTROY_MOTION_INSTANCE, handle);
+}
+
+ResourceCreationInfo RemoteDevice::create_accel(
+    const AccelOption &option) noexcept {
+    return ResourceCreationInfo{
+        .handle = _impl->create_accel_resource(
+            MessageKind::CREATE_ACCEL, option),
+        .native_handle = nullptr};
+}
+
+void RemoteDevice::destroy_accel(uint64_t handle) noexcept {
+    _impl->destroy_accel_resource(MessageKind::DESTROY_ACCEL, handle);
+}
+
+luisa::string RemoteDevice::query(
+    luisa::string_view property) noexcept {
+    return _impl->query(property);
+}
+
+DeviceExtension *RemoteDevice::extension(luisa::string_view) noexcept {
+    return nullptr;
+}
+
+void RemoteDevice::set_name(
+    Resource::Tag resource_tag, uint64_t resource_handle,
+    luisa::string_view name) noexcept {
+    _impl->set_name(resource_tag, resource_handle, name);
+}
+
+}// namespace luisa::compute::remote
+
+LUISA_EXPORT_API luisa::compute::DeviceInterface *create(
+    luisa::compute::Context &&context,
+    const luisa::compute::DeviceConfig *config) noexcept {
+    return luisa::new_with_allocator<
+        luisa::compute::remote::RemoteDevice>(
+        std::move(context), config);
+}
+
+LUISA_EXPORT_API void destroy(
+    luisa::compute::DeviceInterface *device) noexcept {
+    luisa::delete_with_allocator(device);
+}
+
+LUISA_EXPORT_API void backend_device_names(
+    luisa::vector<luisa::string> &names) noexcept {
+    names.clear();
+    names.emplace_back("Remote LuisaCompute device");
+}
+
+#include "../common/export_version.inl.h"

--- a/src/backends/remote/remote_device.h
+++ b/src/backends/remote/remote_device.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <memory>
+
+#include <luisa/runtime/rhi/device_interface.h>
+
+namespace luisa::compute::remote {
+
+class RemoteDevice final : public DeviceInterface {
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+
+public:
+    explicit RemoteDevice(Context &&context,
+                          const DeviceConfig *config) noexcept;
+    ~RemoteDevice() noexcept override;
+
+    [[nodiscard]] void *native_handle() const noexcept override;
+    [[nodiscard]] uint compute_warp_size() const noexcept override;
+    [[nodiscard]] size_t compute_max_shared_memory_size() const noexcept override;
+    [[nodiscard]] uint64_t memory_granularity() const noexcept override;
+
+    [[nodiscard]] BufferCreationInfo create_buffer(
+        const Type *element, size_t elem_count,
+        void *external_memory) noexcept override;
+    void destroy_buffer(uint64_t handle) noexcept override;
+
+    [[nodiscard]] ResourceCreationInfo create_texture(
+        PixelFormat format, uint dimension,
+        uint width, uint height, uint depth,
+        uint mipmap_levels, void *external_native_handle,
+        bool simultaneous_access,
+        bool allow_raster_target) noexcept override;
+    void destroy_texture(uint64_t handle) noexcept override;
+
+    [[nodiscard]] ResourceCreationInfo create_bindless_array(
+        size_t size, BindlessSlotType type) noexcept override;
+    void destroy_bindless_array(uint64_t handle) noexcept override;
+
+    [[nodiscard]] ResourceCreationInfo create_stream(
+        StreamTag stream_tag) noexcept override;
+    void destroy_stream(uint64_t handle) noexcept override;
+    void synchronize_stream(uint64_t stream_handle) noexcept override;
+    void dispatch(uint64_t stream_handle, CommandList &&list) noexcept override;
+    void set_stream_log_callback(
+        uint64_t stream_handle,
+        const StreamLogCallback &callback) noexcept override;
+
+    [[nodiscard]] SwapchainCreationInfo create_swapchain(
+        const SwapchainOption &option,
+        uint64_t stream_handle) noexcept override;
+    void destroy_swapchain(uint64_t handle) noexcept override;
+    void present_display_in_stream(
+        uint64_t stream_handle, uint64_t swapchain_handle,
+        uint64_t image_handle) noexcept override;
+
+    [[nodiscard]] ShaderCreationInfo create_shader(
+        const ShaderOption &option, Function kernel) noexcept override;
+    [[nodiscard]] ShaderCreationInfo load_shader(
+        luisa::string_view name,
+        luisa::span<const Type *const> arg_types) noexcept override;
+    [[nodiscard]] Usage shader_argument_usage(
+        uint64_t handle, size_t index) noexcept override;
+    void destroy_shader(uint64_t handle) noexcept override;
+
+    [[nodiscard]] ResourceCreationInfo create_event() noexcept override;
+    void destroy_event(uint64_t handle) noexcept override;
+    void signal_event(uint64_t handle, uint64_t stream_handle,
+                      uint64_t fence_value) noexcept override;
+    void wait_event(uint64_t handle, uint64_t stream_handle,
+                    uint64_t fence_value) noexcept override;
+    [[nodiscard]] bool is_event_completed(
+        uint64_t handle, uint64_t fence_value) const noexcept override;
+    void synchronize_event(
+        uint64_t handle, uint64_t fence_value) noexcept override;
+
+    [[nodiscard]] ResourceCreationInfo create_mesh(
+        const AccelOption &option) noexcept override;
+    void destroy_mesh(uint64_t handle) noexcept override;
+    [[nodiscard]] ResourceCreationInfo create_procedural_primitive(
+        const AccelOption &option) noexcept override;
+    void destroy_procedural_primitive(uint64_t handle) noexcept override;
+    [[nodiscard]] ResourceCreationInfo create_curve(
+        const AccelOption &option) noexcept override;
+    void destroy_curve(uint64_t handle) noexcept override;
+    [[nodiscard]] ResourceCreationInfo create_motion_instance(
+        const AccelMotionOption &option) noexcept override;
+    void destroy_motion_instance(uint64_t handle) noexcept override;
+    [[nodiscard]] ResourceCreationInfo create_accel(
+        const AccelOption &option) noexcept override;
+    void destroy_accel(uint64_t handle) noexcept override;
+
+    [[nodiscard]] luisa::string query(
+        luisa::string_view property) noexcept override;
+    [[nodiscard]] DeviceExtension *extension(
+        luisa::string_view name) noexcept override;
+    void set_name(Resource::Tag resource_tag,
+                  uint64_t resource_handle,
+                  luisa::string_view name) noexcept override;
+};
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_protocol.cpp
+++ b/src/backends/remote/remote_protocol.cpp
@@ -1,0 +1,252 @@
+#include "remote_protocol.h"
+
+#include <bit>
+#include <cstring>
+
+#include <luisa/core/stl/hash.h>
+
+namespace luisa::compute::remote {
+
+namespace {
+
+template<typename T>
+void append_little_endian(luisa::vector<std::byte> &bytes, T value) noexcept {
+    static_assert(std::is_unsigned_v<T>);
+    for (auto i = 0u; i < sizeof(T); i++) {
+        bytes.emplace_back(static_cast<std::byte>(value & static_cast<T>(0xffu)));
+        value >>= 8u;
+    }
+}
+
+template<typename T>
+[[nodiscard]] T read_little_endian(luisa::span<const std::byte> bytes) noexcept {
+    static_assert(std::is_unsigned_v<T>);
+    T value{};
+    for (auto i = 0u; i < sizeof(T); i++) {
+        value |= static_cast<T>(std::to_integer<uint8_t>(bytes[i])) << (i * 8u);
+    }
+    return value;
+}
+
+}// namespace
+
+void Writer::write_u8(uint8_t value) noexcept {
+    _bytes.emplace_back(static_cast<std::byte>(value));
+}
+
+void Writer::write_u16(uint16_t value) noexcept {
+    append_little_endian(_bytes, value);
+}
+
+void Writer::write_u32(uint32_t value) noexcept {
+    append_little_endian(_bytes, value);
+}
+
+void Writer::write_u64(uint64_t value) noexcept {
+    append_little_endian(_bytes, value);
+}
+
+void Writer::write_i64(int64_t value) noexcept {
+    write_u64(std::bit_cast<uint64_t>(value));
+}
+
+void Writer::write_bool(bool value) noexcept {
+    write_u8(value ? 1u : 0u);
+}
+
+void Writer::write_f32(float value) noexcept {
+    write_u32(std::bit_cast<uint32_t>(value));
+}
+
+void Writer::write_bytes(luisa::span<const std::byte> value) noexcept {
+    _bytes.insert(_bytes.end(), value.begin(), value.end());
+}
+
+void Writer::write_blob(luisa::span<const std::byte> value) noexcept {
+    write_u64(value.size());
+    write_bytes(value);
+}
+
+void Writer::write_string(luisa::string_view value) noexcept {
+    write_u64(value.size());
+    write_bytes({reinterpret_cast<const std::byte *>(value.data()), value.size()});
+}
+
+bool Reader::_require(size_t size) noexcept {
+    if (!ok()) { return false; }
+    if (size > remaining()) {
+        _fail("Truncated remote protocol payload.");
+        return false;
+    }
+    return true;
+}
+
+void Reader::_fail(luisa::string message) noexcept {
+    if (_error.empty()) { _error = std::move(message); }
+}
+
+uint8_t Reader::read_u8() noexcept {
+    if (!_require(1u)) { return 0u; }
+    return std::to_integer<uint8_t>(_bytes[_offset++]);
+}
+
+uint16_t Reader::read_u16() noexcept {
+    if (!_require(sizeof(uint16_t))) { return 0u; }
+    auto value = read_little_endian<uint16_t>(_bytes.subspan(_offset, sizeof(uint16_t)));
+    _offset += sizeof(uint16_t);
+    return value;
+}
+
+uint32_t Reader::read_u32() noexcept {
+    if (!_require(sizeof(uint32_t))) { return 0u; }
+    auto value = read_little_endian<uint32_t>(_bytes.subspan(_offset, sizeof(uint32_t)));
+    _offset += sizeof(uint32_t);
+    return value;
+}
+
+uint64_t Reader::read_u64() noexcept {
+    if (!_require(sizeof(uint64_t))) { return 0u; }
+    auto value = read_little_endian<uint64_t>(_bytes.subspan(_offset, sizeof(uint64_t)));
+    _offset += sizeof(uint64_t);
+    return value;
+}
+
+int64_t Reader::read_i64() noexcept {
+    return std::bit_cast<int64_t>(read_u64());
+}
+
+bool Reader::read_bool() noexcept {
+    auto value = read_u8();
+    if (ok() && value > 1u) { _fail("Invalid remote protocol boolean."); }
+    return value != 0u;
+}
+
+float Reader::read_f32() noexcept {
+    return std::bit_cast<float>(read_u32());
+}
+
+luisa::span<const std::byte> Reader::read_bytes(size_t size) noexcept {
+    if (!_require(size)) { return {}; }
+    auto value = _bytes.subspan(_offset, size);
+    _offset += size;
+    return value;
+}
+
+luisa::span<const std::byte> Reader::read_blob() noexcept {
+    auto size = read_u64();
+    if (!ok()) { return {}; }
+    if (size > _limits.max_frame_payload || size > std::numeric_limits<size_t>::max()) {
+        _fail("Remote protocol blob exceeds the configured limit.");
+        return {};
+    }
+    return read_bytes(static_cast<size_t>(size));
+}
+
+luisa::string Reader::read_string() noexcept {
+    auto size = read_u64();
+    if (!ok()) { return {}; }
+    if (size > _limits.max_string_size || size > std::numeric_limits<size_t>::max()) {
+        _fail("Remote protocol string exceeds the configured limit.");
+        return {};
+    }
+    auto value = read_bytes(static_cast<size_t>(size));
+    if (!ok()) { return {}; }
+    return {reinterpret_cast<const char *>(value.data()), value.size()};
+}
+
+bool Reader::finish() noexcept {
+    if (ok() && remaining() != 0u) {
+        _fail("Unexpected trailing bytes in remote protocol payload.");
+    }
+    return ok();
+}
+
+luisa::vector<std::byte> encode_frame_header(const FrameHeader &header) noexcept {
+    Writer writer{frame_header_size};
+    writer.write_u32(protocol_magic);
+    writer.write_u16(header.wire_major);
+    writer.write_u16(header.wire_minor);
+    writer.write_u16(static_cast<uint16_t>(header.kind));
+    writer.write_u16(header.flags);
+    writer.write_u32(0u);
+    writer.write_u64(header.request_id);
+    writer.write_u64(header.payload_size);
+    writer.write_u64(header.payload_checksum);
+    return std::move(writer).take();
+}
+
+bool decode_frame_header(luisa::span<const std::byte> bytes,
+                         FrameHeader &header,
+                         luisa::string &error,
+                         ProtocolLimits limits) noexcept {
+    if (bytes.size() != frame_header_size) {
+        error = "Invalid remote protocol frame-header size.";
+        return false;
+    }
+    Reader reader{bytes, limits};
+    if (reader.read_u32() != protocol_magic) {
+        error = "Invalid remote protocol magic.";
+        return false;
+    }
+    header.wire_major = reader.read_u16();
+    header.wire_minor = reader.read_u16();
+    if (header.wire_major != protocol_major ||
+        header.wire_minor > protocol_minor) {
+        error = "Unsupported remote protocol version.";
+        return false;
+    }
+    header.kind = static_cast<MessageKind>(reader.read_u16());
+    header.flags = reader.read_u16();
+    if (reader.read_u32() != 0u) {
+        error = "Remote protocol reserved frame bits are nonzero.";
+        return false;
+    }
+    header.request_id = reader.read_u64();
+    header.payload_size = reader.read_u64();
+    header.payload_checksum = reader.read_u64();
+    if (!reader.finish()) {
+        error = reader.error();
+        return false;
+    }
+    if (header.payload_size > limits.max_frame_payload ||
+        header.payload_size > std::numeric_limits<size_t>::max()) {
+        error = "Remote protocol frame exceeds the configured payload limit.";
+        return false;
+    }
+    return true;
+}
+
+uint64_t payload_checksum(luisa::span<const std::byte> payload) noexcept {
+    return luisa::hash64(payload.data(), payload.size(), 0x4c4352505f5631ull);
+}
+
+luisa::vector<std::byte> make_response_payload(
+    MessageKind request_kind,
+    Status status,
+    luisa::string_view message,
+    luisa::span<const std::byte> body) noexcept {
+    Writer writer;
+    writer.write_u16(static_cast<uint16_t>(request_kind));
+    writer.write_u16(static_cast<uint16_t>(status));
+    writer.write_string(message);
+    writer.write_bytes(body);
+    return std::move(writer).take();
+}
+
+bool decode_response_payload(luisa::span<const std::byte> payload,
+                             ResponseView &response,
+                             luisa::string &error,
+                             ProtocolLimits limits) noexcept {
+    Reader reader{payload, limits};
+    response.request_kind = static_cast<MessageKind>(reader.read_u16());
+    response.status = static_cast<Status>(reader.read_u16());
+    response.message = reader.read_string();
+    if (!reader.ok()) {
+        error = reader.error();
+        return false;
+    }
+    response.body = payload.subspan(reader.offset());
+    return true;
+}
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_protocol.h
+++ b/src/backends/remote/remote_protocol.h
@@ -1,0 +1,238 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include <luisa/core/stl/memory.h>
+#include <luisa/core/stl/string.h>
+#include <luisa/core/stl/vector.h>
+
+namespace luisa::compute::remote {
+
+constexpr uint32_t protocol_magic = 0x5052434cu;// "LCRP" in little endian
+constexpr uint16_t protocol_major = 1u;
+constexpr uint16_t protocol_minor = 1u;
+constexpr size_t frame_header_size = 40u;
+constexpr uint64_t default_max_frame_payload = 512ull * 1024ull * 1024ull;
+constexpr uint64_t default_max_string_size = 1ull * 1024ull * 1024ull;
+constexpr uint64_t default_max_array_size = 1ull << 24u;
+
+enum class MessageKind : uint16_t {
+    HELLO = 1u,
+    RESPONSE = 2u,
+    ERROR = 3u,
+    CREATE_BUFFER = 10u,
+    DESTROY_BUFFER = 11u,
+    CREATE_TEXTURE = 12u,
+    DESTROY_TEXTURE = 13u,
+    CREATE_BINDLESS_ARRAY = 14u,
+    DESTROY_BINDLESS_ARRAY = 15u,
+    CREATE_STREAM = 16u,
+    DESTROY_STREAM = 17u,
+    SYNCHRONIZE_STREAM = 18u,
+    CREATE_SHADER = 19u,
+    LOAD_SHADER = 20u,
+    DESTROY_SHADER = 21u,
+    CREATE_EVENT = 22u,
+    DESTROY_EVENT = 23u,
+    SIGNAL_EVENT = 24u,
+    WAIT_EVENT = 25u,
+    IS_EVENT_COMPLETED = 26u,
+    SYNCHRONIZE_EVENT = 27u,
+    CREATE_MESH = 28u,
+    DESTROY_MESH = 29u,
+    CREATE_PROCEDURAL_PRIMITIVE = 30u,
+    DESTROY_PROCEDURAL_PRIMITIVE = 31u,
+    CREATE_CURVE = 32u,
+    DESTROY_CURVE = 33u,
+    CREATE_MOTION_INSTANCE = 34u,
+    DESTROY_MOTION_INSTANCE = 35u,
+    CREATE_ACCEL = 36u,
+    DESTROY_ACCEL = 37u,
+    DISPATCH = 40u,
+    DISPATCH_COMPLETE = 41u,
+    QUERY = 42u,
+    SET_NAME = 43u,
+    STREAM_LOG = 44u,
+    GOODBYE = 45u,
+    SHADER_ARGUMENT_USAGE = 46u,
+    SET_STREAM_LOG_CALLBACK = 47u,
+    PREPARE_BLOBS = 48u,
+    UPLOAD_BLOBS = 49u,
+    BLOB_CACHE_INFO = 50u,
+    PROTOCOL_INFO = 51u,
+};
+
+enum class Feature : uint64_t {
+    BUFFER = 1ull << 0u,
+    TEXTURE = 1ull << 1u,
+    STREAM = 1ull << 2u,
+    AST_SHADER = 1ull << 3u,
+    EVENT = 1ull << 4u,
+    ASYNC_DISPATCH = 1ull << 5u,
+    STREAM_LOG = 1ull << 6u,
+    BINDLESS_ARRAY = 1ull << 7u,
+    RAY_TRACING = 1ull << 8u,
+    BLOB_CACHE = 1ull << 9u,
+    LIMIT_NEGOTIATION = 1ull << 10u,
+    DEVICE_SELECTION = 1ull << 11u,
+};
+
+[[nodiscard]] constexpr uint64_t operator|(Feature lhs, Feature rhs) noexcept {
+    return static_cast<uint64_t>(lhs) | static_cast<uint64_t>(rhs);
+}
+
+enum class ResourceKind : uint8_t {
+    BUFFER = 1u,
+    TEXTURE = 2u,
+    BINDLESS_ARRAY = 3u,
+    STREAM = 4u,
+    SHADER = 5u,
+    EVENT = 6u,
+    MESH = 7u,
+    CURVE = 8u,
+    PROCEDURAL_PRIMITIVE = 9u,
+    MOTION_INSTANCE = 10u,
+    ACCEL = 11u,
+};
+
+enum class BufferKind : uint8_t {
+    BYTE = 0u,
+    INDIRECT_DISPATCH = 1u,
+};
+
+constexpr uint64_t resource_kind_shift = 56u;
+constexpr uint64_t resource_index_mask = (1ull << resource_kind_shift) - 1ull;
+
+[[nodiscard]] constexpr uint64_t make_resource_id(
+    ResourceKind kind, uint64_t index) noexcept {
+    return (static_cast<uint64_t>(kind) << resource_kind_shift) |
+           (index & resource_index_mask);
+}
+
+[[nodiscard]] constexpr ResourceKind resource_kind(uint64_t id) noexcept {
+    return static_cast<ResourceKind>(id >> resource_kind_shift);
+}
+
+enum class Status : uint16_t {
+    OK = 0u,
+    INVALID_REQUEST = 1u,
+    UNSUPPORTED = 2u,
+    NOT_FOUND = 3u,
+    BACKEND_ERROR = 4u,
+    VERSION_MISMATCH = 5u,
+    AUTHENTICATION_FAILED = 6u,
+    RESOURCE_LIMIT = 7u,
+    CONNECTION_CLOSED = 8u,
+    TIMEOUT = 9u,
+};
+
+struct ProtocolLimits {
+    uint64_t max_frame_payload{default_max_frame_payload};
+    uint64_t max_string_size{default_max_string_size};
+    uint64_t max_array_size{default_max_array_size};
+};
+
+struct FrameHeader {
+    MessageKind kind{};
+    uint16_t flags{};
+    uint64_t request_id{};
+    uint64_t payload_size{};
+    uint64_t payload_checksum{};
+    uint16_t wire_major{protocol_major};
+    uint16_t wire_minor{protocol_minor};
+};
+
+class Writer {
+
+private:
+    luisa::vector<std::byte> _bytes;
+
+public:
+    Writer() noexcept = default;
+    explicit Writer(size_t reserve) noexcept { _bytes.reserve(reserve); }
+
+    void write_u8(uint8_t value) noexcept;
+    void write_u16(uint16_t value) noexcept;
+    void write_u32(uint32_t value) noexcept;
+    void write_u64(uint64_t value) noexcept;
+    void write_i64(int64_t value) noexcept;
+    void write_bool(bool value) noexcept;
+    void write_f32(float value) noexcept;
+    void write_bytes(luisa::span<const std::byte> value) noexcept;
+    void write_blob(luisa::span<const std::byte> value) noexcept;
+    void write_string(luisa::string_view value) noexcept;
+
+    [[nodiscard]] auto bytes() const noexcept { return luisa::span{_bytes}; }
+    [[nodiscard]] auto &&take() && noexcept { return std::move(_bytes); }
+};
+
+class Reader {
+
+private:
+    luisa::span<const std::byte> _bytes;
+    ProtocolLimits _limits;
+    size_t _offset{};
+    luisa::string _error;
+
+private:
+    [[nodiscard]] bool _require(size_t size) noexcept;
+    void _fail(luisa::string message) noexcept;
+
+public:
+    explicit Reader(luisa::span<const std::byte> bytes,
+                    ProtocolLimits limits = {}) noexcept
+        : _bytes{bytes}, _limits{limits} {}
+
+    [[nodiscard]] uint8_t read_u8() noexcept;
+    [[nodiscard]] uint16_t read_u16() noexcept;
+    [[nodiscard]] uint32_t read_u32() noexcept;
+    [[nodiscard]] uint64_t read_u64() noexcept;
+    [[nodiscard]] int64_t read_i64() noexcept;
+    [[nodiscard]] bool read_bool() noexcept;
+    [[nodiscard]] float read_f32() noexcept;
+    [[nodiscard]] luisa::span<const std::byte> read_bytes(size_t size) noexcept;
+    [[nodiscard]] luisa::span<const std::byte> read_blob() noexcept;
+    [[nodiscard]] luisa::string read_string() noexcept;
+
+    [[nodiscard]] auto offset() const noexcept { return _offset; }
+    [[nodiscard]] auto remaining() const noexcept { return _bytes.size() - _offset; }
+    [[nodiscard]] auto error() const noexcept { return luisa::string_view{_error}; }
+    [[nodiscard]] auto ok() const noexcept { return _error.empty(); }
+    [[nodiscard]] bool finish() noexcept;
+};
+
+[[nodiscard]] luisa::vector<std::byte>
+encode_frame_header(const FrameHeader &header) noexcept;
+
+[[nodiscard]] bool decode_frame_header(
+    luisa::span<const std::byte> bytes,
+    FrameHeader &header,
+    luisa::string &error,
+    ProtocolLimits limits = {}) noexcept;
+
+[[nodiscard]] uint64_t payload_checksum(
+    luisa::span<const std::byte> payload) noexcept;
+
+[[nodiscard]] luisa::vector<std::byte> make_response_payload(
+    MessageKind request_kind,
+    Status status,
+    luisa::string_view message,
+    luisa::span<const std::byte> body = {}) noexcept;
+
+struct ResponseView {
+    MessageKind request_kind{};
+    Status status{Status::INVALID_REQUEST};
+    luisa::string message;
+    luisa::span<const std::byte> body;
+};
+
+[[nodiscard]] bool decode_response_payload(
+    luisa::span<const std::byte> payload,
+    ResponseView &response,
+    luisa::string &error,
+    ProtocolLimits limits = {}) noexcept;
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_server.cpp
+++ b/src/backends/remote/remote_server.cpp
@@ -132,6 +132,7 @@ private:
     luisa::shared_ptr<BlobCache> _blob_cache;
     const ServerOptions &_options;
     bool _device_selection_enabled{};
+    std::mutex _socket_mutex;
     std::mutex _write_mutex;
     std::mutex _pending_mutex;
     std::unordered_set<uint64_t> _pending_submissions;
@@ -1515,9 +1516,10 @@ public:
     void stop() noexcept {
         _alive.store(false, std::memory_order_release);
         asio::error_code ignored;
-        _socket.cancel(ignored);
+        std::scoped_lock lock{_socket_mutex};
+        // Asio permits shutdown concurrently with synchronous reads and writes,
+        // but close must remain on the session thread after they unblock.
         _socket.shutdown(Tcp::socket::shutdown_both, ignored);
-        _socket.close(ignored);
     }
 
     void run() noexcept {
@@ -1533,8 +1535,11 @@ public:
         }
         _alive.store(false, std::memory_order_release);
         asio::error_code ignored;
-        _socket.shutdown(Tcp::socket::shutdown_both, ignored);
-        _socket.close(ignored);
+        {
+            std::scoped_lock lock{_socket_mutex, _write_mutex};
+            _socket.shutdown(Tcp::socket::shutdown_both, ignored);
+            _socket.close(ignored);
+        }
         _cleanup();
         _native.reset();
     }

--- a/src/backends/remote/remote_server.cpp
+++ b/src/backends/remote/remote_server.cpp
@@ -1,0 +1,2073 @@
+#include "remote_server.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <bit>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <asio.hpp>
+
+#include <luisa/ast/ast2json.h>
+#include <luisa/ast/type.h>
+#include <luisa/core/logging.h>
+#include <luisa/core/mathematics.h>
+#include <luisa/core/stl/format.h>
+
+#include "remote_command_codec.h"
+
+namespace luisa::compute::remote {
+
+namespace {
+
+using Tcp = asio::ip::tcp;
+constexpr luisa::string_view indirect_dispatch_element_type_name =
+    "LC_IndirectKernelDispatch";
+
+struct Reply {
+    Status status{Status::OK};
+    luisa::string message;
+    luisa::vector<std::byte> body;
+};
+
+[[nodiscard]] Reply invalid(luisa::string message) noexcept {
+    return Reply{.status = Status::INVALID_REQUEST,
+                 .message = std::move(message)};
+}
+
+[[nodiscard]] Reply unsupported(luisa::string message) noexcept {
+    return Reply{.status = Status::UNSUPPORTED,
+                 .message = std::move(message)};
+}
+
+[[nodiscard]] Reply not_found(luisa::string message) noexcept {
+    return Reply{.status = Status::NOT_FOUND,
+                 .message = std::move(message)};
+}
+
+[[nodiscard]] bool secure_equal(
+    luisa::string_view lhs, luisa::string_view rhs) noexcept {
+    auto difference = static_cast<uint8_t>(lhs.size() != rhs.size());
+    auto count = std::max(lhs.size(), rhs.size());
+    for (size_t i = 0u; i < count; i++) {
+        auto lhs_byte = i < lhs.size() ? static_cast<uint8_t>(lhs[i]) : 0u;
+        auto rhs_byte = i < rhs.size() ? static_cast<uint8_t>(rhs[i]) : 0u;
+        difference |= lhs_byte ^ rhs_byte;
+    }
+    return difference == 0u;
+}
+
+[[nodiscard]] bool valid_range(
+    size_t offset, size_t size, size_t total) noexcept {
+    return offset <= total && size <= total - offset;
+}
+
+[[nodiscard]] bool valid_backend_name(
+    luisa::string_view name) noexcept {
+    if (name.size() > 128u) { return false; }
+    return std::all_of(
+        name.begin(), name.end(), [](char c) noexcept {
+            auto u = static_cast<unsigned char>(c);
+            return (u >= 'a' && u <= 'z') ||
+                   (u >= 'A' && u <= 'Z') ||
+                   (u >= '0' && u <= '9') ||
+                   c == '_' || c == '-' || c == '.';
+        });
+}
+
+}// namespace
+
+class Session final : public luisa::enable_shared_from_this<Session>,
+                      public CommandHandleResolver,
+                      public ASTJsonBindingResolver {
+
+private:
+    struct BufferRecord {
+        BufferCreationInfo native;
+        size_t size_bytes{};
+        bool is_indirect_dispatch{};
+        size_t indirect_dispatch_capacity{};
+    };
+    struct TextureRecord {
+        ResourceCreationInfo native;
+        PixelStorage storage{};
+        uint3 size{};
+        uint mip_levels{};
+    };
+    struct ResourceRecord {
+        ResourceCreationInfo native;
+    };
+    struct StreamRecord {
+        ResourceCreationInfo native;
+        bool log_callback_installed{};
+    };
+    struct BindlessRecord {
+        ResourceCreationInfo native;
+        size_t slot_count{};
+        BindlessSlotType slot_type{};
+    };
+    struct ShaderRecord {
+        ShaderCreationInfo native;
+        luisa::vector<ShaderArgumentDesc> arguments;
+    };
+    struct MotionInstanceRecord {
+        ResourceCreationInfo native;
+        size_t keyframe_count{};
+    };
+    struct PreparedBlobBatch {
+        luisa::vector<BlobKey> keys;
+        luisa::vector<BlobCache::BlobPtr> blobs;
+    };
+
+    Tcp::socket _socket;
+    luisa::shared_ptr<DeviceInterface> _native;
+    const DeviceFactory &_device_factory;
+    luisa::shared_ptr<BlobCache> _blob_cache;
+    const ServerOptions &_options;
+    bool _device_selection_enabled{};
+    std::mutex _write_mutex;
+    std::mutex _pending_mutex;
+    std::unordered_set<uint64_t> _pending_submissions;
+    std::unordered_map<uint64_t, BufferRecord> _buffers;
+    std::unordered_map<uint64_t, TextureRecord> _textures;
+    std::unordered_map<uint64_t, BindlessRecord> _bindless_arrays;
+    std::unordered_map<uint64_t, StreamRecord> _streams;
+    std::unordered_map<uint64_t, ShaderRecord> _shaders;
+    std::unordered_map<uint64_t, ResourceRecord> _events;
+    std::unordered_map<uint64_t, ResourceRecord> _meshes;
+    std::unordered_map<uint64_t, ResourceRecord> _curves;
+    std::unordered_map<uint64_t, ResourceRecord> _procedural_primitives;
+    std::unordered_map<uint64_t, MotionInstanceRecord> _motion_instances;
+    std::unordered_map<uint64_t, ResourceRecord> _accels;
+    std::unordered_map<uint64_t, PreparedBlobBatch> _blob_batches;
+    std::atomic_bool _alive{true};
+    uint64_t _next_resource_index{1u};
+    bool _handshake_complete{false};
+    bool _close_after_reply{false};
+    uint16_t _wire_minor{protocol_minor};
+    bool _wire_version_set{false};
+
+private:
+    [[nodiscard]] size_t _resource_count() const noexcept {
+        return _buffers.size() + _textures.size() + _bindless_arrays.size() +
+               _streams.size() + _shaders.size() + _events.size() +
+               _meshes.size() + _curves.size() +
+               _procedural_primitives.size() + _motion_instances.size() +
+               _accels.size();
+    }
+
+    [[nodiscard]] uint64_t _allocate_id(ResourceKind kind) noexcept {
+        if (_next_resource_index > resource_index_mask) { return invalid_resource_handle; }
+        return make_resource_id(kind, _next_resource_index++);
+    }
+
+    [[nodiscard]] bool _can_create_resource(Reply &reply) const noexcept {
+        if (_resource_count() >= _options.max_resources) {
+            reply.status = Status::RESOURCE_LIMIT;
+            reply.message = "Remote session resource-count limit reached.";
+            return false;
+        }
+        if (_next_resource_index > resource_index_mask) {
+            reply.status = Status::RESOURCE_LIMIT;
+            reply.message = "Remote resource-ID space exhausted.";
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _send_frame(
+        MessageKind kind, uint64_t request_id,
+        luisa::span<const std::byte> payload) noexcept {
+        if (!_alive.load(std::memory_order_acquire) ||
+            payload.size() > _options.protocol_limits.max_frame_payload) {
+            return false;
+        }
+        auto header = encode_frame_header(FrameHeader{
+            .kind = kind,
+            .request_id = request_id,
+            .payload_size = payload.size(),
+            .payload_checksum = payload_checksum(payload),
+            .wire_major = protocol_major,
+            .wire_minor = _wire_minor});
+        asio::error_code error;
+        {
+            std::scoped_lock lock{_write_mutex};
+            std::array<asio::const_buffer, 2u> buffers{
+                asio::buffer(static_cast<const void *>(header.data()), header.size()),
+                asio::buffer(payload.data(), payload.size())};
+            asio::write(_socket, buffers, error);
+        }
+        if (error) { _alive.store(false, std::memory_order_release); }
+        return !error;
+    }
+
+    [[nodiscard]] bool _send_reply(
+        MessageKind request_kind, uint64_t request_id,
+        Reply reply) noexcept {
+        auto payload = make_response_payload(
+            request_kind, reply.status, reply.message, reply.body);
+        auto response_kind = reply.status == Status::OK ?
+                                 MessageKind::RESPONSE :
+                                 MessageKind::ERROR;
+        return _send_frame(response_kind, request_id, payload);
+    }
+
+    [[nodiscard]] bool _read_frame(
+        FrameHeader &header, luisa::vector<std::byte> &payload) noexcept {
+        std::array<std::byte, frame_header_size> header_bytes{};
+        asio::error_code error;
+        asio::read(_socket, asio::buffer(header_bytes), error);
+        if (error) { return false; }
+        luisa::string decode_error;
+        if (!decode_frame_header(
+                header_bytes, header, decode_error,
+                _options.protocol_limits) ||
+            header.request_id == 0u) {
+            return false;
+        }
+        if (!_wire_version_set) {
+            _wire_minor = header.wire_minor;
+            _wire_version_set = true;
+        } else if (header.wire_major != protocol_major ||
+                   header.wire_minor != _wire_minor) {
+            return false;
+        }
+        payload.resize(static_cast<size_t>(header.payload_size));
+        if (!payload.empty()) {
+            asio::read(_socket, asio::buffer(payload), error);
+            if (error) { return false; }
+        }
+        return payload_checksum(payload) == header.payload_checksum;
+    }
+
+    [[nodiscard]] Reply _hello(luisa::span<const std::byte> payload) noexcept {
+        if (_handshake_complete) {
+            return invalid("Remote HELLO may only be sent once per session.");
+        }
+        Reader reader{payload, _options.protocol_limits};
+        auto endian_marker = reader.read_u32();
+        auto pointer_width = reader.read_u8();
+        auto ieee754 = reader.read_u8();
+        auto reserved = reader.read_u16();
+        auto token = reader.read_string();
+        DeviceRequest device_request;
+        if (reader.ok() && reader.remaining() != 0u) {
+            device_request.backend = reader.read_string();
+            auto device_index = reader.read_u64();
+            device_request.enable_validation = reader.read_bool();
+            if (device_index > std::numeric_limits<size_t>::max()) {
+                return invalid("Remote device index exceeds the host size limit.");
+            }
+            device_request.device_index = static_cast<size_t>(device_index);
+        }
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (std::endian::native != std::endian::little ||
+            endian_marker != 0x01020304u || pointer_width != 8u ||
+            ieee754 != 1u || reserved != 0u) {
+            return Reply{
+                .status = Status::VERSION_MISMATCH,
+                .message = "Remote protocol v1 requires little-endian, 64-bit, IEEE-754 hosts."};
+        }
+        if (!secure_equal(token, _options.token)) {
+            _close_after_reply = true;
+            return Reply{
+                .status = Status::AUTHENTICATION_FAILED,
+                .message = "Remote authentication failed."};
+        }
+        if (!valid_backend_name(device_request.backend)) {
+            _close_after_reply = true;
+            return invalid("Remote backend name contains invalid characters or is too long.");
+        }
+        luisa::string device_error;
+        auto factory_failed = false;
+        try {
+            _native = _device_factory(device_request, device_error);
+        } catch (const std::exception &exception) {
+            factory_failed = true;
+            device_error = luisa::format(
+                "Remote device factory threw an exception: {}", exception.what());
+        } catch (...) {
+            factory_failed = true;
+            device_error = "Remote device factory threw an unknown exception.";
+        }
+        if (_native == nullptr) {
+            _close_after_reply = true;
+            return Reply{
+                .status = factory_failed ?
+                              Status::BACKEND_ERROR :
+                              Status::UNSUPPORTED,
+                .message = device_error.empty() ?
+                               "Remote device request was rejected by the service." :
+                               std::move(device_error)};
+        }
+        _handshake_complete = true;
+        Writer writer;
+        writer.write_string(_native->backend_name());
+        writer.write_u32(_native->compute_warp_size());
+        writer.write_u64(_native->compute_max_shared_memory_size());
+        writer.write_u64(_native->memory_granularity());
+        auto features =
+            static_cast<uint64_t>(Feature::BUFFER) |
+            static_cast<uint64_t>(Feature::TEXTURE) |
+            static_cast<uint64_t>(Feature::STREAM) |
+            static_cast<uint64_t>(Feature::AST_SHADER) |
+            static_cast<uint64_t>(Feature::EVENT) |
+            static_cast<uint64_t>(Feature::ASYNC_DISPATCH) |
+            static_cast<uint64_t>(Feature::STREAM_LOG) |
+            static_cast<uint64_t>(Feature::BINDLESS_ARRAY) |
+            static_cast<uint64_t>(Feature::RAY_TRACING) |
+            static_cast<uint64_t>(Feature::LIMIT_NEGOTIATION);
+        if (_device_selection_enabled) {
+            features |= static_cast<uint64_t>(Feature::DEVICE_SELECTION);
+        }
+        auto blob_cache_enabled =
+            _blob_cache != nullptr &&
+            _options.max_blob_entry_size != 0u &&
+            _options.max_blobs_per_batch != 0u &&
+            _options.max_prepared_blob_batches != 0u;
+        if (blob_cache_enabled) {
+            features |= static_cast<uint64_t>(Feature::BLOB_CACHE);
+        }
+        writer.write_u64(features);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _create_buffer(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto kind_value = reader.read_u8();
+        auto value = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (kind_value > static_cast<uint8_t>(BufferKind::INDIRECT_DISPATCH) ||
+            value > std::numeric_limits<size_t>::max()) {
+            return invalid("Remote buffer descriptor is invalid.");
+        }
+        auto kind = static_cast<BufferKind>(kind_value);
+        if ((kind == BufferKind::BYTE &&
+             value > _options.max_resource_size) ||
+            (kind == BufferKind::INDIRECT_DISPATCH &&
+             value > _options.protocol_limits.max_array_size)) {
+            return Reply{.status = Status::RESOURCE_LIMIT,
+                         .message = "Remote buffer exceeds the resource-size limit."};
+        }
+        Reply reply;
+        if (!_can_create_resource(reply)) { return reply; }
+        auto count = static_cast<size_t>(value);
+        auto element = kind == BufferKind::BYTE ?
+                           Type::of<void>() :
+                           Type::custom(indirect_dispatch_element_type_name);
+        auto native = _native->create_buffer(
+            element, count, nullptr);
+        if (!native.valid() ||
+            native.total_size_bytes > _options.max_resource_size) {
+            if (native.valid()) { _native->destroy_buffer(native.handle); }
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create a bounded buffer."};
+        }
+        auto id = _allocate_id(ResourceKind::BUFFER);
+        if (id == invalid_resource_handle) {
+            _native->destroy_buffer(native.handle);
+            return Reply{.status = Status::RESOURCE_LIMIT,
+                         .message = "Remote resource-ID space exhausted."};
+        }
+        _buffers.emplace(
+            id, BufferRecord{
+                    .native = native,
+                    .size_bytes = native.total_size_bytes,
+                    .is_indirect_dispatch =
+                        kind == BufferKind::INDIRECT_DISPATCH,
+                    .indirect_dispatch_capacity =
+                        kind == BufferKind::INDIRECT_DISPATCH ? count : 0u});
+        Writer writer;
+        writer.write_u64(id);
+        writer.write_u64(native.element_stride);
+        writer.write_u64(native.total_size_bytes);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_buffer(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _buffers.find(id);
+        if (iter == _buffers.end()) { return not_found("Remote buffer was not found."); }
+        _native->destroy_buffer(iter->second.native.handle);
+        _buffers.erase(iter);
+        return {};
+    }
+
+    [[nodiscard]] Reply _create_texture(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto format_value = reader.read_u32();
+        auto dimension = reader.read_u32();
+        auto width = reader.read_u32();
+        auto height = reader.read_u32();
+        auto depth = reader.read_u32();
+        auto mip_levels = reader.read_u32();
+        auto simultaneous_access = reader.read_bool();
+        auto allow_raster_target = reader.read_bool();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (format_value >= pixel_format_count ||
+            (dimension != 2u && dimension != 3u) ||
+            width == 0u || height == 0u || depth == 0u || mip_levels == 0u ||
+            (dimension == 2u && depth != 1u)) {
+            return invalid("Remote texture descriptor is invalid.");
+        }
+        auto storage = pixel_format_to_storage(
+            static_cast<PixelFormat>(format_value));
+        auto base_size = uint3{width, height, depth};
+        auto max_dimension = std::max({width, height, depth});
+        auto max_mip_levels = 1u;
+        while (max_dimension > 1u) {
+            max_dimension >>= 1u;
+            max_mip_levels++;
+        }
+        if (mip_levels > max_mip_levels) {
+            return invalid("Remote texture mip-level count is invalid.");
+        }
+        uint64_t total_size{};
+        for (auto level = 0u; level < mip_levels; level++) {
+            auto level_size = luisa::max(base_size >> level, 1u);
+            auto size_result = checked_pixel_storage_size(storage, level_size);
+            if (!size_result ||
+                size_result.size > _options.max_resource_size -
+                                       std::min(total_size, _options.max_resource_size)) {
+                return Reply{.status = Status::RESOURCE_LIMIT,
+                             .message = "Remote texture exceeds the resource-size limit."};
+            }
+            total_size += size_result.size;
+        }
+        if (total_size > _options.max_resource_size) {
+            return Reply{.status = Status::RESOURCE_LIMIT,
+                         .message = "Remote texture exceeds the resource-size limit."};
+        }
+        Reply reply;
+        if (!_can_create_resource(reply)) { return reply; }
+        auto native = _native->create_texture(
+            static_cast<PixelFormat>(format_value), dimension,
+            width, height, depth, mip_levels, nullptr,
+            simultaneous_access, allow_raster_target);
+        if (!native.valid()) {
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create the texture."};
+        }
+        auto id = _allocate_id(ResourceKind::TEXTURE);
+        _textures.emplace(
+            id, TextureRecord{native, storage, base_size, mip_levels});
+        Writer writer;
+        writer.write_u64(id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_texture(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _textures.find(id);
+        if (iter == _textures.end()) { return not_found("Remote texture was not found."); }
+        _native->destroy_texture(iter->second.native.handle);
+        _textures.erase(iter);
+        return {};
+    }
+
+    [[nodiscard]] Reply _create_bindless_array(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto slot_count = reader.read_u64();
+        auto slot_type_value = reader.read_u32();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (slot_count == 0u || slot_count > _options.protocol_limits.max_array_size ||
+            slot_count > std::numeric_limits<size_t>::max() ||
+            slot_type_value > static_cast<uint32_t>(BindlessSlotType::TEXTURE3D_ONLY)) {
+            return invalid("Remote bindless-array descriptor is invalid.");
+        }
+        Reply reply;
+        if (!_can_create_resource(reply)) { return reply; }
+        auto slot_type = static_cast<BindlessSlotType>(slot_type_value);
+        auto native = _native->create_bindless_array(
+            static_cast<size_t>(slot_count), slot_type);
+        if (!native.valid()) {
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create the bindless array."};
+        }
+        auto id = _allocate_id(ResourceKind::BINDLESS_ARRAY);
+        _bindless_arrays.emplace(
+            id, BindlessRecord{native, static_cast<size_t>(slot_count), slot_type});
+        Writer writer;
+        writer.write_u64(id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_bindless_array(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _bindless_arrays.find(id);
+        if (iter == _bindless_arrays.end()) {
+            return not_found("Remote bindless array was not found.");
+        }
+        _native->destroy_bindless_array(iter->second.native.handle);
+        _bindless_arrays.erase(iter);
+        return {};
+    }
+
+    [[nodiscard]] Reply _create_stream(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto tag_value = reader.read_u32();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (tag_value > static_cast<uint32_t>(StreamTag::COPY)) {
+            return unsupported("Remote protocol v1 does not support custom streams.");
+        }
+        Reply reply;
+        if (!_can_create_resource(reply)) { return reply; }
+        auto native = _native->create_stream(static_cast<StreamTag>(tag_value));
+        if (!native.valid()) {
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create the stream."};
+        }
+        auto id = _allocate_id(ResourceKind::STREAM);
+        _streams.emplace(id, StreamRecord{native});
+        Writer writer;
+        writer.write_u64(id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_stream(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _streams.find(id);
+        if (iter == _streams.end()) { return not_found("Remote stream was not found."); }
+        _native->synchronize_stream(iter->second.native.handle);
+        if (iter->second.log_callback_installed) {
+            _native->set_stream_log_callback(iter->second.native.handle, {});
+        }
+        _native->destroy_stream(iter->second.native.handle);
+        _streams.erase(iter);
+        return {};
+    }
+
+    [[nodiscard]] Reply _synchronize_stream(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _streams.find(id);
+        if (iter == _streams.end()) { return not_found("Remote stream was not found."); }
+        _native->synchronize_stream(iter->second.native.handle);
+        return {};
+    }
+
+    [[nodiscard]] static ShaderOption _read_shader_option(
+        Reader &reader) noexcept {
+        ShaderOption option;
+        option.enable_cache = reader.read_bool();
+        option.enable_fast_math = reader.read_bool();
+        option.enable_debug_info = reader.read_bool();
+        option.compile_only = reader.read_bool();
+        option.max_registers = reader.read_u32();
+        option.time_trace = reader.read_bool();
+        option.enable_extended_accel_limits = reader.read_bool();
+        option.enable_scalarizer = reader.read_bool();
+        option.enable_ray_query_pipeline = reader.read_bool();
+        option.force_ray_query_pipeline = reader.read_bool();
+        option.enable_driver_optimization = reader.read_bool();
+        option.name = reader.read_string();
+        return option;
+    }
+
+    [[nodiscard]] Reply _create_shader(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto option = _read_shader_option(reader);
+        auto ast_bytes = reader.read_blob();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (ast_bytes.size() > ASTJsonLimits{}.max_document_bytes) {
+            return Reply{.status = Status::RESOURCE_LIMIT,
+                         .message = "Remote shader AST exceeds the document limit."};
+        }
+        auto ast = from_json(
+            luisa::string_view{reinterpret_cast<const char *>(ast_bytes.data()),
+                               ast_bytes.size()},
+            ASTJsonLimits{}, this);
+        if (!ast) {
+            return invalid(luisa::format(
+                "Remote shader AST is invalid: {}", ast.error));
+        }
+        auto function = Function{ast.function.get()};
+        if (function.tag() != Function::Tag::KERNEL) {
+            return invalid("Remote shader AST root must be a kernel.");
+        }
+        luisa::vector<ShaderArgumentDesc> arguments;
+        arguments.reserve(function.unbound_arguments().size());
+        for (auto variable : function.unbound_arguments()) {
+            ShaderArgumentDesc argument;
+            auto type = variable.type();
+            switch (variable.tag()) {
+                case Variable::Tag::BUFFER:
+                    if (!(type->is_buffer() ||
+                          (type->is_custom() &&
+                           type->description() ==
+                               ast_json_indirect_dispatch_buffer_type_name))) {
+                        return invalid("Remote shader buffer argument type is invalid.");
+                    }
+                    argument.tag = Argument::Tag::BUFFER;
+                    argument.indirect_dispatch_buffer = type->is_custom();
+                    break;
+                case Variable::Tag::TEXTURE:
+                    if (!type->is_texture()) {
+                        return invalid("Remote shader texture argument type is invalid.");
+                    }
+                    argument.tag = Argument::Tag::TEXTURE;
+                    break;
+                case Variable::Tag::BINDLESS_ARRAY:
+                    if (!type->is_bindless_array()) {
+                        return invalid("Remote shader bindless argument type is invalid.");
+                    }
+                    argument.tag = Argument::Tag::BINDLESS_ARRAY;
+                    break;
+                case Variable::Tag::ACCEL:
+                    if (!type->is_accel()) {
+                        return invalid("Remote shader accel argument type is invalid.");
+                    }
+                    argument.tag = Argument::Tag::ACCEL;
+                    break;
+                case Variable::Tag::LOCAL:
+                    if (type->is_resource() || type->is_custom()) {
+                        return invalid("Remote shader uniform argument type is invalid.");
+                    }
+                    argument.tag = Argument::Tag::UNIFORM;
+                    argument.uniform_size = type->size();
+                    argument.uniform_alignment = type->alignment();
+                    break;
+                default:
+                    return invalid("Remote shader contains an unsupported argument kind.");
+            }
+            arguments.emplace_back(argument);
+        }
+        Reply reply;
+        if (!option.compile_only && !_can_create_resource(reply)) { return reply; }
+        auto native = _native->create_shader(option, function);
+        if (!native.valid() && !option.compile_only) {
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create the shader."};
+        }
+        auto id = invalid_resource_handle;
+        if (native.valid()) {
+            id = _allocate_id(ResourceKind::SHADER);
+            _shaders.emplace(
+                id, ShaderRecord{native, std::move(arguments)});
+        }
+        Writer writer;
+        writer.write_u64(id);
+        writer.write_u32(native.block_size.x);
+        writer.write_u32(native.block_size.y);
+        writer.write_u32(native.block_size.z);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_shader(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _shaders.find(id);
+        if (iter == _shaders.end()) { return not_found("Remote shader was not found."); }
+        _native->destroy_shader(iter->second.native.handle);
+        _shaders.erase(iter);
+        return {};
+    }
+
+    [[nodiscard]] Reply _shader_argument_usage(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        auto index = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _shaders.find(id);
+        if (iter == _shaders.end()) { return not_found("Remote shader was not found."); }
+        if (index > std::numeric_limits<size_t>::max() ||
+            index >= iter->second.arguments.size()) {
+            return invalid("Remote shader argument index is invalid.");
+        }
+        auto usage = _native->shader_argument_usage(
+            iter->second.native.handle, static_cast<size_t>(index));
+        Writer writer;
+        writer.write_u32(static_cast<uint32_t>(usage));
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _create_event(
+        luisa::span<const std::byte> payload) noexcept {
+        if (!payload.empty()) { return invalid("Remote create-event payload must be empty."); }
+        Reply reply;
+        if (!_can_create_resource(reply)) { return reply; }
+        auto native = _native->create_event();
+        if (!native.valid()) {
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create the event."};
+        }
+        auto id = _allocate_id(ResourceKind::EVENT);
+        _events.emplace(id, ResourceRecord{native});
+        Writer writer;
+        writer.write_u64(id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_event(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto iter = _events.find(id);
+        if (iter == _events.end()) { return not_found("Remote event was not found."); }
+        _native->destroy_event(iter->second.native.handle);
+        _events.erase(iter);
+        return {};
+    }
+
+    [[nodiscard]] Reply _event_stream_operation(
+        MessageKind kind, luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto event_id = reader.read_u64();
+        auto stream_id = reader.read_u64();
+        auto value = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto event = _events.find(event_id);
+        auto stream = _streams.find(stream_id);
+        if (event == _events.end() || stream == _streams.end()) {
+            return not_found("Remote event or stream was not found.");
+        }
+        if (kind == MessageKind::SIGNAL_EVENT) {
+            _native->signal_event(
+                event->second.native.handle, stream->second.native.handle, value);
+        } else {
+            _native->wait_event(
+                event->second.native.handle, stream->second.native.handle, value);
+        }
+        return {};
+    }
+
+    [[nodiscard]] Reply _event_query(
+        MessageKind kind, luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        auto value = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto event = _events.find(id);
+        if (event == _events.end()) { return not_found("Remote event was not found."); }
+        if (kind == MessageKind::SYNCHRONIZE_EVENT) {
+            _native->synchronize_event(event->second.native.handle, value);
+            return {};
+        }
+        Writer writer;
+        writer.write_bool(_native->is_event_completed(
+            event->second.native.handle, value));
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] bool _decode_accel_option(
+        luisa::span<const std::byte> payload,
+        AccelOption &option, luisa::string &error) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto hint = reader.read_u32();
+        option.allow_compaction = reader.read_bool();
+        option.allow_update = reader.read_bool();
+        option.motion.keyframe_count = reader.read_u32();
+        option.motion.time_start = reader.read_f32();
+        option.motion.time_end = reader.read_f32();
+        option.motion.should_vanish_start = reader.read_bool();
+        option.motion.should_vanish_end = reader.read_bool();
+        auto mode = reader.read_u8();
+        if (!reader.finish()) {
+            error = reader.error();
+            return false;
+        }
+        if (hint > static_cast<uint32_t>(AccelOption::UsageHint::FAST_BUILD) ||
+            mode > static_cast<uint8_t>(AccelMotionMode::SRT) ||
+            option.motion.keyframe_count >
+                _options.protocol_limits.max_array_size ||
+            !std::isfinite(option.motion.time_start) ||
+            !std::isfinite(option.motion.time_end) ||
+            option.motion.time_start > option.motion.time_end) {
+            error = "Remote acceleration-structure option is invalid.";
+            return false;
+        }
+        option.hint = static_cast<AccelOption::UsageHint>(hint);
+        option.motion.mode = static_cast<AccelMotionMode>(mode);
+        return true;
+    }
+
+    [[nodiscard]] Reply _create_accel_resource(
+        MessageKind kind, luisa::span<const std::byte> payload) noexcept {
+        AccelOption option;
+        luisa::string error;
+        if (!_decode_accel_option(payload, option, error)) {
+            return invalid(std::move(error));
+        }
+        if (kind == MessageKind::CREATE_MOTION_INSTANCE &&
+            option.motion.keyframe_count < 2u) {
+            return invalid("Remote motion instances require at least two keyframes.");
+        }
+        Reply reply;
+        if (!_can_create_resource(reply)) { return reply; }
+        ResourceCreationInfo native;
+        ResourceKind resource_kind_value{};
+        switch (kind) {
+            case MessageKind::CREATE_MESH:
+                native = _native->create_mesh(option);
+                resource_kind_value = ResourceKind::MESH;
+                break;
+            case MessageKind::CREATE_CURVE:
+                native = _native->create_curve(option);
+                resource_kind_value = ResourceKind::CURVE;
+                break;
+            case MessageKind::CREATE_PROCEDURAL_PRIMITIVE:
+                native = _native->create_procedural_primitive(option);
+                resource_kind_value = ResourceKind::PROCEDURAL_PRIMITIVE;
+                break;
+            case MessageKind::CREATE_MOTION_INSTANCE:
+                native = _native->create_motion_instance(option.motion);
+                resource_kind_value = ResourceKind::MOTION_INSTANCE;
+                break;
+            case MessageKind::CREATE_ACCEL:
+                native = _native->create_accel(option);
+                resource_kind_value = ResourceKind::ACCEL;
+                break;
+            default: return invalid("Invalid remote acceleration-structure request.");
+        }
+        if (!native.valid()) {
+            return Reply{.status = Status::BACKEND_ERROR,
+                         .message = "Native backend failed to create the acceleration-structure resource."};
+        }
+        auto id = _allocate_id(resource_kind_value);
+        switch (resource_kind_value) {
+            case ResourceKind::MESH:
+                _meshes.emplace(id, ResourceRecord{native});
+                break;
+            case ResourceKind::CURVE:
+                _curves.emplace(id, ResourceRecord{native});
+                break;
+            case ResourceKind::PROCEDURAL_PRIMITIVE:
+                _procedural_primitives.emplace(id, ResourceRecord{native});
+                break;
+            case ResourceKind::MOTION_INSTANCE:
+                _motion_instances.emplace(
+                    id, MotionInstanceRecord{
+                            native, option.motion.keyframe_count});
+                break;
+            case ResourceKind::ACCEL:
+                _accels.emplace(id, ResourceRecord{native});
+                break;
+            default: break;
+        }
+        Writer writer;
+        writer.write_u64(id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _destroy_accel_resource(
+        MessageKind kind, luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto id = reader.read_u64();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        switch (kind) {
+            case MessageKind::DESTROY_MESH:
+                if (auto iter = _meshes.find(id); iter != _meshes.end()) {
+                    _native->destroy_mesh(iter->second.native.handle);
+                    _meshes.erase(iter);
+                    return {};
+                }
+                break;
+            case MessageKind::DESTROY_CURVE:
+                if (auto iter = _curves.find(id); iter != _curves.end()) {
+                    _native->destroy_curve(iter->second.native.handle);
+                    _curves.erase(iter);
+                    return {};
+                }
+                break;
+            case MessageKind::DESTROY_PROCEDURAL_PRIMITIVE:
+                if (auto iter = _procedural_primitives.find(id);
+                    iter != _procedural_primitives.end()) {
+                    _native->destroy_procedural_primitive(iter->second.native.handle);
+                    _procedural_primitives.erase(iter);
+                    return {};
+                }
+                break;
+            case MessageKind::DESTROY_MOTION_INSTANCE:
+                if (auto iter = _motion_instances.find(id);
+                    iter != _motion_instances.end()) {
+                    _native->destroy_motion_instance(iter->second.native.handle);
+                    _motion_instances.erase(iter);
+                    return {};
+                }
+                break;
+            case MessageKind::DESTROY_ACCEL:
+                if (auto iter = _accels.find(id); iter != _accels.end()) {
+                    _native->destroy_accel(iter->second.native.handle);
+                    _accels.erase(iter);
+                    return {};
+                }
+                break;
+            default: return invalid("Invalid remote acceleration-structure destroy request.");
+        }
+        return not_found("Remote acceleration-structure resource was not found.");
+    }
+
+    [[nodiscard]] Reply _prepare_blobs(
+        luisa::span<const std::byte> payload) noexcept {
+        if (_blob_cache == nullptr) {
+            return unsupported("Remote blob caching is disabled on this server.");
+        }
+        Reader reader{payload, _options.protocol_limits};
+        auto submission_id = reader.read_u64();
+        auto count = reader.read_u64();
+        if (!reader.ok()) { return invalid(luisa::string{reader.error()}); }
+        if (submission_id == 0u || count == 0u ||
+            count > _options.max_blobs_per_batch ||
+            count > _options.protocol_limits.max_array_size ||
+            count > std::numeric_limits<size_t>::max()) {
+            return invalid("Remote blob-prepare descriptor count or submission ID is invalid.");
+        }
+        if (_blob_batches.size() >= _options.max_prepared_blob_batches) {
+            return Reply{
+                .status = Status::RESOURCE_LIMIT,
+                .message = "Remote prepared-blob batch limit reached."};
+        }
+        if (_blob_batches.contains(submission_id)) {
+            return invalid("A remote blob batch already exists for this submission ID.");
+        }
+        {
+            std::scoped_lock lock{_pending_mutex};
+            if (_pending_submissions.contains(submission_id)) {
+                return invalid("Remote submission ID is already pending.");
+            }
+        }
+
+        PreparedBlobBatch batch;
+        batch.keys.reserve(static_cast<size_t>(count));
+        batch.blobs.reserve(static_cast<size_t>(count));
+        std::unordered_set<BlobKey, BlobKeyHash> unique;
+        uint64_t total_size{};
+        luisa::vector<uint32_t> misses;
+        for (uint64_t i = 0u; i < count; i++) {
+            BlobKey key;
+            if (!read_blob_key(reader, key)) {
+                return invalid(luisa::string{reader.error()});
+            }
+            if (key.size == 0u ||
+                key.size > _options.max_blob_entry_size ||
+                key.size > _blob_cache->capacity_bytes() ||
+                total_size > _blob_cache->capacity_bytes() - key.size) {
+                return Reply{
+                    .status = Status::RESOURCE_LIMIT,
+                    .message = "Remote prepared blobs exceed the cache limits."};
+            }
+            if (!unique.emplace(key).second) {
+                return invalid("Remote blob descriptors must be unique within a batch.");
+            }
+            total_size += key.size;
+            batch.keys.emplace_back(key);
+            auto blob = _blob_cache->find(key);
+            if (blob == nullptr) {
+                misses.emplace_back(static_cast<uint32_t>(i));
+            }
+            batch.blobs.emplace_back(std::move(blob));
+        }
+        if (!reader.finish()) {
+            return invalid(luisa::string{reader.error()});
+        }
+        _blob_batches.emplace(submission_id, std::move(batch));
+        Writer writer;
+        writer.write_u64(submission_id);
+        writer.write_u64(misses.size());
+        for (auto index : misses) { writer.write_u32(index); }
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _blob_cache_info(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        if (!reader.finish()) {
+            return invalid(luisa::string{reader.error()});
+        }
+        if (_blob_cache == nullptr) {
+            return unsupported("Remote blob caching is disabled on this server.");
+        }
+        Writer writer;
+        writer.write_u64(_options.max_blob_entry_size);
+        writer.write_u64(_options.blob_cache_min_size);
+        writer.write_u64(_options.max_blobs_per_batch);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _protocol_info(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        if (!reader.finish()) {
+            return invalid(luisa::string{reader.error()});
+        }
+        Writer writer;
+        writer.write_u64(_options.protocol_limits.max_frame_payload);
+        writer.write_u64(_options.protocol_limits.max_string_size);
+        writer.write_u64(_options.protocol_limits.max_array_size);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _upload_blobs(
+        luisa::span<const std::byte> payload) noexcept {
+        if (_blob_cache == nullptr) {
+            return unsupported("Remote blob caching is disabled on this server.");
+        }
+        struct PendingUpload {
+            uint32_t index{};
+            BlobKey key;
+            luisa::span<const std::byte> bytes;
+        };
+        Reader reader{payload, _options.protocol_limits};
+        auto submission_id = reader.read_u64();
+        auto count = reader.read_u64();
+        auto batch_iterator = _blob_batches.find(submission_id);
+        if (!reader.ok()) { return invalid(luisa::string{reader.error()}); }
+        if (submission_id == 0u ||
+            batch_iterator == _blob_batches.end() ||
+            count == 0u ||
+            count > batch_iterator->second.keys.size() ||
+            count > std::numeric_limits<size_t>::max()) {
+            return invalid("Remote blob-upload batch or count is invalid.");
+        }
+        auto &batch = batch_iterator->second;
+        luisa::vector<PendingUpload> pending;
+        pending.reserve(static_cast<size_t>(count));
+        luisa::vector<uint8_t> seen(batch.keys.size(), 0u);
+        for (uint64_t i = 0u; i < count; i++) {
+            auto index = reader.read_u32();
+            BlobKey key;
+            if (!read_blob_key(reader, key)) {
+                return invalid(luisa::string{reader.error()});
+            }
+            auto bytes = reader.read_blob();
+            if (!reader.ok()) {
+                return invalid(luisa::string{reader.error()});
+            }
+            if (index >= batch.keys.size() || seen[index] != 0u ||
+                batch.blobs[index] != nullptr ||
+                key != batch.keys[index] || bytes.size() != key.size) {
+                return invalid("Remote blob-upload descriptor does not match its prepared slot.");
+            }
+            seen[index] = 1u;
+            pending.emplace_back(PendingUpload{index, key, bytes});
+        }
+        if (!reader.finish()) {
+            return invalid(luisa::string{reader.error()});
+        }
+
+        luisa::vector<BlobCache::BlobPtr> published;
+        published.reserve(pending.size());
+        for (auto &&upload : pending) {
+            luisa::string error;
+            BlobCacheError cache_error{};
+            auto blob = _blob_cache->publish(
+                upload.key, upload.bytes, cache_error, error);
+            if (blob == nullptr) {
+                auto status = cache_error == BlobCacheError::CAPACITY ?
+                                  Status::RESOURCE_LIMIT :
+                                  Status::INVALID_REQUEST;
+                return Reply{.status = status, .message = std::move(error)};
+            }
+            published.emplace_back(std::move(blob));
+        }
+        for (size_t i = 0u; i < pending.size(); i++) {
+            batch.blobs[pending[i].index] = std::move(published[i]);
+        }
+        Writer writer;
+        writer.write_u64(submission_id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    void _send_completion(
+        uint64_t submission_id,
+        luisa::vector<ServerDownload> downloads) noexcept {
+        {
+            std::scoped_lock lock{_pending_mutex};
+            _pending_submissions.erase(submission_id);
+        }
+        Writer writer;
+        writer.write_u64(submission_id);
+        writer.write_u16(static_cast<uint16_t>(Status::OK));
+        writer.write_string({});
+        writer.write_u64(downloads.size());
+        for (auto &&download : downloads) {
+            writer.write_u32(download.index);
+            writer.write_blob(*download.storage);
+        }
+        static_cast<void>(_send_frame(
+            MessageKind::DISPATCH_COMPLETE, submission_id,
+            writer.bytes()));
+    }
+
+    [[nodiscard]] Reply _dispatch(
+        luisa::span<const std::byte> payload) noexcept {
+        auto decoded = decode_submission(payload, *this, _options.protocol_limits);
+        auto blob_batch = _blob_batches.find(decoded.submission_id);
+        if (!decoded) {
+            if (blob_batch != _blob_batches.end()) {
+                _blob_batches.erase(blob_batch);
+            }
+            return invalid(std::move(decoded.error));
+        }
+        if (blob_batch != _blob_batches.end()) {
+            luisa::vector<uint8_t> used(
+                blob_batch->second.keys.size(), 0u);
+            for (auto index : decoded.upload_blob_indices) {
+                if (index >= used.size()) {
+                    _blob_batches.erase(blob_batch);
+                    decoded.command_list.clear();
+                    return invalid("Remote dispatch references an invalid prepared blob index.");
+                }
+                used[index] = 1u;
+            }
+            auto complete = std::all_of(
+                blob_batch->second.blobs.begin(),
+                blob_batch->second.blobs.end(),
+                [](auto &&blob) noexcept { return blob != nullptr; });
+            auto all_used = std::all_of(
+                used.begin(), used.end(),
+                [](auto value) noexcept { return value != 0u; });
+            auto filled_count = static_cast<size_t>(std::count_if(
+                blob_batch->second.blobs.begin(),
+                blob_batch->second.blobs.end(),
+                [](auto &&blob) noexcept { return blob != nullptr; }));
+            auto used_count = static_cast<size_t>(std::count_if(
+                used.begin(), used.end(),
+                [](auto value) noexcept { return value != 0u; }));
+            auto descriptor_count = blob_batch->second.keys.size();
+            _blob_batches.erase(blob_batch);
+            if (!complete || !all_used) {
+                decoded.command_list.clear();
+                return invalid(luisa::format(
+                    "Remote dispatch blob batch is incomplete or contains unused descriptors "
+                    "({} descriptors, {} filled, {} referenced).",
+                    descriptor_count, filled_count, used_count));
+            }
+        } else if (!decoded.upload_blob_indices.empty()) {
+            decoded.command_list.clear();
+            return invalid("Remote dispatch references a missing prepared blob batch.");
+        }
+        auto stream = _streams.find(decoded.stream_handle);
+        if (stream == _streams.end()) {
+            decoded.command_list.clear();
+            return not_found("Remote dispatch stream was not found.");
+        }
+        {
+            std::scoped_lock lock{_pending_mutex};
+            if (_pending_submissions.size() >= _options.max_pending_submissions) {
+                decoded.command_list.clear();
+                return Reply{.status = Status::RESOURCE_LIMIT,
+                             .message = "Remote pending-submission limit reached."};
+            }
+            if (!_pending_submissions.emplace(decoded.submission_id).second) {
+                decoded.command_list.clear();
+                return invalid("Remote submission ID is already pending.");
+            }
+        }
+        auto submission_id = decoded.submission_id;
+        auto downloads = std::move(decoded.downloads);
+        auto upload_blobs = std::move(decoded.upload_blobs);
+        auto self = shared_from_this();
+        decoded.command_list.add_callback(
+            [self = std::move(self), submission_id,
+             downloads = std::move(downloads),
+             upload_blobs = std::move(upload_blobs)]() mutable noexcept {
+                static_cast<void>(upload_blobs);
+                self->_send_completion(submission_id, std::move(downloads));
+            });
+        _native->dispatch(
+            stream->second.native.handle,
+            std::move(decoded.command_list));
+        Writer writer;
+        writer.write_u64(submission_id);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] Reply _query(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto property = reader.read_string();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        luisa::string value;
+        if (property == "remote.blob_cache.enabled") {
+            value = _blob_cache == nullptr ? "false" : "true";
+        } else if (property == "remote.blob_cache.capacity_bytes") {
+            value = luisa::format(
+                "{}", _blob_cache == nullptr ?
+                          0u :
+                          _blob_cache->capacity_bytes());
+        } else if (property.starts_with("remote.blob_cache.") &&
+                   _blob_cache != nullptr) {
+            auto stats = _blob_cache->stats();
+            if (property == "remote.blob_cache.hits") {
+                value = luisa::format("{}", stats.hits);
+            } else if (property == "remote.blob_cache.misses") {
+                value = luisa::format("{}", stats.misses);
+            } else if (property == "remote.blob_cache.stores") {
+                value = luisa::format("{}", stats.stores);
+            } else if (property == "remote.blob_cache.evictions") {
+                value = luisa::format("{}", stats.evictions);
+            } else if (property == "remote.blob_cache.uploaded_bytes") {
+                value = luisa::format("{}", stats.uploaded_bytes);
+            } else if (property == "remote.blob_cache.resident_bytes") {
+                value = luisa::format("{}", stats.resident_bytes);
+            } else if (property == "remote.blob_cache.resident_entries") {
+                value = luisa::format("{}", stats.resident_entries);
+            }
+        } else {
+            value = _native->query(property);
+        }
+        Writer writer;
+        writer.write_string(value);
+        return Reply{.body = std::move(writer).take()};
+    }
+
+    [[nodiscard]] bool _resolve_resource_for_name(
+        Resource::Tag tag, uint64_t remote, uint64_t &native) const noexcept {
+        switch (tag) {
+            case Resource::Tag::BUFFER:
+                if (auto i = _buffers.find(remote); i != _buffers.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::TEXTURE:
+                if (auto i = _textures.find(remote); i != _textures.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::BINDLESS_ARRAY:
+                if (auto i = _bindless_arrays.find(remote);
+                    i != _bindless_arrays.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::STREAM:
+                if (auto i = _streams.find(remote); i != _streams.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::EVENT:
+                if (auto i = _events.find(remote); i != _events.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::SHADER:
+                if (auto i = _shaders.find(remote); i != _shaders.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::MESH:
+                if (auto i = _meshes.find(remote); i != _meshes.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::CURVE:
+                if (auto i = _curves.find(remote); i != _curves.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::PROCEDURAL_PRIMITIVE:
+                if (auto i = _procedural_primitives.find(remote);
+                    i != _procedural_primitives.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::MOTION_INSTANCE:
+                if (auto i = _motion_instances.find(remote);
+                    i != _motion_instances.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            case Resource::Tag::ACCEL:
+                if (auto i = _accels.find(remote); i != _accels.end()) {
+                    native = i->second.native.handle;
+                    return true;
+                }
+                break;
+            default: break;
+        }
+        return false;
+    }
+
+    [[nodiscard]] Reply _set_name(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto tag_value = reader.read_u32();
+        auto remote = reader.read_u64();
+        auto name = reader.read_string();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        if (tag_value > static_cast<uint32_t>(Resource::Tag::TENSOR_GRAPH)) {
+            return invalid("Remote resource tag is invalid.");
+        }
+        auto tag = static_cast<Resource::Tag>(tag_value);
+        uint64_t native{};
+        if (!_resolve_resource_for_name(tag, remote, native)) {
+            return not_found("Remote named resource was not found or unsupported.");
+        }
+        _native->set_name(tag, native, name);
+        return {};
+    }
+
+    [[nodiscard]] Reply _set_stream_log_callback(
+        luisa::span<const std::byte> payload) noexcept {
+        Reader reader{payload, _options.protocol_limits};
+        auto remote_stream = reader.read_u64();
+        auto enabled = reader.read_bool();
+        if (!reader.finish()) { return invalid(luisa::string{reader.error()}); }
+        auto stream = _streams.find(remote_stream);
+        if (stream == _streams.end()) { return not_found("Remote stream was not found."); }
+        if (!enabled) {
+            if (stream->second.log_callback_installed) {
+                _native->set_stream_log_callback(stream->second.native.handle, {});
+                stream->second.log_callback_installed = false;
+            }
+            return {};
+        }
+        auto weak = luisa::weak_ptr<Session>{shared_from_this()};
+        auto max_string_size = _options.protocol_limits.max_string_size;
+        _native->set_stream_log_callback(
+            stream->second.native.handle,
+            [weak = std::move(weak), remote_stream,
+             max_string_size](luisa::string_view message) noexcept {
+                if (auto self = weak.lock()) {
+                    if (message.size() > max_string_size) {
+                        message = message.substr(0u, static_cast<size_t>(max_string_size));
+                    }
+                    Writer writer;
+                    writer.write_u64(remote_stream);
+                    writer.write_string(message);
+                    static_cast<void>(self->_send_frame(
+                        MessageKind::STREAM_LOG, remote_stream, writer.bytes()));
+                }
+            });
+        stream->second.log_callback_installed = true;
+        return {};
+    }
+
+    [[nodiscard]] Reply _handle(
+        MessageKind kind, luisa::span<const std::byte> payload) noexcept {
+        if (kind == MessageKind::HELLO) { return _hello(payload); }
+        if (!_handshake_complete) {
+            return Reply{.status = Status::AUTHENTICATION_FAILED,
+                         .message = "Remote HELLO is required before other requests."};
+        }
+        switch (kind) {
+            case MessageKind::CREATE_BUFFER: return _create_buffer(payload);
+            case MessageKind::DESTROY_BUFFER: return _destroy_buffer(payload);
+            case MessageKind::CREATE_TEXTURE: return _create_texture(payload);
+            case MessageKind::DESTROY_TEXTURE: return _destroy_texture(payload);
+            case MessageKind::CREATE_BINDLESS_ARRAY: return _create_bindless_array(payload);
+            case MessageKind::DESTROY_BINDLESS_ARRAY: return _destroy_bindless_array(payload);
+            case MessageKind::CREATE_STREAM: return _create_stream(payload);
+            case MessageKind::DESTROY_STREAM: return _destroy_stream(payload);
+            case MessageKind::SYNCHRONIZE_STREAM: return _synchronize_stream(payload);
+            case MessageKind::CREATE_SHADER: return _create_shader(payload);
+            case MessageKind::DESTROY_SHADER: return _destroy_shader(payload);
+            case MessageKind::SHADER_ARGUMENT_USAGE: return _shader_argument_usage(payload);
+            case MessageKind::CREATE_EVENT: return _create_event(payload);
+            case MessageKind::DESTROY_EVENT: return _destroy_event(payload);
+            case MessageKind::SIGNAL_EVENT:
+            case MessageKind::WAIT_EVENT: return _event_stream_operation(kind, payload);
+            case MessageKind::IS_EVENT_COMPLETED:
+            case MessageKind::SYNCHRONIZE_EVENT: return _event_query(kind, payload);
+            case MessageKind::DISPATCH: return _dispatch(payload);
+            case MessageKind::PREPARE_BLOBS: return _prepare_blobs(payload);
+            case MessageKind::UPLOAD_BLOBS: return _upload_blobs(payload);
+            case MessageKind::BLOB_CACHE_INFO: return _blob_cache_info(payload);
+            case MessageKind::PROTOCOL_INFO: return _protocol_info(payload);
+            case MessageKind::QUERY: return _query(payload);
+            case MessageKind::SET_NAME: return _set_name(payload);
+            case MessageKind::SET_STREAM_LOG_CALLBACK:
+                return _set_stream_log_callback(payload);
+            case MessageKind::CREATE_MESH:
+            case MessageKind::CREATE_CURVE:
+            case MessageKind::CREATE_PROCEDURAL_PRIMITIVE:
+            case MessageKind::CREATE_MOTION_INSTANCE:
+            case MessageKind::CREATE_ACCEL:
+                return _create_accel_resource(kind, payload);
+            case MessageKind::DESTROY_MESH:
+            case MessageKind::DESTROY_CURVE:
+            case MessageKind::DESTROY_PROCEDURAL_PRIMITIVE:
+            case MessageKind::DESTROY_MOTION_INSTANCE:
+            case MessageKind::DESTROY_ACCEL:
+                return _destroy_accel_resource(kind, payload);
+            case MessageKind::GOODBYE:
+                _close_after_reply = true;
+                return {};
+            case MessageKind::LOAD_SHADER:
+                return unsupported("Remote protocol v1 does not implement this resource yet.");
+            default:
+                return unsupported("Remote request kind is unsupported.");
+        }
+    }
+
+    void _cleanup() noexcept {
+        if (_native == nullptr) { return; }
+        _blob_batches.clear();
+        for (auto &[id, stream] : _streams) {
+            static_cast<void>(id);
+            _native->synchronize_stream(stream.native.handle);
+            if (stream.log_callback_installed) {
+                _native->set_stream_log_callback(stream.native.handle, {});
+            }
+        }
+        for (auto &[id, shader] : _shaders) {
+            static_cast<void>(id);
+            _native->destroy_shader(shader.native.handle);
+        }
+        for (auto &[id, event] : _events) {
+            static_cast<void>(id);
+            _native->destroy_event(event.native.handle);
+        }
+        for (auto &[id, accel] : _accels) {
+            static_cast<void>(id);
+            _native->destroy_accel(accel.native.handle);
+        }
+        for (auto &[id, instance] : _motion_instances) {
+            static_cast<void>(id);
+            _native->destroy_motion_instance(instance.native.handle);
+        }
+        for (auto &[id, mesh] : _meshes) {
+            static_cast<void>(id);
+            _native->destroy_mesh(mesh.native.handle);
+        }
+        for (auto &[id, curve] : _curves) {
+            static_cast<void>(id);
+            _native->destroy_curve(curve.native.handle);
+        }
+        for (auto &[id, primitive] : _procedural_primitives) {
+            static_cast<void>(id);
+            _native->destroy_procedural_primitive(primitive.native.handle);
+        }
+        for (auto &[id, array] : _bindless_arrays) {
+            static_cast<void>(id);
+            _native->destroy_bindless_array(array.native.handle);
+        }
+        for (auto &[id, texture] : _textures) {
+            static_cast<void>(id);
+            _native->destroy_texture(texture.native.handle);
+        }
+        for (auto &[id, buffer] : _buffers) {
+            static_cast<void>(id);
+            _native->destroy_buffer(buffer.native.handle);
+        }
+        for (auto &[id, stream] : _streams) {
+            static_cast<void>(id);
+            _native->destroy_stream(stream.native.handle);
+        }
+        _shaders.clear();
+        _events.clear();
+        _accels.clear();
+        _motion_instances.clear();
+        _meshes.clear();
+        _curves.clear();
+        _procedural_primitives.clear();
+        _bindless_arrays.clear();
+        _textures.clear();
+        _buffers.clear();
+        _streams.clear();
+    }
+
+public:
+    Session(Tcp::socket socket,
+            const DeviceFactory &device_factory,
+            luisa::shared_ptr<BlobCache> blob_cache,
+            const ServerOptions &options,
+            bool device_selection_enabled) noexcept
+        : _socket{std::move(socket)},
+          _device_factory{device_factory},
+          _blob_cache{std::move(blob_cache)},
+          _options{options},
+          _device_selection_enabled{device_selection_enabled} {}
+
+    ~Session() noexcept override = default;
+
+    void stop() noexcept {
+        _alive.store(false, std::memory_order_release);
+        asio::error_code ignored;
+        _socket.cancel(ignored);
+        _socket.shutdown(Tcp::socket::shutdown_both, ignored);
+        _socket.close(ignored);
+    }
+
+    void run() noexcept {
+        while (_alive.load(std::memory_order_acquire)) {
+            FrameHeader header;
+            luisa::vector<std::byte> payload;
+            if (!_read_frame(header, payload)) { break; }
+            auto reply = _handle(header.kind, payload);
+            if (!_send_reply(header.kind, header.request_id, std::move(reply))) {
+                break;
+            }
+            if (_close_after_reply) { break; }
+        }
+        _alive.store(false, std::memory_order_release);
+        asio::error_code ignored;
+        _socket.shutdown(Tcp::socket::shutdown_both, ignored);
+        _socket.close(ignored);
+        _cleanup();
+        _native.reset();
+    }
+
+    [[nodiscard]] bool resolve_buffer(
+        uint64_t remote, uint64_t &native, size_t &size_bytes,
+        luisa::string &error) const noexcept override {
+        auto iter = _buffers.find(remote);
+        if (iter == _buffers.end() || resource_kind(remote) != ResourceKind::BUFFER) {
+            error = "Remote buffer handle was not found.";
+            return false;
+        }
+        if (iter->second.is_indirect_dispatch) {
+            error = "An indirect-dispatch buffer cannot be used as a byte buffer.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        size_bytes = iter->second.size_bytes;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_buffer_descriptor(
+        uint64_t remote, ResolvedBuffer &buffer,
+        luisa::string &error) const noexcept override {
+        auto iter = _buffers.find(remote);
+        if (iter == _buffers.end() ||
+            resource_kind(remote) != ResourceKind::BUFFER) {
+            error = "Remote buffer handle was not found.";
+            return false;
+        }
+        buffer = ResolvedBuffer{
+            .handle = iter->second.native.handle,
+            .size_bytes = iter->second.size_bytes,
+            .is_indirect_dispatch = iter->second.is_indirect_dispatch,
+            .indirect_dispatch_capacity =
+                iter->second.indirect_dispatch_capacity};
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_texture(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        auto iter = _textures.find(remote);
+        if (iter == _textures.end() || resource_kind(remote) != ResourceKind::TEXTURE) {
+            error = "Remote texture handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_texture_descriptor(
+        uint64_t remote, ResolvedTexture &texture,
+        luisa::string &error) const noexcept override {
+        auto iter = _textures.find(remote);
+        if (iter == _textures.end() || resource_kind(remote) != ResourceKind::TEXTURE) {
+            error = "Remote texture handle was not found.";
+            return false;
+        }
+        texture = ResolvedTexture{
+            .handle = iter->second.native.handle,
+            .storage = iter->second.storage,
+            .size = iter->second.size,
+            .mip_levels = iter->second.mip_levels};
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_bindless_array(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        auto iter = _bindless_arrays.find(remote);
+        if (iter == _bindless_arrays.end() ||
+            resource_kind(remote) != ResourceKind::BINDLESS_ARRAY) {
+            error = "Remote bindless-array handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_bindless_array_for_update(
+        uint64_t remote, uint64_t &native, size_t &slot_count,
+        BindlessSlotType &slot_type,
+        luisa::string &error) const noexcept override {
+        auto iter = _bindless_arrays.find(remote);
+        if (iter == _bindless_arrays.end() ||
+            resource_kind(remote) != ResourceKind::BINDLESS_ARRAY) {
+            error = "Remote bindless-array handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        slot_count = iter->second.slot_count;
+        slot_type = iter->second.slot_type;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_accel(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        auto iter = _accels.find(remote);
+        if (iter == _accels.end() || resource_kind(remote) != ResourceKind::ACCEL) {
+            error = "Remote acceleration-structure handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_mesh(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        auto iter = _meshes.find(remote);
+        if (iter == _meshes.end() || resource_kind(remote) != ResourceKind::MESH) {
+            error = "Remote mesh handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_curve(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        auto iter = _curves.find(remote);
+        if (iter == _curves.end() || resource_kind(remote) != ResourceKind::CURVE) {
+            error = "Remote curve handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_procedural_primitive(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        auto iter = _procedural_primitives.find(remote);
+        if (iter == _procedural_primitives.end() ||
+            resource_kind(remote) != ResourceKind::PROCEDURAL_PRIMITIVE) {
+            error = "Remote procedural-primitive handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_motion_instance(
+        uint64_t remote, uint64_t &native, size_t &keyframe_count,
+        luisa::string &error) const noexcept override {
+        auto iter = _motion_instances.find(remote);
+        if (iter == _motion_instances.end() ||
+            resource_kind(remote) != ResourceKind::MOTION_INSTANCE) {
+            error = "Remote motion-instance handle was not found.";
+            return false;
+        }
+        native = iter->second.native.handle;
+        keyframe_count = iter->second.keyframe_count;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_accel_resource(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        return resolve_accel(remote, native, error);
+    }
+
+    [[nodiscard]] bool resolve_primitive(
+        uint64_t remote, uint64_t &native,
+        luisa::string &error) const noexcept override {
+        switch (resource_kind(remote)) {
+            case ResourceKind::MESH:
+                return resolve_mesh(remote, native, error);
+            case ResourceKind::CURVE:
+                return resolve_curve(remote, native, error);
+            case ResourceKind::PROCEDURAL_PRIMITIVE:
+                return resolve_procedural_primitive(remote, native, error);
+            case ResourceKind::MOTION_INSTANCE: {
+                size_t unused{};
+                return resolve_motion_instance(remote, native, unused, error);
+            }
+            default:
+                error = "Remote primitive handle has an invalid resource kind.";
+                return false;
+        }
+    }
+
+    [[nodiscard]] bool resolve_upload_blob(
+        uint64_t submission_id, uint32_t blob_index,
+        size_t expected_size, BlobCache::BlobPtr &blob,
+        luisa::string &error) const noexcept override {
+        auto batch = _blob_batches.find(submission_id);
+        if (batch == _blob_batches.end() ||
+            blob_index >= batch->second.blobs.size()) {
+            error = "Remote cached upload references an unknown blob batch or index.";
+            return false;
+        }
+        auto &&key = batch->second.keys[blob_index];
+        auto &&cached = batch->second.blobs[blob_index];
+        if (cached == nullptr) {
+            error = "Remote cached upload references a blob body that was not uploaded.";
+            return false;
+        }
+        if (key.size != expected_size ||
+            cached->size() != expected_size) {
+            error = "Remote cached upload failed size verification.";
+            return false;
+        }
+        blob = cached;
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_shader(
+        uint64_t remote, ResolvedShader &shader,
+        luisa::string &error) const noexcept override {
+        auto iter = _shaders.find(remote);
+        if (iter == _shaders.end() || resource_kind(remote) != ResourceKind::SHADER) {
+            error = "Remote shader handle was not found.";
+            return false;
+        }
+        shader = ResolvedShader{
+            .handle = iter->second.native.handle,
+            .arguments = iter->second.arguments};
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_buffer(
+        const Type *serialized_type, uint64_t serialized_handle,
+        size_t serialized_offset,
+        size_t serialized_size, Function::BufferBinding &binding,
+        luisa::string &error) const noexcept override {
+        ResolvedBuffer buffer;
+        if (!resolve_buffer_descriptor(
+                serialized_handle, buffer, error)) {
+            return false;
+        }
+        auto expected_indirect = serialized_type->is_custom() &&
+                                 serialized_type->description() ==
+                                     ast_json_indirect_dispatch_buffer_type_name;
+        if (buffer.is_indirect_dispatch != expected_indirect) {
+            error = "Remote AST buffer kind does not match its serialized type.";
+            return false;
+        }
+        auto total = expected_indirect ?
+                         buffer.indirect_dispatch_capacity :
+                         buffer.size_bytes;
+        if (!valid_range(serialized_offset, serialized_size, total)) {
+            error = "Remote AST buffer binding is out of bounds.";
+            return false;
+        }
+        binding = Function::BufferBinding{
+            buffer.handle, serialized_offset, serialized_size};
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_texture(
+        uint64_t serialized_handle, uint32_t serialized_level,
+        Function::TextureBinding &binding,
+        luisa::string &error) const noexcept override {
+        auto iter = _textures.find(serialized_handle);
+        if (iter == _textures.end() || serialized_level >= iter->second.mip_levels) {
+            error = "Remote AST texture binding is invalid.";
+            return false;
+        }
+        binding = Function::TextureBinding{
+            iter->second.native.handle, serialized_level};
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_bindless_array(
+        uint64_t serialized_handle,
+        Function::BindlessArrayBinding &binding,
+        luisa::string &error) const noexcept override {
+        uint64_t native{};
+        if (!resolve_bindless_array(serialized_handle, native, error)) { return false; }
+        binding = Function::BindlessArrayBinding{native};
+        return true;
+    }
+
+    [[nodiscard]] bool resolve_accel(
+        uint64_t serialized_handle, Function::AccelBinding &binding,
+        luisa::string &error) const noexcept override {
+        uint64_t native{};
+        if (!resolve_accel(serialized_handle, native, error)) { return false; }
+        binding = Function::AccelBinding{native};
+        return true;
+    }
+};
+
+class Server::Impl {
+
+private:
+    struct SessionWorker {
+        luisa::shared_ptr<Session> session;
+        luisa::shared_ptr<std::atomic_bool> done;
+        std::thread thread;
+    };
+
+    asio::io_context _io;
+    Tcp::acceptor _acceptor;
+    DeviceFactory _device_factory;
+    ServerOptions _options;
+    luisa::shared_ptr<BlobCache> _blob_cache;
+    std::atomic_bool _stopping{false};
+    std::atomic_bool _running{false};
+    std::mutex _sessions_mutex;
+    luisa::vector<luisa::unique_ptr<SessionWorker>> _sessions;
+    uint16_t _port{};
+    bool _ipv6{};
+    bool _device_selection_enabled{};
+
+private:
+    void _reap_finished_sessions() noexcept {
+        luisa::vector<luisa::unique_ptr<SessionWorker>> finished;
+        {
+            std::scoped_lock lock{_sessions_mutex};
+            for (auto i = _sessions.size(); i != 0u;) {
+                i--;
+                if (_sessions[i]->done->load(std::memory_order_acquire)) {
+                    finished.emplace_back(std::move(_sessions[i]));
+                    _sessions.erase(_sessions.begin() + i);
+                }
+            }
+        }
+        for (auto &worker : finished) {
+            if (worker->thread.joinable()) { worker->thread.join(); }
+        }
+    }
+
+    void _stop_and_join_sessions() noexcept {
+        luisa::vector<luisa::unique_ptr<SessionWorker>> sessions;
+        {
+            std::scoped_lock lock{_sessions_mutex};
+            sessions = std::move(_sessions);
+            _sessions.clear();
+        }
+        for (auto &worker : sessions) { worker->session->stop(); }
+        for (auto &worker : sessions) {
+            if (worker->thread.joinable()) { worker->thread.join(); }
+        }
+    }
+
+public:
+    Impl(DeviceFactory device_factory, ServerOptions options,
+         bool device_selection_enabled)
+        : _acceptor{_io},
+          _device_factory{std::move(device_factory)},
+          _options{std::move(options)},
+          _device_selection_enabled{device_selection_enabled} {
+        if (!_device_factory) {
+            throw std::invalid_argument{"Remote server requires a device factory."};
+        }
+        if (_options.protocol_limits.max_frame_payload < 256u ||
+            _options.protocol_limits.max_string_size == 0u ||
+            _options.protocol_limits.max_array_size == 0u ||
+            _options.max_concurrent_sessions == 0u ||
+            _options.max_concurrent_sessions > 4096u) {
+            throw std::invalid_argument{
+                "Remote server protocol or session limits are invalid."};
+        }
+        constexpr uint64_t blob_upload_frame_overhead = 68u;
+        constexpr uint64_t blob_prepare_header_size = 16u;
+        constexpr uint64_t blob_descriptor_size =
+            sizeof(uint64_t) + blob_digest_size;
+        auto frame_blob_limit =
+            _options.protocol_limits.max_frame_payload >
+                    blob_upload_frame_overhead ?
+                _options.protocol_limits.max_frame_payload -
+                    blob_upload_frame_overhead :
+                0u;
+        _options.max_blob_entry_size = std::min(
+            {_options.max_blob_entry_size,
+             _options.max_blob_cache_bytes,
+             _options.max_resource_size,
+             frame_blob_limit});
+        auto frame_blob_count_limit =
+            (_options.protocol_limits.max_frame_payload -
+             std::min(blob_prepare_header_size,
+                      _options.protocol_limits.max_frame_payload)) /
+            blob_descriptor_size;
+        _options.max_blobs_per_batch = std::min(
+            {_options.max_blobs_per_batch,
+             _options.protocol_limits.max_array_size,
+             frame_blob_count_limit,
+             static_cast<uint64_t>(
+                 std::numeric_limits<uint32_t>::max())});
+        if (_options.max_blob_cache_bytes == 0u ||
+            _options.max_blob_entry_size == 0u ||
+            _options.blob_cache_min_size >
+                _options.max_blob_entry_size ||
+            _options.max_blobs_per_batch == 0u ||
+            _options.max_prepared_blob_batches == 0u) {
+            _options.max_blob_entry_size = 0u;
+        } else {
+            _blob_cache = luisa::make_shared<BlobCache>(
+                _options.max_blob_cache_bytes);
+        }
+        asio::error_code error;
+        auto address = asio::ip::make_address(_options.listen_address, error);
+        if (error) {
+            throw std::invalid_argument{luisa::format(
+                "Invalid remote listen address '{}': {}",
+                _options.listen_address, error.message())};
+        }
+        _ipv6 = address.is_v6();
+        auto endpoint = Tcp::endpoint{address, _options.port};
+        _acceptor.open(endpoint.protocol());
+        _acceptor.set_option(Tcp::acceptor::reuse_address{true});
+        _acceptor.bind(endpoint);
+        _acceptor.listen();
+        _port = _acceptor.local_endpoint().port();
+    }
+
+    ~Impl() noexcept { stop(); }
+
+    void run() {
+        if (_running.exchange(true, std::memory_order_acq_rel)) {
+            throw std::logic_error{"Remote server is already running."};
+        }
+        while (!_stopping.load(std::memory_order_acquire)) {
+            Tcp::socket socket{_io};
+            asio::error_code error;
+            _acceptor.accept(socket, error);
+            if (error) {
+                if (_stopping.load(std::memory_order_acquire)) { break; }
+                if (error == asio::error::interrupted) { continue; }
+                LUISA_WARNING("Remote accept failed: {}", error.message());
+                continue;
+            }
+            if (_stopping.load(std::memory_order_acquire)) {
+                socket.close(error);
+                break;
+            }
+            _reap_finished_sessions();
+            {
+                std::scoped_lock lock{_sessions_mutex};
+                if (_sessions.size() >= _options.max_concurrent_sessions) {
+                    LUISA_WARNING(
+                        "Rejecting remote connection: concurrent-session limit ({}) reached.",
+                        _options.max_concurrent_sessions);
+                    socket.shutdown(Tcp::socket::shutdown_both, error);
+                    socket.close(error);
+                    continue;
+                }
+            }
+            auto session = luisa::make_shared<Session>(
+                std::move(socket), _device_factory, _blob_cache, _options,
+                _device_selection_enabled);
+            auto worker = luisa::make_unique<SessionWorker>();
+            worker->session = session;
+            worker->done = luisa::make_shared<std::atomic_bool>(false);
+            try {
+                worker->thread = std::thread{
+                    [session = std::move(session), done = worker->done]() noexcept {
+                        session->run();
+                        done->store(true, std::memory_order_release);
+                    }};
+            } catch (const std::exception &exception) {
+                LUISA_WARNING(
+                    "Failed to start remote session worker: {}", exception.what());
+                worker->session->stop();
+                continue;
+            } catch (...) {
+                LUISA_WARNING("Failed to start remote session worker.");
+                worker->session->stop();
+                continue;
+            }
+            {
+                std::scoped_lock lock{_sessions_mutex};
+                _sessions.emplace_back(std::move(worker));
+            }
+        }
+        _stop_and_join_sessions();
+        _running.store(false, std::memory_order_release);
+    }
+
+    void stop() noexcept {
+        if (_stopping.exchange(true, std::memory_order_acq_rel)) { return; }
+        // Wake a blocking accept without depending on platform-specific
+        // acceptor cancellation behavior.
+        asio::io_context wake_io;
+        Tcp::socket wake_socket{wake_io};
+        asio::error_code ignored;
+        auto loopback = _ipv6 ?
+                            asio::ip::address{asio::ip::address_v6::loopback()} :
+                            asio::ip::address{asio::ip::address_v4::loopback()};
+        wake_socket.connect(Tcp::endpoint{loopback, _port}, ignored);
+        wake_socket.close(ignored);
+        _acceptor.close(ignored);
+        luisa::vector<luisa::shared_ptr<Session>> sessions;
+        {
+            std::scoped_lock lock{_sessions_mutex};
+            sessions.reserve(_sessions.size());
+            for (auto &worker : _sessions) {
+                sessions.emplace_back(worker->session);
+            }
+        }
+        for (auto &&session : sessions) { session->stop(); }
+    }
+
+    [[nodiscard]] uint16_t port() const noexcept { return _port; }
+};
+
+Server::Server(luisa::shared_ptr<DeviceInterface> native_device,
+               ServerOptions options)
+    : _impl{std::make_unique<Impl>(
+          [native = std::move(native_device)](
+              const DeviceRequest &request,
+              luisa::string &error) -> luisa::shared_ptr<DeviceInterface> {
+              if (native == nullptr) {
+                  error = "Remote server has no native device.";
+                  return nullptr;
+              }
+              if ((!request.backend.empty() &&
+                   request.backend != native->backend_name()) ||
+                  request.device_index !=
+                      std::numeric_limits<size_t>::max() ||
+                  request.enable_validation) {
+                  error = "This remote server uses a fixed native device and cannot honor device-selection parameters.";
+                  return nullptr;
+              }
+              return native;
+          },
+          std::move(options), false)} {}
+
+Server::Server(DeviceFactory device_factory, ServerOptions options)
+    : _impl{std::make_unique<Impl>(
+          std::move(device_factory), std::move(options), true)} {}
+
+Server::~Server() noexcept = default;
+
+void Server::run() { _impl->run(); }
+
+void Server::stop() noexcept { _impl->stop(); }
+
+uint16_t Server::port() const noexcept { return _impl->port(); }
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_server.h
+++ b/src/backends/remote/remote_server.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+
+#include <luisa/core/stl/memory.h>
+#include <luisa/core/stl/string.h>
+#include <luisa/runtime/rhi/device_interface.h>
+
+#include "remote_protocol.h"
+
+namespace luisa::compute::remote {
+
+struct ServerOptions {
+    luisa::string listen_address{"127.0.0.1"};
+    uint16_t port{18080u};
+    luisa::string token;
+    uint64_t max_resource_size{16ull * 1024ull * 1024ull * 1024ull};
+    uint64_t max_resources{1ull << 20u};
+    uint64_t max_pending_submissions{4096u};
+    uint64_t max_blob_cache_bytes{512ull * 1024ull * 1024ull};
+    uint64_t max_blob_entry_size{64ull * 1024ull * 1024ull};
+    uint64_t blob_cache_min_size{64ull * 1024ull};
+    uint64_t max_blobs_per_batch{4096u};
+    uint64_t max_prepared_blob_batches{64u};
+    uint64_t max_concurrent_sessions{64u};
+    ProtocolLimits protocol_limits;
+};
+
+struct DeviceRequest {
+    luisa::string backend;
+    size_t device_index{std::numeric_limits<size_t>::max()};
+    bool enable_validation{false};
+};
+
+using DeviceFactory = std::function<luisa::shared_ptr<DeviceInterface>(
+    const DeviceRequest &request, luisa::string &error)>;
+
+class Server final {
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+
+public:
+    Server(luisa::shared_ptr<DeviceInterface> native_device,
+           ServerOptions options = {});
+    Server(DeviceFactory device_factory, ServerOptions options = {});
+    ~Server() noexcept;
+    Server(Server const &) = delete;
+    Server(Server &&) = delete;
+    Server &operator=(Server const &) = delete;
+    Server &operator=(Server &&) = delete;
+
+    void run();
+    void stop() noexcept;
+    [[nodiscard]] uint16_t port() const noexcept;
+};
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_server_main.cpp
+++ b/src/backends/remote/remote_server_main.cpp
@@ -1,0 +1,329 @@
+#include <algorithm>
+#include <charconv>
+#include <csignal>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <limits>
+#include <mutex>
+#include <string_view>
+#include <thread>
+
+#include <asio.hpp>
+
+#include <luisa/core/logging.h>
+#include <luisa/core/stl/format.h>
+#include <luisa/runtime/context.h>
+#include <luisa/runtime/device.h>
+
+#include "remote_server.h"
+
+namespace {
+
+struct CommandLine {
+    luisa::string backend;
+    luisa::string listen{"127.0.0.1"};
+    luisa::string token;
+    luisa::vector<luisa::string> allowed_backends;
+    uint16_t port{18080u};
+    size_t device_index{std::numeric_limits<size_t>::max()};
+    uint64_t max_sessions{64u};
+    uint64_t blob_cache_bytes{512ull * 1024ull * 1024ull};
+    uint64_t blob_cache_entry_bytes{64ull * 1024ull * 1024ull};
+    uint64_t blob_cache_min_bytes{64ull * 1024ull};
+    bool validation{false};
+    bool allow_client_validation{false};
+    bool print_ready{false};
+    bool help{false};
+};
+
+[[nodiscard]] bool parse_unsigned(
+    std::string_view text, uint64_t &value) noexcept {
+    auto result = std::from_chars(
+        text.data(), text.data() + text.size(), value);
+    return result.ec == std::errc{} &&
+           result.ptr == text.data() + text.size();
+}
+
+[[nodiscard]] bool parse_command_line(
+    int argc, char *argv[], CommandLine &command,
+    luisa::string &error) noexcept {
+    if (auto token = std::getenv("LUISA_REMOTE_TOKEN")) {
+        command.token = token;
+    }
+    for (auto i = 1; i < argc; i++) {
+        auto argument = std::string_view{argv[i]};
+        if (argument == "--help" || argument == "-h") {
+            command.help = true;
+            continue;
+        }
+        if (argument == "--validation") {
+            command.validation = true;
+            continue;
+        }
+        if (argument == "--print-ready") {
+            command.print_ready = true;
+            continue;
+        }
+        if (argument == "--allow-client-validation") {
+            command.allow_client_validation = true;
+            continue;
+        }
+        if (i + 1 >= argc) {
+            error = luisa::format("Missing value after '{}'.", argument);
+            return false;
+        }
+        auto value = std::string_view{argv[++i]};
+        if (argument == "--backend") {
+            command.backend = value;
+        } else if (argument == "--allow-backend") {
+            command.allowed_backends.emplace_back(value);
+        } else if (argument == "--listen") {
+            command.listen = value;
+        } else if (argument == "--token") {
+            command.token = value;
+        } else if (argument == "--port") {
+            uint64_t parsed{};
+            if (!parse_unsigned(value, parsed) ||
+                parsed > std::numeric_limits<uint16_t>::max()) {
+                error = "Invalid remote server port.";
+                return false;
+            }
+            command.port = static_cast<uint16_t>(parsed);
+        } else if (argument == "--device-index") {
+            uint64_t parsed{};
+            if (!parse_unsigned(value, parsed) ||
+                parsed > std::numeric_limits<size_t>::max()) {
+                error = "Invalid native device index.";
+                return false;
+            }
+            command.device_index = static_cast<size_t>(parsed);
+        } else if (argument == "--blob-cache-bytes") {
+            if (!parse_unsigned(value, command.blob_cache_bytes)) {
+                error = "Invalid remote blob-cache byte capacity.";
+                return false;
+            }
+        } else if (argument == "--blob-cache-entry-bytes") {
+            if (!parse_unsigned(value, command.blob_cache_entry_bytes)) {
+                error = "Invalid remote blob-cache entry byte limit.";
+                return false;
+            }
+        } else if (argument == "--blob-cache-min-bytes") {
+            if (!parse_unsigned(value, command.blob_cache_min_bytes)) {
+                error = "Invalid remote blob-cache minimum byte size.";
+                return false;
+            }
+        } else if (argument == "--max-sessions") {
+            if (!parse_unsigned(value, command.max_sessions) ||
+                command.max_sessions == 0u ||
+                command.max_sessions > 4096u) {
+                error = "Invalid remote concurrent-session limit.";
+                return false;
+            }
+        } else {
+            error = luisa::format("Unknown option '{}'.", argument);
+            return false;
+        }
+    }
+    return true;
+}
+
+void print_usage(std::ostream &stream) {
+    stream << "Usage: luisa-remote-server [options]\n"
+              "  --backend <name>       Default backend (default: first non-remote backend)\n"
+              "  --allow-backend <name> Allow a client-selectable backend; repeatable\n"
+              "  --listen <address>     Listen address (default: 127.0.0.1)\n"
+              "  --port <port>          TCP port (default: 18080)\n"
+              "  --token <token>        Shared token (or LUISA_REMOTE_TOKEN)\n"
+              "  --device-index <index> Native device index\n"
+              "  --max-sessions <n>     Concurrent client limit (default: 64)\n"
+              "  --blob-cache-bytes <n> Shared blob-cache capacity; 0 disables it\n"
+              "  --blob-cache-entry-bytes <n> Maximum cached upload size\n"
+              "  --blob-cache-min-bytes <n> Recommended minimum cached upload size\n"
+              "  --validation           Enable native validation layer\n"
+              "  --allow-client-validation Allow clients to request native validation\n"
+              "  --print-ready          Print 'LCRP_READY_V1 <port>' after binding\n"
+              "  --help                  Show this help\n";
+}
+
+class SignalStopper final {
+
+private:
+    asio::io_context _io;
+    asio::signal_set _signals;
+    std::thread _thread;
+
+public:
+    explicit SignalStopper(luisa::compute::remote::Server &server)
+        : _signals{_io, SIGINT, SIGTERM} {
+        _signals.async_wait(
+            [&server](const asio::error_code &error, int signal) {
+                if (!error) {
+                    LUISA_INFO(
+                        "Stopping Luisa remote server after signal {}.",
+                        signal);
+                    server.stop();
+                }
+            });
+        _thread = std::thread{[this] { _io.run(); }};
+    }
+
+    ~SignalStopper() noexcept {
+        _io.stop();
+        if (_thread.joinable()) { _thread.join(); }
+    }
+
+    SignalStopper(SignalStopper const &) = delete;
+    SignalStopper(SignalStopper &&) = delete;
+    SignalStopper &operator=(SignalStopper const &) = delete;
+    SignalStopper &operator=(SignalStopper &&) = delete;
+};
+
+}// namespace
+
+int main(int argc, char *argv[]) {
+    CommandLine command;
+    luisa::string error;
+    if (!parse_command_line(argc, argv, command, error)) {
+        std::cerr << error << '\n';
+        print_usage(std::cerr);
+        return 2;
+    }
+    if (command.help) {
+        print_usage(std::cout);
+        return 0;
+    }
+    try {
+        luisa::compute::Context context{argv[0]};
+        if (command.backend.empty()) {
+            for (auto &&backend : context.installed_backends()) {
+                if (backend != "remote") {
+                    command.backend = backend;
+                    break;
+                }
+            }
+        }
+        if (command.backend.empty() || command.backend == "remote") {
+            std::cerr << "A non-remote native backend is required.\n";
+            return 2;
+        }
+        auto installed = context.installed_backends();
+        auto is_installed = [installed](luisa::string_view backend) noexcept {
+            return backend != "remote" &&
+                   std::find(installed.begin(), installed.end(), backend) !=
+                       installed.end();
+        };
+        if (!is_installed(command.backend)) {
+            std::cerr << "Default backend '" << command.backend
+                      << "' is not installed or cannot be remote.\n";
+            return 2;
+        }
+        if (command.allowed_backends.empty()) {
+            command.allowed_backends.emplace_back(command.backend);
+        } else if (std::find(
+                       command.allowed_backends.begin(),
+                       command.allowed_backends.end(), command.backend) ==
+                   command.allowed_backends.end()) {
+            command.allowed_backends.emplace_back(command.backend);
+        }
+        for (auto &&backend : command.allowed_backends) {
+            if (!is_installed(backend)) {
+                std::cerr << "Allowed backend '" << backend
+                          << "' is not installed or cannot be remote.\n";
+                return 2;
+            }
+        }
+        std::sort(
+            command.allowed_backends.begin(),
+            command.allowed_backends.end());
+        command.allowed_backends.erase(
+            std::unique(
+                command.allowed_backends.begin(),
+                command.allowed_backends.end()),
+            command.allowed_backends.end());
+        auto factory_mutex = luisa::make_shared<std::mutex>();
+        auto device_factory =
+            [&context, factory_mutex,
+             default_backend = command.backend,
+             default_device_index = command.device_index,
+             allowed_backends = command.allowed_backends,
+             validation = command.validation,
+             allow_client_validation = command.allow_client_validation](
+                const luisa::compute::remote::DeviceRequest &request,
+                luisa::string &factory_error)
+            -> luisa::shared_ptr<luisa::compute::DeviceInterface> {
+            auto backend = request.backend.empty() ?
+                               default_backend :
+                               request.backend;
+            if (!std::binary_search(
+                    allowed_backends.begin(), allowed_backends.end(), backend)) {
+                factory_error = luisa::format(
+                    "Backend '{}' is not allowed by this remote service.",
+                    backend);
+                return nullptr;
+            }
+            if (request.enable_validation && !allow_client_validation) {
+                factory_error = "Client-requested native validation is disabled by this remote service.";
+                return nullptr;
+            }
+            auto device_index =
+                request.device_index == std::numeric_limits<size_t>::max() ?
+                    default_device_index :
+                    request.device_index;
+            std::scoped_lock lock{*factory_mutex};
+            if (device_index != std::numeric_limits<size_t>::max()) {
+                auto names = context.backend_device_names(backend);
+                if (device_index >= names.size()) {
+                    factory_error = luisa::format(
+                        "Device index {} is out of range for backend '{}'.",
+                        device_index, backend);
+                    return nullptr;
+                }
+            }
+            luisa::compute::DeviceConfig config;
+            config.device_index = device_index;
+            // AST compilation must remain available on the execution host.
+            config.headless = false;
+            auto device = context.create_device(
+                backend, &config,
+                validation || request.enable_validation);
+            auto native = device.impl_shared();
+            if (native == nullptr) {
+                factory_error = luisa::format(
+                    "Backend '{}' failed to create a device.", backend);
+                return nullptr;
+            }
+            LUISA_INFO(
+                "Created remote service device using backend '{}'.", backend);
+            return native;
+        };
+        luisa::compute::remote::ServerOptions options;
+        options.listen_address = command.listen;
+        options.port = command.port;
+        options.token = command.token;
+        options.max_blob_cache_bytes = command.blob_cache_bytes;
+        options.max_blob_entry_size = command.blob_cache_entry_bytes;
+        options.blob_cache_min_size = command.blob_cache_min_bytes;
+        options.max_concurrent_sessions = command.max_sessions;
+        luisa::compute::remote::Server server{
+            std::move(device_factory), std::move(options)};
+        LUISA_INFO(
+            "Luisa remote service is listening on {}:{} with default backend '{}' and {} allowed backend(s).",
+            command.listen, server.port(), command.backend,
+            command.allowed_backends.size());
+        if (command.print_ready) {
+            std::cout << "LCRP_READY_V1 " << server.port() << '\n'
+                      << std::flush;
+            if (!std::cout) {
+                std::cerr << "Failed to publish remote server readiness.\n";
+                return 1;
+            }
+        }
+        SignalStopper signal_stopper{server};
+        server.run();
+        return 0;
+    } catch (const std::exception &exception) {
+        std::cerr << "Remote server failed: " << exception.what() << '\n';
+        return 1;
+    }
+}

--- a/src/backends/remote/remote_transport.cpp
+++ b/src/backends/remote/remote_transport.cpp
@@ -32,7 +32,7 @@ private:
     std::thread::id _reader_thread_id{};
     mutable std::mutex _state_mutex;
     std::mutex _write_mutex;
-    std::mutex _close_mutex;
+    std::mutex _socket_mutex;
     std::mutex _join_mutex;
     std::unordered_map<uint64_t, std::shared_ptr<Pending>> _pending;
     NotificationHandler _notification_handler;
@@ -82,7 +82,7 @@ private:
             .payload_checksum = payload_checksum(payload)});
         asio::error_code ec;
         {
-            std::scoped_lock lock{_write_mutex};
+            std::scoped_lock lock{_socket_mutex, _write_mutex};
             std::array<asio::const_buffer, 2u> buffers{
                 asio::buffer(static_cast<const void *>(header.data()), header.size()),
                 asio::buffer(payload.data(), payload.size())};
@@ -103,12 +103,15 @@ private:
             return true;
         }
         auto completed = false;
-        asio::async_read(
-            _socket, asio::buffer(data, size),
-            [&](const asio::error_code &read_error, size_t) noexcept {
-                error = read_error;
-                completed = true;
-            });
+        {
+            std::scoped_lock lock{_socket_mutex};
+            asio::async_read(
+                _socket, asio::buffer(data, size),
+                [&](const asio::error_code &read_error, size_t) noexcept {
+                    error = read_error;
+                    completed = true;
+                });
+        }
         _io.run();
         _io.restart();
         return completed && !error;
@@ -136,6 +139,7 @@ private:
             luisa::string decode_error;
             if (!decode_frame_header(header_bytes, header, decode_error, _limits)) {
                 _set_closed(std::move(decode_error));
+                std::scoped_lock lock{_socket_mutex};
                 asio::error_code ignored;
                 _socket.close(ignored);
                 return;
@@ -151,6 +155,7 @@ private:
             }
             if (payload_checksum(payload) != header.payload_checksum) {
                 _set_closed("Remote protocol payload checksum mismatch.");
+                std::scoped_lock lock{_socket_mutex};
                 asio::error_code ignored;
                 _socket.close(ignored);
                 return;
@@ -224,7 +229,7 @@ public:
             return false;
         }
         {
-            std::scoped_lock close_lock{_close_mutex};
+            std::scoped_lock socket_lock{_socket_mutex};
             {
                 std::scoped_lock lock{_state_mutex};
                 if (_connected) {
@@ -241,7 +246,7 @@ public:
             std::scoped_lock join_lock{_join_mutex};
             if (_reader.joinable()) { _reader.join(); }
         }
-        std::scoped_lock close_lock{_close_mutex};
+        std::scoped_lock socket_lock{_socket_mutex};
         {
             std::scoped_lock lock{_state_mutex};
             if (_connected) {
@@ -367,7 +372,7 @@ public:
         auto initiate_close = false;
         std::thread::id reader_thread_id;
         {
-            std::scoped_lock close_lock{_close_mutex};
+            std::scoped_lock socket_lock{_socket_mutex};
             {
                 std::scoped_lock lock{_state_mutex};
                 initiate_close = !_closing;

--- a/src/backends/remote/remote_transport.cpp
+++ b/src/backends/remote/remote_transport.cpp
@@ -1,0 +1,441 @@
+#include "remote_transport.h"
+
+#include <array>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+#include <asio.hpp>
+
+#include <luisa/core/stl/format.h>
+
+namespace luisa::compute::remote {
+
+using Tcp = asio::ip::tcp;
+
+class Connection::Impl {
+
+private:
+    struct Pending {
+        MessageKind expected_kind{};
+        std::condition_variable cv;
+        Response response;
+        bool done{false};
+    };
+
+    ProtocolLimits _limits;
+    asio::io_context _io;
+    Tcp::socket _socket{_io};
+    std::thread _reader;
+    std::thread::id _reader_thread_id{};
+    mutable std::mutex _state_mutex;
+    std::mutex _write_mutex;
+    std::mutex _close_mutex;
+    std::mutex _join_mutex;
+    std::unordered_map<uint64_t, std::shared_ptr<Pending>> _pending;
+    NotificationHandler _notification_handler;
+    CloseHandler _close_handler;
+    std::atomic_uint64_t _next_request_id{1u};
+    bool _connected{false};
+    bool _closing{false};
+    luisa::string _error;
+
+private:
+    void _set_closed(luisa::string error) noexcept {
+        CloseHandler close_handler;
+        luisa::string callback_error;
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (!_connected && !_error.empty()) { return; }
+            _connected = false;
+            if (_error.empty()) { _error = std::move(error); }
+            callback_error = _error;
+            close_handler = _close_handler;
+            for (auto &[id, pending] : _pending) {
+                static_cast<void>(id);
+                if (!pending->done) {
+                    pending->response.status = Status::CONNECTION_CLOSED;
+                    pending->response.message = _error;
+                    pending->done = true;
+                    pending->cv.notify_one();
+                }
+            }
+        }
+        if (close_handler) { close_handler(callback_error); }
+    }
+
+    [[nodiscard]] bool _write_frame(
+        MessageKind kind,
+        uint64_t request_id,
+        luisa::span<const std::byte> payload,
+        luisa::string &error) noexcept {
+        if (payload.size() > _limits.max_frame_payload) {
+            error = "Remote protocol payload exceeds the configured frame limit.";
+            return false;
+        }
+        auto header = encode_frame_header(FrameHeader{
+            .kind = kind,
+            .request_id = request_id,
+            .payload_size = payload.size(),
+            .payload_checksum = payload_checksum(payload)});
+        asio::error_code ec;
+        {
+            std::scoped_lock lock{_write_mutex};
+            std::array<asio::const_buffer, 2u> buffers{
+                asio::buffer(static_cast<const void *>(header.data()), header.size()),
+                asio::buffer(payload.data(), payload.size())};
+            asio::write(_socket, buffers, ec);
+        }
+        if (ec) {
+            error = luisa::format("Remote socket write failed: {}", ec.message());
+            _set_closed(error);
+            return false;
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool _read_exact(
+        void *data, size_t size, asio::error_code &error) noexcept {
+        if (size == 0u) {
+            error.clear();
+            return true;
+        }
+        auto completed = false;
+        asio::async_read(
+            _socket, asio::buffer(data, size),
+            [&](const asio::error_code &read_error, size_t) noexcept {
+                error = read_error;
+                completed = true;
+            });
+        _io.run();
+        _io.restart();
+        return completed && !error;
+    }
+
+    void _reader_loop() noexcept {
+        {
+            std::scoped_lock lock{_state_mutex};
+            _reader_thread_id = std::this_thread::get_id();
+        }
+        while (true) {
+            std::array<std::byte, frame_header_size> header_bytes{};
+            asio::error_code ec;
+            if (!_read_exact(header_bytes.data(), header_bytes.size(), ec)) {
+                bool closing;
+                {
+                    std::scoped_lock lock{_state_mutex};
+                    closing = _closing;
+                }
+                _set_closed(closing ? "Remote connection closed." :
+                                      luisa::format("Remote socket read failed: {}", ec.message()));
+                return;
+            }
+            FrameHeader header;
+            luisa::string decode_error;
+            if (!decode_frame_header(header_bytes, header, decode_error, _limits)) {
+                _set_closed(std::move(decode_error));
+                asio::error_code ignored;
+                _socket.close(ignored);
+                return;
+            }
+            luisa::vector<std::byte> payload;
+            payload.resize(static_cast<size_t>(header.payload_size));
+            if (!payload.empty()) {
+                if (!_read_exact(payload.data(), payload.size(), ec)) {
+                    _set_closed(luisa::format(
+                        "Remote socket payload read failed: {}", ec.message()));
+                    return;
+                }
+            }
+            if (payload_checksum(payload) != header.payload_checksum) {
+                _set_closed("Remote protocol payload checksum mismatch.");
+                asio::error_code ignored;
+                _socket.close(ignored);
+                return;
+            }
+            if (header.kind == MessageKind::RESPONSE ||
+                header.kind == MessageKind::ERROR) {
+                std::shared_ptr<Pending> pending;
+                {
+                    std::scoped_lock lock{_state_mutex};
+                    if (auto iter = _pending.find(header.request_id);
+                        iter != _pending.end()) {
+                        pending = iter->second;
+                    }
+                }
+                if (!pending) { continue; }
+                ResponseView view;
+                luisa::string response_error;
+                Response response;
+                if (!decode_response_payload(
+                        payload, view, response_error, _limits)) {
+                    response.status = Status::INVALID_REQUEST;
+                    response.message = std::move(response_error);
+                } else if (view.request_kind != pending->expected_kind) {
+                    response.status = Status::INVALID_REQUEST;
+                    response.message = "Remote response kind does not match its request.";
+                } else {
+                    response.request_kind = view.request_kind;
+                    response.status = view.status;
+                    response.message = std::move(view.message);
+                    response.body.assign(view.body.begin(), view.body.end());
+                }
+                {
+                    std::scoped_lock lock{_state_mutex};
+                    if (!pending->done) {
+                        pending->response = std::move(response);
+                        pending->done = true;
+                        pending->cv.notify_one();
+                    }
+                }
+                continue;
+            }
+            NotificationHandler handler;
+            {
+                std::scoped_lock lock{_state_mutex};
+                handler = _notification_handler;
+            }
+            if (handler) { handler(header.kind, header.request_id, payload); }
+        }
+    }
+
+public:
+    explicit Impl(ProtocolLimits limits) noexcept : _limits{limits} {}
+
+    ~Impl() noexcept { close(); }
+
+    [[nodiscard]] bool connect(luisa::string_view host,
+                               uint16_t port,
+                               std::chrono::milliseconds timeout,
+                               luisa::string &error) noexcept {
+        std::thread::id reader_thread_id;
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (_connected) {
+                error = "Remote connection is already open.";
+                return false;
+            }
+            reader_thread_id = _reader_thread_id;
+        }
+        if (reader_thread_id == std::this_thread::get_id()) {
+            error = "Remote connection cannot reconnect from its reader callback.";
+            return false;
+        }
+        {
+            std::scoped_lock close_lock{_close_mutex};
+            {
+                std::scoped_lock lock{_state_mutex};
+                if (_connected) {
+                    error = "Remote connection is already open.";
+                    return false;
+                }
+            }
+            asio::error_code ignored;
+            _socket.cancel(ignored);
+            _socket.shutdown(Tcp::socket::shutdown_both, ignored);
+            _socket.close(ignored);
+        }
+        {
+            std::scoped_lock join_lock{_join_mutex};
+            if (_reader.joinable()) { _reader.join(); }
+        }
+        std::scoped_lock close_lock{_close_mutex};
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (_connected) {
+                error = "Remote connection is already open.";
+                return false;
+            }
+            _error.clear();
+            _closing = false;
+            _reader_thread_id = {};
+        }
+        _io.restart();
+        Tcp::resolver resolver{_io};
+        asio::error_code ec;
+        auto endpoints = resolver.resolve(
+            luisa::string{host}, std::to_string(port), ec);
+        if (ec) {
+            error = luisa::format("Remote endpoint resolution failed: {}", ec.message());
+            return false;
+        }
+        asio::steady_timer timer{_io};
+        bool connect_done = false;
+        bool timed_out = false;
+        timer.expires_after(timeout);
+        timer.async_wait([&](const asio::error_code &timer_error) noexcept {
+            if (!timer_error && !connect_done) {
+                timed_out = true;
+                asio::error_code ignored;
+                _socket.close(ignored);
+            }
+        });
+        asio::async_connect(
+            _socket, endpoints,
+            [&](const asio::error_code &connect_error, const Tcp::endpoint &) noexcept {
+                ec = connect_error;
+                connect_done = true;
+                asio::error_code ignored;
+                static_cast<void>(timer.cancel());
+            });
+        _io.run();
+        _io.restart();
+        if (timed_out) {
+            error = "Remote connection timed out.";
+            return false;
+        }
+        if (ec) {
+            error = luisa::format("Remote connection failed: {}", ec.message());
+            return false;
+        }
+        {
+            std::scoped_lock lock{_state_mutex};
+            _connected = true;
+        }
+        _reader = std::thread{[this]() noexcept { _reader_loop(); }};
+        return true;
+    }
+
+    [[nodiscard]] Response request(
+        MessageKind kind,
+        luisa::span<const std::byte> payload,
+        std::chrono::milliseconds timeout) noexcept {
+        auto request_id = _next_request_id.fetch_add(1u, std::memory_order_relaxed);
+        auto pending = std::make_shared<Pending>();
+        pending->expected_kind = kind;
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (!_connected) {
+                return Response{
+                    .request_kind = kind,
+                    .status = Status::CONNECTION_CLOSED,
+                    .message = _error.empty() ? "Remote connection is closed." : _error};
+            }
+            _pending.emplace(request_id, pending);
+        }
+        luisa::string write_error;
+        if (!_write_frame(kind, request_id, payload, write_error)) {
+            std::scoped_lock lock{_state_mutex};
+            _pending.erase(request_id);
+            return Response{
+                .request_kind = kind,
+                .status = Status::CONNECTION_CLOSED,
+                .message = std::move(write_error)};
+        }
+        std::unique_lock lock{_state_mutex};
+        auto completed = pending->cv.wait_for(
+            lock, timeout, [&]() noexcept { return pending->done || !_connected; });
+        if (!completed) {
+            _pending.erase(request_id);
+            return Response{
+                .request_kind = kind,
+                .status = Status::TIMEOUT,
+                .message = "Remote request timed out."};
+        }
+        auto response = std::move(pending->response);
+        _pending.erase(request_id);
+        return response;
+    }
+
+    [[nodiscard]] bool notify(MessageKind kind,
+                              uint64_t request_id,
+                              luisa::span<const std::byte> payload,
+                              luisa::string &error) noexcept {
+        {
+            std::scoped_lock lock{_state_mutex};
+            if (!_connected) {
+                error = _error.empty() ? "Remote connection is closed." : _error;
+                return false;
+            }
+        }
+        return _write_frame(kind, request_id, payload, error);
+    }
+
+    void set_notification_handler(NotificationHandler handler) noexcept {
+        std::scoped_lock lock{_state_mutex};
+        _notification_handler = std::move(handler);
+    }
+
+    void set_close_handler(CloseHandler handler) noexcept {
+        std::scoped_lock lock{_state_mutex};
+        _close_handler = std::move(handler);
+    }
+
+    void close() noexcept {
+        auto initiate_close = false;
+        std::thread::id reader_thread_id;
+        {
+            std::scoped_lock close_lock{_close_mutex};
+            {
+                std::scoped_lock lock{_state_mutex};
+                initiate_close = !_closing;
+                _closing = true;
+                reader_thread_id = _reader_thread_id;
+            }
+            if (initiate_close) {
+                asio::error_code ignored;
+                _socket.cancel(ignored);
+                _socket.shutdown(Tcp::socket::shutdown_both, ignored);
+                _socket.close(ignored);
+            }
+        }
+        if (reader_thread_id != std::this_thread::get_id()) {
+            std::scoped_lock join_lock{_join_mutex};
+            if (_reader.joinable()) { _reader.join(); }
+        }
+        _set_closed("Remote connection closed.");
+    }
+
+    [[nodiscard]] bool connected() const noexcept {
+        std::scoped_lock lock{_state_mutex};
+        return _connected;
+    }
+
+    [[nodiscard]] luisa::string error() const noexcept {
+        std::scoped_lock lock{_state_mutex};
+        return _error;
+    }
+};
+
+Connection::Connection(ProtocolLimits limits) noexcept
+    : _impl{std::make_unique<Impl>(limits)} {}
+
+Connection::~Connection() noexcept = default;
+
+bool Connection::connect(luisa::string_view host,
+                         uint16_t port,
+                         std::chrono::milliseconds timeout,
+                         luisa::string &error) noexcept {
+    return _impl->connect(host, port, timeout, error);
+}
+
+Response Connection::request(MessageKind kind,
+                             luisa::span<const std::byte> payload,
+                             std::chrono::milliseconds timeout) noexcept {
+    return _impl->request(kind, payload, timeout);
+}
+
+bool Connection::notify(MessageKind kind,
+                        uint64_t request_id,
+                        luisa::span<const std::byte> payload,
+                        luisa::string &error) noexcept {
+    return _impl->notify(kind, request_id, payload, error);
+}
+
+void Connection::set_notification_handler(NotificationHandler handler) noexcept {
+    _impl->set_notification_handler(std::move(handler));
+}
+
+void Connection::set_close_handler(CloseHandler handler) noexcept {
+    _impl->set_close_handler(std::move(handler));
+}
+
+void Connection::close() noexcept { _impl->close(); }
+
+bool Connection::connected() const noexcept { return _impl->connected(); }
+
+luisa::string Connection::error() const noexcept { return _impl->error(); }
+
+}// namespace luisa::compute::remote

--- a/src/backends/remote/remote_transport.h
+++ b/src/backends/remote/remote_transport.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include <luisa/core/stl/memory.h>
+#include <luisa/core/stl/string.h>
+#include <luisa/core/stl/vector.h>
+
+#include "remote_protocol.h"
+
+namespace luisa::compute::remote {
+
+struct Response {
+    MessageKind request_kind{};
+    Status status{Status::CONNECTION_CLOSED};
+    luisa::string message;
+    luisa::vector<std::byte> body;
+
+    [[nodiscard]] explicit operator bool() const noexcept {
+        return status == Status::OK;
+    }
+};
+
+class Connection final {
+
+public:
+    using NotificationHandler = std::function<void(
+        MessageKind, uint64_t, luisa::span<const std::byte>)>;
+    using CloseHandler = std::function<void(luisa::string_view)>;
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+
+public:
+    explicit Connection(ProtocolLimits limits = {}) noexcept;
+    ~Connection() noexcept;
+    Connection(Connection const &) = delete;
+    Connection(Connection &&) = delete;
+    Connection &operator=(Connection const &) = delete;
+    Connection &operator=(Connection &&) = delete;
+
+    [[nodiscard]] bool connect(
+        luisa::string_view host,
+        uint16_t port,
+        std::chrono::milliseconds timeout,
+        luisa::string &error) noexcept;
+
+    [[nodiscard]] Response request(
+        MessageKind kind,
+        luisa::span<const std::byte> payload,
+        std::chrono::milliseconds timeout) noexcept;
+
+    [[nodiscard]] bool notify(
+        MessageKind kind,
+        uint64_t request_id,
+        luisa::span<const std::byte> payload,
+        luisa::string &error) noexcept;
+
+    void set_notification_handler(NotificationHandler handler) noexcept;
+    void set_close_handler(CloseHandler handler) noexcept;
+    void close() noexcept;
+
+    [[nodiscard]] bool connected() const noexcept;
+    [[nodiscard]] luisa::string error() const noexcept;
+};
+
+}// namespace luisa::compute::remote

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -618,6 +618,8 @@ luisa_compute_add_test(test_warp_prefix_scan    unit/runtime/test_warp_prefix_sc
 luisa_compute_add_test(test_warp_sparse_collectives unit/runtime/test_warp_sparse_collectives.cpp)
 luisa_compute_add_test(test_hip_wave_size       unit/runtime/test_hip_wave_size.cpp)
 luisa_compute_add_test(test_mha_warp_reduction  unit/runtime/test_mha_warp_reduction.cpp)
+luisa_compute_add_test(test_ast_json_serde      unit/ast/test_ast_json_serde.cpp
+        LABELS "unit;unit_ast")
 if (TARGET luisa-compute-backend-vk AND LUISA_COMPUTE_ENABLE_VK_XIR_SPIRV)
     # Requires an explicit backend argument and a physical Vulkan device, so
     # build it for the native path but keep it out of unattended CTest runs.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -620,6 +620,48 @@ luisa_compute_add_test(test_hip_wave_size       unit/runtime/test_hip_wave_size.
 luisa_compute_add_test(test_mha_warp_reduction  unit/runtime/test_mha_warp_reduction.cpp)
 luisa_compute_add_test(test_ast_json_serde      unit/ast/test_ast_json_serde.cpp
         LABELS "unit;unit_ast")
+if (LUISA_COMPUTE_ENABLE_REMOTE)
+    luisa_compute_add_test(test_remote_blob_cache
+            unit/runtime/test_remote_blob_cache.cpp
+            LABELS "unit;unit_runtime;remote")
+    target_link_libraries(test_remote_blob_cache PRIVATE
+            luisa-compute-remote-runtime)
+    luisa_compute_add_test(test_remote_protocol unit/runtime/test_remote_protocol.cpp
+            LABELS "unit;unit_runtime;remote")
+    target_link_libraries(test_remote_protocol PRIVATE
+            luisa-compute-remote-common)
+    luisa_compute_add_test(test_remote_transport unit/runtime/test_remote_transport.cpp
+            LABELS "unit;unit_runtime;remote")
+    target_link_libraries(test_remote_transport PRIVATE
+            luisa-compute-remote-common
+            luisa-compute-ext-asio)
+    luisa_compute_add_test(test_remote_backend_e2e
+            unit/runtime/test_remote_backend_e2e.cpp
+            LABELS "unit;unit_runtime;remote;integration")
+    target_link_libraries(test_remote_backend_e2e PRIVATE
+            luisa-compute-remote-runtime
+            luisa-compute-ext-asio)
+    add_dependencies(test_remote_backend_e2e
+            luisa-compute-backend-remote)
+    luisa_compute_add_test(test_remote_backend_native
+            unit/runtime/test_remote_backend_native.cpp)
+    add_dependencies(test_remote_backend_native
+            luisa-compute-backend-remote)
+    if (TARGET luisa-compute-backend-metal)
+        add_dependencies(test_remote_backend_native
+                luisa-compute-backend-metal)
+    endif ()
+    if (LUISA_COMPUTE_ENABLE_GUI)
+        luisa_compute_add_test(test_remote_backend_swapchain
+                unit/runtime/test_remote_backend_swapchain.cpp)
+        add_dependencies(test_remote_backend_swapchain
+                luisa-compute-backend-remote)
+        if (TARGET luisa-compute-backend-metal)
+            add_dependencies(test_remote_backend_swapchain
+                    luisa-compute-backend-metal)
+        endif ()
+    endif ()
+endif ()
 if (TARGET luisa-compute-backend-vk AND LUISA_COMPUTE_ENABLE_VK_XIR_SPIRV)
     # Requires an explicit backend argument and a physical Vulkan device, so
     # build it for the native path but keep it out of unattended CTest runs.

--- a/src/tests/unit/ast/test_ast_json_serde.cpp
+++ b/src/tests/unit/ast/test_ast_json_serde.cpp
@@ -1,0 +1,463 @@
+// Tests for the versioned and bounded AST JSON interchange format.
+
+#include "ut/ut.hpp"
+
+#include <luisa/ast/ast2json.h>
+#include <luisa/ast/function_builder.h>
+
+using namespace luisa;
+using namespace luisa::compute;
+using namespace luisa::compute::detail;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+
+namespace {
+
+[[nodiscard]] shared_ptr<const FunctionBuilder> make_kernel() {
+    auto twice = FunctionBuilder::define_callable([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_name("twice");
+        auto value = builder->argument(Type::of<float>());
+        builder->set_variable_name(value->variable().uid(), "value");
+        auto two = builder->literal(Type::of<float>(), 2.0f);
+        builder->return_(builder->binary(
+            Type::of<float>(), BinaryOp::MUL, value, two));
+    });
+    return FunctionBuilder::define_kernel([&] {
+        auto builder = FunctionBuilder::current();
+        builder->set_name("remote_roundtrip");
+        builder->set_block_size(uint3{64u, 1u, 1u});
+        builder->set_allowed_warp_size(32u);
+        auto output = builder->buffer(Type::buffer(Type::of<float>()));
+        builder->set_variable_name(output->variable().uid(), "output");
+        auto index = builder->swizzle(
+            Type::of<uint>(), builder->dispatch_id(), 1u, 0u);
+        auto input = builder->literal(Type::of<float>(), 3.0f);
+        auto value = builder->call(
+            Type::of<float>(), Function{twice.get()}, {input});
+        builder->call(CallOp::BUFFER_WRITE, {output, index, value});
+    });
+}
+
+void test_round_trip() {
+    auto source = make_kernel();
+    auto encoded = try_to_json(Function{source.get()});
+    expect(static_cast<bool>(encoded));
+    expect(encoded.error.empty());
+    expect(encoded.json.find("luisa.compute.ast") != string::npos);
+
+    auto decoded = from_json(encoded.json);
+    expect(static_cast<bool>(decoded)) << decoded.error;
+    if (!decoded) { return; }
+    auto function = Function{decoded.function.get()};
+    expect(function.tag() == Function::Tag::KERNEL);
+    expect(all(function.block_size() == uint3{64u, 1u, 1u}));
+    expect(function.allowed_warp_size().value_or(0u) == 32u);
+    expect(function.custom_callables().size() == 1u);
+    expect(function.hash() == Function{source.get()}.hash());
+
+    auto encoded_again = try_to_json(function);
+    expect(static_cast<bool>(encoded_again));
+    auto decoded_again = from_json(encoded_again.json);
+    expect(static_cast<bool>(decoded_again)) << decoded_again.error;
+    if (!decoded_again) { return; }
+    expect(Function{decoded_again.function.get()}.hash() == function.hash());
+}
+
+void test_control_flow_round_trip() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_name("control_flow");
+        builder->set_block_size(uint3{8u, 2u, 1u});
+        auto output = builder->buffer(Type::buffer(Type::of<uint>()));
+        auto index = builder->local(Type::of<uint>());
+        builder->set_variable_name(index->variable().uid(), "index");
+        auto zero = builder->literal(Type::of<uint>(), 0u);
+        auto one = builder->literal(Type::of<uint>(), 1u);
+        auto four = builder->literal(Type::of<uint>(), 4u);
+        builder->assign(index, zero);
+        auto condition = builder->binary(
+            Type::of<bool>(), BinaryOp::LESS, index, four);
+        auto step = builder->binary(
+            Type::of<uint>(), BinaryOp::ADD, index, one);
+        auto loop = builder->for_(index, condition, step);
+        builder->with(loop->body(), [&] {
+            auto low_bit = builder->binary(
+                Type::of<uint>(), BinaryOp::BIT_AND, index, one);
+            auto even = builder->binary(
+                Type::of<bool>(), BinaryOp::EQUAL, low_bit, zero);
+            auto branch = builder->if_(even);
+            builder->with(branch->true_branch(), [&] {
+                builder->call(CallOp::BUFFER_WRITE, {output, index, index});
+            });
+            builder->with(branch->false_branch(), [&] {
+                builder->comment_("odd lane");
+            });
+        });
+        auto tail = builder->loop_();
+        builder->with(tail->body(), [&] {
+            builder->comment_("single iteration");
+            builder->break_();
+        });
+        const Expression *arguments[]{index};
+        builder->print_("index = {}", arguments);
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(static_cast<bool>(encoded)) << encoded.error;
+    auto decoded = from_json(encoded.json);
+    expect(static_cast<bool>(decoded)) << decoded.error;
+    if (!decoded) { return; }
+    expect(Function{decoded.function.get()}.hash() == Function{source.get()}.hash());
+}
+
+void test_scalar_assignment_conversion_round_trip() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto value = builder->local(Type::of<uint>());
+        builder->assign(
+            value, builder->literal(Type::of<int>(), 7));
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(static_cast<bool>(encoded)) << encoded.error;
+    auto decoded = from_json(encoded.json);
+    expect(static_cast<bool>(decoded)) << decoded.error;
+    if (decoded) {
+        expect(Function{decoded.function.get()}.hash() ==
+               Function{source.get()}.hash());
+    }
+
+    auto invalid = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto value = builder->local(Type::of<float2>());
+        builder->assign(
+            value, builder->literal(Type::of<float>(), 1.0f));
+    });
+    auto invalid_encoded = try_to_json(Function{invalid.get()});
+    expect(!static_cast<bool>(invalid_encoded));
+    expect(invalid_encoded.error.find("assignment") != string::npos);
+}
+
+void test_indirect_dispatch_buffer_round_trip() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_name("indirect_dispatch_writer");
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto dispatch_buffer = builder->buffer(
+            Type::custom(ast_json_indirect_dispatch_buffer_type_name));
+        auto one = builder->literal(Type::of<uint>(), 1u);
+        builder->call(
+            CallOp::INDIRECT_SET_DISPATCH_COUNT,
+            {dispatch_buffer, one});
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(static_cast<bool>(encoded)) << encoded.error;
+    auto decoded = from_json(encoded.json);
+    expect(static_cast<bool>(decoded)) << decoded.error;
+    if (!decoded) { return; }
+    auto function = Function{decoded.function.get()};
+    expect(function.arguments().size() == 1u);
+    expect(function.arguments().front().tag() == Variable::Tag::BUFFER);
+    expect(function.arguments().front().type()->description() ==
+           ast_json_indirect_dispatch_buffer_type_name);
+    expect(function.hash() == Function{source.get()}.hash());
+}
+
+void test_ray_query_custom_types_round_trip() {
+    for (auto type_name : {ast_json_ray_query_all_type_name,
+                           ast_json_ray_query_any_type_name}) {
+        auto source = FunctionBuilder::define_kernel([type_name] {
+            auto builder = FunctionBuilder::current();
+            builder->set_block_size(uint3{1u, 1u, 1u});
+            auto query = builder->local(Type::custom(type_name));
+            static_cast<void>(builder->ray_query_(query));
+        });
+        auto encoded = try_to_json(Function{source.get()});
+        expect(static_cast<bool>(encoded)) << encoded.error;
+        auto decoded = from_json(encoded.json);
+        expect(static_cast<bool>(decoded)) << decoded.error;
+        if (decoded) {
+            expect(Function{decoded.function.get()}.hash() ==
+                   Function{source.get()}.hash());
+        }
+    }
+}
+
+void test_unknown_custom_type_rejected() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto value = builder->local(Type::custom("UntrustedRemoteCustomType"));
+        static_cast<void>(builder->ray_query_(value));
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(!static_cast<bool>(encoded));
+    expect(encoded.error.find("Custom AST types") != string::npos);
+}
+
+void test_nested_custom_type_rejected() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        static_cast<void>(builder->buffer(
+            Type::buffer(Type::custom(ast_json_ray_query_all_type_name))));
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(!static_cast<bool>(encoded));
+    expect(encoded.error.find("nested in buffers") != string::npos);
+
+    // The legacy encoder remains available for source compatibility, so the
+    // decoder must independently reject the same unsafe type construction.
+    auto decoded = from_json(to_json(Function{source.get()}));
+    expect(!static_cast<bool>(decoded));
+    expect(decoded.error.find("portable data type") != string::npos);
+}
+
+class RemappingResolver final : public ASTJsonBindingResolver {
+
+public:
+    [[nodiscard]] bool resolve_buffer(
+        const Type *serialized_type, uint64_t serialized_handle,
+        size_t serialized_offset,
+        size_t serialized_size, Function::BufferBinding &binding,
+        string &error) const noexcept override {
+        if (serialized_type != Type::buffer(Type::of<float>()) ||
+            serialized_handle != 17u) {
+            error = "unexpected serialized buffer handle";
+            return false;
+        }
+        binding = Function::BufferBinding{
+            99u, serialized_offset + 4u, serialized_size};
+        return true;
+    }
+};
+
+void test_binding_resolver() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto buffer = builder->buffer_binding(
+            Type::buffer(Type::of<float>()), 17u, 8u, 64u);
+        auto zero = builder->literal(Type::of<uint>(), 0u);
+        auto value = builder->call(
+            Type::of<float>(), CallOp::BUFFER_READ, {buffer, zero});
+        builder->expression_statement(value);
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(static_cast<bool>(encoded));
+    RemappingResolver resolver;
+    auto decoded = from_json(encoded.json, {}, &resolver);
+    expect(static_cast<bool>(decoded)) << decoded.error;
+    if (!decoded) { return; }
+    auto bindings = Function{decoded.function.get()}.bound_arguments();
+    expect(bindings.size() == 1u);
+    auto binding = get<Function::BufferBinding>(bindings.front());
+    expect(binding.handle == 99u);
+    expect(binding.offset == 12u);
+    expect(binding.size == 64u);
+}
+
+void cpu_custom(void *, void *) {}
+void cpu_custom_destroy(void *) {}
+
+void test_unsafe_node_rejected() {
+    auto source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto argument = builder->literal(Type::of<int>(), 1);
+        auto expression = builder->call(
+            Type::of<int>(), cpu_custom, cpu_custom_destroy,
+            nullptr, argument);
+        builder->expression_statement(expression);
+    });
+    auto encoded = try_to_json(Function{source.get()});
+    expect(!static_cast<bool>(encoded));
+    expect(encoded.error.find("CPU custom") != string::npos);
+}
+
+void test_malformed_documents_rejected() {
+    auto empty = from_json("{}");
+    expect(!static_cast<bool>(empty));
+    expect(!empty.error.empty());
+
+    auto source = make_kernel();
+    auto encoded = try_to_json(Function{source.get()});
+    expect(static_cast<bool>(encoded));
+
+    auto wrong_version = encoded.json;
+    auto version = wrong_version.find("\"version\": 1");
+    expect(version != string::npos);
+    wrong_version[version + string_view{"\"version\": "}.size()] = '2';
+    auto version_result = from_json(wrong_version);
+    expect(!static_cast<bool>(version_result));
+    expect(version_result.error.find("version") != string::npos);
+
+    auto bad_base64 = encoded.json;
+    auto value = bad_base64.find("\"value\": \"");
+    expect(value != string::npos);
+    bad_base64[value + string_view{"\"value\": \""}.size()] = '!';
+    auto base64_result = from_json(bad_base64);
+    expect(!static_cast<bool>(base64_result));
+    expect(base64_result.error.find("Base64") != string::npos);
+
+    auto too_small = from_json(
+        encoded.json, ASTJsonLimits{.max_document_bytes = 8u});
+    expect(!static_cast<bool>(too_small));
+    expect(too_small.error.find("byte limit") != string::npos);
+
+    auto duplicate_schema = encoded.json;
+    duplicate_schema.insert(1u, "\n  \"schema\": \"luisa.compute.ast\",");
+    auto duplicate_result = from_json(duplicate_schema);
+    expect(!static_cast<bool>(duplicate_result));
+    expect(duplicate_result.error.find("duplicate member") != string::npos);
+
+    auto bad_arity = encoded.json;
+    auto write = bad_arity.find("\"op\": \"BUFFER_WRITE\"");
+    expect(write != string::npos);
+    bad_arity.replace(
+        write, string_view{"\"op\": \"BUFFER_WRITE\""}.size(),
+        "\"op\": \"ASYNC_COPY\"");
+    auto arity_result = from_json(bad_arity);
+    expect(!static_cast<bool>(arity_result));
+    expect(arity_result.error.find("requires") != string::npos);
+
+    auto indirect_source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto dispatch_buffer = builder->buffer(
+            Type::custom(ast_json_indirect_dispatch_buffer_type_name));
+        auto one = builder->literal(Type::of<uint>(), 1u);
+        builder->call(
+            CallOp::INDIRECT_SET_DISPATCH_COUNT,
+            {dispatch_buffer, one});
+    });
+    auto indirect_encoded = try_to_json(Function{indirect_source.get()});
+    expect(static_cast<bool>(indirect_encoded));
+    auto bad_indirect_arity = indirect_encoded.json;
+    auto indirect_count = bad_indirect_arity.find(
+        "\"op\": \"INDIRECT_SET_DISPATCH_COUNT\"");
+    expect(indirect_count != string::npos);
+    bad_indirect_arity.replace(
+        indirect_count,
+        string_view{"\"op\": \"INDIRECT_SET_DISPATCH_COUNT\""}.size(),
+        "\"op\": \"INDIRECT_SET_DISPATCH_KERNEL\"");
+    auto indirect_arity_result = from_json(bad_indirect_arity);
+    expect(!static_cast<bool>(indirect_arity_result));
+    expect(indirect_arity_result.error.find("exactly 5") != string::npos);
+
+    auto tiny_parse_budget = from_json(
+        encoded.json,
+        ASTJsonLimits{.max_parse_memory_bytes = 1u});
+    expect(!static_cast<bool>(tiny_parse_budget));
+    expect(tiny_parse_budget.error.find("parse") != string::npos);
+
+    auto tiny_node_budget = from_json(
+        encoded.json,
+        ASTJsonLimits{.max_nodes = 2u});
+    expect(!static_cast<bool>(tiny_node_budget));
+    expect(tiny_node_budget.error.find("node count") != string::npos);
+
+    auto structure_source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto value = builder->local(
+            Type::structure(16u, {Type::of<float4>()}));
+        builder->assign(value, value);
+    });
+    auto structure_encoded = try_to_json(
+        Function{structure_source.get()});
+    expect(static_cast<bool>(structure_encoded));
+    auto bad_structure_alignment = structure_encoded.json;
+    auto structure_tag = bad_structure_alignment.find(
+        "\"tag\": \"STRUCTURE\"");
+    expect(structure_tag != string::npos);
+    if (structure_tag == string::npos) { return; }
+    auto structure_alignment = bad_structure_alignment.find(
+        "\"alignment\": 16");
+    expect(structure_alignment != string::npos);
+    if (structure_alignment == string::npos) { return; }
+    bad_structure_alignment.replace(
+        structure_alignment,
+        string_view{"\"alignment\": 16"}.size(),
+        "\"alignment\": 1");
+    auto structure_result = from_json(bad_structure_alignment);
+    expect(!static_cast<bool>(structure_result));
+    expect(structure_result.error.find("member alignment") != string::npos);
+
+    auto byte_buffer_source = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto buffer = builder->buffer(Type::of<ByteBuffer>());
+        auto zero = builder->literal(Type::of<uint>(), 0u);
+        auto value = builder->call(
+            Type::of<uint>(), CallOp::BYTE_BUFFER_READ,
+            {buffer, zero});
+        builder->expression_statement(value);
+    });
+    auto byte_buffer_encoded = try_to_json(
+        Function{byte_buffer_source.get()});
+    expect(static_cast<bool>(byte_buffer_encoded));
+    auto bad_atomic = byte_buffer_encoded.json;
+    auto byte_buffer_read = bad_atomic.find(
+        "\"op\": \"BYTE_BUFFER_READ\"");
+    expect(byte_buffer_read != string::npos);
+    if (byte_buffer_read == string::npos) { return; }
+    bad_atomic.replace(
+        byte_buffer_read,
+        string_view{"\"op\": \"BYTE_BUFFER_READ\""}.size(),
+        "\"op\": \"ATOMIC_FETCH_ADD\"");
+    auto atomic_result = from_json(bad_atomic);
+    expect(!static_cast<bool>(atomic_result));
+    expect(atomic_result.error.find("typed buffer") != string::npos);
+
+    auto invalid_lvalue = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto one = builder->literal(Type::of<uint>(), 1u);
+        builder->assign(one, one);
+    });
+    auto invalid_lvalue_encoded = try_to_json(
+        Function{invalid_lvalue.get()});
+    expect(!static_cast<bool>(invalid_lvalue_encoded));
+    expect(invalid_lvalue_encoded.error.find("not assignable") != string::npos);
+
+    auto invalid_ray_query = FunctionBuilder::define_kernel([] {
+        auto builder = FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        auto value = builder->local(Type::of<uint>());
+        static_cast<void>(builder->ray_query_(value));
+    });
+    auto invalid_ray_query_encoded = try_to_json(
+        Function{invalid_ray_query.get()});
+    expect(!static_cast<bool>(invalid_ray_query_encoded));
+    expect(invalid_ray_query_encoded.error.find("non-ray-query") != string::npos);
+}
+
+}// namespace
+
+static auto test_ast_json_registration = [] {
+    "ast_json_round_trip"_test = test_round_trip;
+    "ast_json_control_flow_round_trip"_test =
+        test_control_flow_round_trip;
+    "ast_json_scalar_assignment_conversion_round_trip"_test =
+        test_scalar_assignment_conversion_round_trip;
+    "ast_json_indirect_dispatch_buffer_round_trip"_test =
+        test_indirect_dispatch_buffer_round_trip;
+    "ast_json_ray_query_custom_types_round_trip"_test =
+        test_ray_query_custom_types_round_trip;
+    "ast_json_unknown_custom_type_rejected"_test =
+        test_unknown_custom_type_rejected;
+    "ast_json_nested_custom_type_rejected"_test =
+        test_nested_custom_type_rejected;
+    "ast_json_binding_resolver"_test = test_binding_resolver;
+    "ast_json_unsafe_node_rejected"_test = test_unsafe_node_rejected;
+    "ast_json_malformed_documents_rejected"_test =
+        test_malformed_documents_rejected;
+    return 0;
+}();
+
+int main(int argc, char *argv[]) {
+    boost::ut::detail::cfg::parse_arg_with_fallback(
+        argc, const_cast<const char **>(argv));
+}

--- a/src/tests/unit/runtime/test_remote_backend_e2e.cpp
+++ b/src/tests/unit/runtime/test_remote_backend_e2e.cpp
@@ -1,0 +1,1343 @@
+// End-to-end test for the C++ remote DeviceInterface, server, command codec,
+// asynchronous completion, readback, and AST resource-binding remap.
+
+#include "ut/ut.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <charconv>
+#include <cstring>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <unordered_set>
+
+#include <asio.hpp>
+
+#include <luisa/backends/ext/remote_config_ext.h>
+#include <luisa/luisa-compute.h>
+
+#include "remote_blob_cache.h"
+#include "remote_server.h"
+#include "remote_transport.h"
+
+using namespace luisa;
+using namespace luisa::compute;
+using namespace luisa::compute::remote;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+using namespace std::chrono_literals;
+
+namespace {
+
+[[nodiscard]] uint64_t parse_u64(string_view text) {
+    uint64_t value{};
+    auto result = std::from_chars(
+        text.data(), text.data() + text.size(), value);
+    expect(result.ec == std::errc{});
+    expect(result.ptr == text.data() + text.size());
+    return value;
+}
+
+void write_test_shader_option(
+    Writer &writer, const ShaderOption &option) noexcept {
+    writer.write_bool(option.enable_cache);
+    writer.write_bool(option.enable_fast_math);
+    writer.write_bool(option.enable_debug_info);
+    writer.write_bool(option.compile_only);
+    writer.write_u32(option.max_registers);
+    writer.write_bool(option.time_trace);
+    writer.write_bool(option.enable_extended_accel_limits);
+    writer.write_bool(option.enable_scalarizer);
+    writer.write_bool(option.enable_ray_query_pipeline);
+    writer.write_bool(option.force_ray_query_pipeline);
+    writer.write_bool(option.enable_driver_optimization);
+    writer.write_string(option.name);
+}
+
+struct MockState {
+    std::atomic_bool ast_received{false};
+    std::atomic_bool ast_binding_remapped{false};
+    std::atomic_bool custom_callable_received{false};
+    std::atomic_bool bindless_update_remapped{false};
+    std::atomic_bool mesh_build_remapped{false};
+    std::atomic_bool curve_build_remapped{false};
+    std::atomic_bool procedural_build_remapped{false};
+    std::atomic_bool motion_build_remapped{false};
+    std::atomic_bool accel_build_remapped{false};
+    std::atomic_bool indirect_buffer_created{false};
+    std::atomic_bool indirect_writer_remapped{false};
+    std::atomic_bool indirect_dispatch_remapped{false};
+    std::atomic_uint texture_command_count{0u};
+    std::atomic_uint live_buffers{0u};
+};
+
+struct MockBuffer {
+    vector<std::byte> bytes;
+    bool indirect_dispatch{};
+    size_t indirect_dispatch_capacity{};
+};
+
+struct MockTexture {
+    PixelStorage storage{};
+    uint3 size{};
+    vector<std::byte> bytes;
+};
+
+struct MockStream {
+    DeviceInterface::StreamLogCallback log_callback;
+};
+
+struct MockShader {
+    vector<Usage> usages;
+    vector<Function::Binding> bindings;
+    uint3 block_size{};
+    bool indirect_writer{};
+};
+
+struct MockBindless {
+    size_t size{};
+    BindlessSlotType type{};
+};
+
+struct MockEvent {
+    std::atomic_uint64_t value{0u};
+};
+
+struct MockPrimitive {
+    Resource::Tag tag{};
+    size_t keyframe_count{};
+};
+
+struct MockAccel {};
+
+class MockDevice final : public DeviceInterface {
+
+private:
+    shared_ptr<MockState> _state;
+    std::mutex _mutex;
+    std::unordered_set<MockBuffer *> _buffers;
+    std::unordered_set<MockTexture *> _textures;
+    std::unordered_set<MockPrimitive *> _primitives;
+    std::unordered_set<MockAccel *> _accels;
+
+public:
+    MockDevice(Context &&context, shared_ptr<MockState> state,
+               string backend = "mock") noexcept
+        : DeviceInterface{std::move(context)}, _state{std::move(state)} {
+        _backend_name = std::move(backend);
+    }
+
+    ~MockDevice() noexcept override = default;
+
+    void *native_handle() const noexcept override {
+        return const_cast<MockDevice *>(this);
+    }
+    uint compute_warp_size() const noexcept override { return 32u; }
+    size_t compute_max_shared_memory_size() const noexcept override { return 32768u; }
+    uint64_t memory_granularity() const noexcept override { return 256u; }
+
+    BufferCreationInfo create_buffer(
+        const Type *element, size_t count, void *) noexcept override {
+        auto indirect = element == Type::of<IndirectKernelDispatch>();
+        auto stride = indirect                    ? 32u :
+                      element == Type::of<void>() ? 1u :
+                                                    element->size();
+        auto buffer = new MockBuffer;
+        buffer->bytes.resize(stride * count);
+        buffer->indirect_dispatch = indirect;
+        buffer->indirect_dispatch_capacity = indirect ? count : 0u;
+        if (indirect) {
+            _state->indirect_buffer_created.store(
+                true, std::memory_order_release);
+        }
+        {
+            std::scoped_lock lock{_mutex};
+            _buffers.emplace(buffer);
+        }
+        _state->live_buffers.fetch_add(1u, std::memory_order_release);
+        BufferCreationInfo info{};
+        info.handle = reinterpret_cast<uint64_t>(buffer);
+        info.native_handle = buffer->bytes.data();
+        info.element_stride = stride;
+        info.total_size_bytes = buffer->bytes.size();
+        return info;
+    }
+
+    void destroy_buffer(uint64_t handle) noexcept override {
+        auto buffer = reinterpret_cast<MockBuffer *>(handle);
+        {
+            std::scoped_lock lock{_mutex};
+            _buffers.erase(buffer);
+        }
+        delete buffer;
+        _state->live_buffers.fetch_sub(1u, std::memory_order_release);
+    }
+
+    ResourceCreationInfo create_texture(
+        PixelFormat format, uint, uint width, uint height, uint depth, uint,
+        void *, bool, bool) noexcept override {
+        auto texture = new MockTexture{
+            .storage = pixel_format_to_storage(format),
+            .size = uint3{width, height, depth}};
+        auto size = checked_pixel_storage_size(
+            texture->storage, texture->size);
+        expect(static_cast<bool>(size));
+        texture->bytes.resize(size.size);
+        {
+            std::scoped_lock lock{_mutex};
+            _textures.emplace(texture);
+        }
+        return ResourceCreationInfo{
+            .handle = reinterpret_cast<uint64_t>(texture),
+            .native_handle = texture};
+    }
+    void destroy_texture(uint64_t handle) noexcept override {
+        auto texture = reinterpret_cast<MockTexture *>(handle);
+        {
+            std::scoped_lock lock{_mutex};
+            _textures.erase(texture);
+        }
+        delete texture;
+    }
+    ResourceCreationInfo create_bindless_array(
+        size_t size, BindlessSlotType type) noexcept override {
+        auto array = new MockBindless{size, type};
+        return ResourceCreationInfo{
+            .handle = reinterpret_cast<uint64_t>(array),
+            .native_handle = array};
+    }
+    void destroy_bindless_array(uint64_t handle) noexcept override {
+        delete reinterpret_cast<MockBindless *>(handle);
+    }
+
+    ResourceCreationInfo create_stream(StreamTag) noexcept override {
+        auto stream = new MockStream;
+        return ResourceCreationInfo{
+            .handle = reinterpret_cast<uint64_t>(stream),
+            .native_handle = stream};
+    }
+    void destroy_stream(uint64_t handle) noexcept override {
+        delete reinterpret_cast<MockStream *>(handle);
+    }
+    void synchronize_stream(uint64_t) noexcept override {}
+
+    void dispatch(uint64_t stream_handle, CommandList &&list) noexcept override {
+        auto commands = list.steal_commands();
+        auto callbacks = list.steal_callbacks();
+        for (auto &&command : commands) {
+            switch (command->tag()) {
+                case Command::Tag::EBufferUploadCommand: {
+                    auto upload = static_cast<BufferUploadCommand *>(command.get());
+                    auto buffer = reinterpret_cast<MockBuffer *>(upload->handle());
+                    std::memcpy(buffer->bytes.data() + upload->offset(),
+                                upload->data(), upload->size());
+                    break;
+                }
+                case Command::Tag::EBufferDownloadCommand: {
+                    auto download = static_cast<BufferDownloadCommand *>(command.get());
+                    auto buffer = reinterpret_cast<MockBuffer *>(download->handle());
+                    std::memcpy(download->data(),
+                                buffer->bytes.data() + download->offset(),
+                                download->size());
+                    break;
+                }
+                case Command::Tag::EBufferCopyCommand: {
+                    auto copy = static_cast<BufferCopyCommand *>(command.get());
+                    auto source = reinterpret_cast<MockBuffer *>(copy->src_handle());
+                    auto destination = reinterpret_cast<MockBuffer *>(copy->dst_handle());
+                    std::memmove(destination->bytes.data() + copy->dst_offset(),
+                                 source->bytes.data() + copy->src_offset(),
+                                 copy->size());
+                    break;
+                }
+                case Command::Tag::ETextureUploadCommand: {
+                    auto upload = static_cast<TextureUploadCommand *>(command.get());
+                    auto texture = reinterpret_cast<MockTexture *>(upload->handle());
+                    {
+                        std::scoped_lock lock{_mutex};
+                        expect(_textures.contains(texture));
+                    }
+                    expect(upload->storage() == texture->storage);
+                    expect(all(upload->size() == texture->size));
+                    expect(all(upload->offset() == 0u));
+                    std::memcpy(texture->bytes.data(), upload->data(),
+                                texture->bytes.size());
+                    _state->texture_command_count.fetch_add(
+                        1u, std::memory_order_relaxed);
+                    break;
+                }
+                case Command::Tag::ETextureDownloadCommand: {
+                    auto download = static_cast<TextureDownloadCommand *>(command.get());
+                    auto texture = reinterpret_cast<MockTexture *>(download->handle());
+                    {
+                        std::scoped_lock lock{_mutex};
+                        expect(_textures.contains(texture));
+                    }
+                    expect(download->storage() == texture->storage);
+                    expect(all(download->size() == texture->size));
+                    expect(all(download->offset() == 0u));
+                    std::memcpy(download->data(), texture->bytes.data(),
+                                texture->bytes.size());
+                    _state->texture_command_count.fetch_add(
+                        1u, std::memory_order_relaxed);
+                    break;
+                }
+                case Command::Tag::ETextureCopyCommand: {
+                    auto copy = static_cast<TextureCopyCommand *>(command.get());
+                    auto source = reinterpret_cast<MockTexture *>(copy->src_handle());
+                    auto destination = reinterpret_cast<MockTexture *>(copy->dst_handle());
+                    {
+                        std::scoped_lock lock{_mutex};
+                        expect(_textures.contains(source));
+                        expect(_textures.contains(destination));
+                    }
+                    expect(copy->storage() == source->storage);
+                    expect(copy->storage() == destination->storage);
+                    expect(all(copy->size() == source->size));
+                    std::memcpy(destination->bytes.data(), source->bytes.data(),
+                                source->bytes.size());
+                    _state->texture_command_count.fetch_add(
+                        1u, std::memory_order_relaxed);
+                    break;
+                }
+                case Command::Tag::EBufferToTextureCopyCommand: {
+                    auto copy = static_cast<BufferToTextureCopyCommand *>(command.get());
+                    auto buffer = reinterpret_cast<MockBuffer *>(copy->buffer());
+                    auto texture = reinterpret_cast<MockTexture *>(copy->texture());
+                    {
+                        std::scoped_lock lock{_mutex};
+                        expect(_buffers.contains(buffer));
+                        expect(_textures.contains(texture));
+                    }
+                    expect(copy->storage() == texture->storage);
+                    expect(all(copy->size() == texture->size));
+                    std::memcpy(texture->bytes.data(),
+                                buffer->bytes.data() + copy->buffer_offset(),
+                                texture->bytes.size());
+                    _state->texture_command_count.fetch_add(
+                        1u, std::memory_order_relaxed);
+                    break;
+                }
+                case Command::Tag::ETextureToBufferCopyCommand: {
+                    auto copy = static_cast<TextureToBufferCopyCommand *>(command.get());
+                    auto buffer = reinterpret_cast<MockBuffer *>(copy->buffer());
+                    auto texture = reinterpret_cast<MockTexture *>(copy->texture());
+                    {
+                        std::scoped_lock lock{_mutex};
+                        expect(_buffers.contains(buffer));
+                        expect(_textures.contains(texture));
+                    }
+                    expect(copy->storage() == texture->storage);
+                    expect(all(copy->size() == texture->size));
+                    std::memcpy(buffer->bytes.data() + copy->buffer_offset(),
+                                texture->bytes.data(), texture->bytes.size());
+                    _state->texture_command_count.fetch_add(
+                        1u, std::memory_order_relaxed);
+                    break;
+                }
+                case Command::Tag::EShaderDispatchCommand: {
+                    auto dispatch = static_cast<ShaderDispatchCommand *>(command.get());
+                    auto shader = reinterpret_cast<MockShader *>(dispatch->handle());
+                    if (dispatch->is_indirect()) {
+                        auto indirect = dispatch->indirect_dispatch();
+                        auto buffer = reinterpret_cast<MockBuffer *>(
+                            indirect.handle);
+                        std::scoped_lock lock{_mutex};
+                        _state->indirect_dispatch_remapped.store(
+                            _buffers.contains(buffer) &&
+                                buffer->indirect_dispatch &&
+                                indirect.offset == 0u &&
+                                indirect.max_dispatch_size == 1u,
+                            std::memory_order_release);
+                        break;
+                    }
+                    if (shader->indirect_writer) {
+                        expect(dispatch->arguments().size() == 1u);
+                        auto argument = dispatch->arguments().front();
+                        auto buffer = reinterpret_cast<MockBuffer *>(
+                            argument.buffer.handle);
+                        std::scoped_lock lock{_mutex};
+                        _state->indirect_writer_remapped.store(
+                            argument.tag == Argument::Tag::BUFFER &&
+                                _buffers.contains(buffer) &&
+                                buffer->indirect_dispatch &&
+                                argument.buffer.size ==
+                                    buffer->indirect_dispatch_capacity,
+                            std::memory_order_release);
+                        break;
+                    }
+                    expect(shader->block_size.x == 32u);
+                    expect(dispatch->arguments().size() == 2u);
+                    auto output_arg = dispatch->arguments()[0u];
+                    auto uniform_arg = dispatch->arguments()[1u];
+                    expect(output_arg.tag == Argument::Tag::BUFFER);
+                    expect(uniform_arg.tag == Argument::Tag::UNIFORM);
+                    auto output = reinterpret_cast<MockBuffer *>(output_arg.buffer.handle);
+                    uint base{};
+                    auto uniform = dispatch->uniform(uniform_arg.uniform);
+                    std::memcpy(&base, uniform.data(), sizeof(base));
+                    auto count = dispatch->dispatch_size().x;
+                    auto values = reinterpret_cast<uint *>(
+                        output->bytes.data() + output_arg.buffer.offset);
+                    for (auto i = 0u; i < count; i++) {
+                        values[i] = base + i;
+                    }
+                    break;
+                }
+                case Command::Tag::EBindlessArrayUpdateCommand: {
+                    auto update = static_cast<BindlessArrayUpdateCommand *>(command.get());
+                    auto array = reinterpret_cast<MockBindless *>(update->handle());
+                    expect(array->type == BindlessSlotType::MULTIPLE);
+                    update->visit_modifications([&](auto const &modifications) {
+                        expect(modifications.size() == 1u);
+                        using Modification = typename std::remove_cvref_t<decltype(modifications)>::value_type;
+                        if constexpr (std::is_same_v<Modification,
+                                                     BindlessArrayUpdateCommand::Modification>) {
+                            auto buffer = reinterpret_cast<MockBuffer *>(
+                                modifications.front().buffer.handle);
+                            std::scoped_lock lock{_mutex};
+                            _state->bindless_update_remapped.store(
+                                _buffers.contains(buffer), std::memory_order_release);
+                        } else {
+                            expect(false) << "unexpected bindless update variant";
+                        }
+                    });
+                    break;
+                }
+                case Command::Tag::EMeshBuildCommand: {
+                    auto build = static_cast<MeshBuildCommand *>(command.get());
+                    auto mesh = reinterpret_cast<MockPrimitive *>(build->handle());
+                    auto vertices = reinterpret_cast<MockBuffer *>(build->vertex_buffer());
+                    auto triangles = reinterpret_cast<MockBuffer *>(build->triangle_buffer());
+                    std::scoped_lock lock{_mutex};
+                    _state->mesh_build_remapped.store(
+                        _primitives.contains(mesh) &&
+                            mesh->tag == Resource::Tag::MESH &&
+                            _buffers.contains(vertices) &&
+                            _buffers.contains(triangles),
+                        std::memory_order_release);
+                    break;
+                }
+                case Command::Tag::ECurveBuildCommand: {
+                    auto build = static_cast<CurveBuildCommand *>(command.get());
+                    auto curve = reinterpret_cast<MockPrimitive *>(build->handle());
+                    auto control_points = reinterpret_cast<MockBuffer *>(build->cp_buffer());
+                    auto segments = reinterpret_cast<MockBuffer *>(build->seg_buffer());
+                    std::scoped_lock lock{_mutex};
+                    _state->curve_build_remapped.store(
+                        _primitives.contains(curve) &&
+                            curve->tag == Resource::Tag::CURVE &&
+                            _buffers.contains(control_points) &&
+                            _buffers.contains(segments),
+                        std::memory_order_release);
+                    break;
+                }
+                case Command::Tag::EProceduralPrimitiveBuildCommand: {
+                    auto build = static_cast<ProceduralPrimitiveBuildCommand *>(command.get());
+                    auto primitive = reinterpret_cast<MockPrimitive *>(build->handle());
+                    auto aabbs = reinterpret_cast<MockBuffer *>(build->aabb_buffer());
+                    std::scoped_lock lock{_mutex};
+                    _state->procedural_build_remapped.store(
+                        _primitives.contains(primitive) &&
+                            primitive->tag == Resource::Tag::PROCEDURAL_PRIMITIVE &&
+                            _buffers.contains(aabbs),
+                        std::memory_order_release);
+                    break;
+                }
+                case Command::Tag::EMotionInstanceBuildCommand: {
+                    auto build = static_cast<MotionInstanceBuildCommand *>(command.get());
+                    auto instance = reinterpret_cast<MockPrimitive *>(build->handle());
+                    auto child = reinterpret_cast<MockPrimitive *>(build->child());
+                    std::scoped_lock lock{_mutex};
+                    _state->motion_build_remapped.store(
+                        _primitives.contains(instance) &&
+                            instance->tag == Resource::Tag::MOTION_INSTANCE &&
+                            build->keyframes().size() == instance->keyframe_count &&
+                            _primitives.contains(child) &&
+                            child->tag == Resource::Tag::MESH,
+                        std::memory_order_release);
+                    break;
+                }
+                case Command::Tag::EAccelBuildCommand: {
+                    auto build = static_cast<AccelBuildCommand *>(command.get());
+                    auto accel = reinterpret_cast<MockAccel *>(build->handle());
+                    auto valid = false;
+                    {
+                        std::scoped_lock lock{_mutex};
+                        valid = _accels.contains(accel) &&
+                                build->modifications().size() == 4u;
+                        for (auto &&modification : build->modifications()) {
+                            if ((modification.flags &
+                                 AccelBuildCommand::Modification::flag_primitive) != 0u) {
+                                valid = valid && _primitives.contains(
+                                                     reinterpret_cast<MockPrimitive *>(
+                                                         modification.primitive));
+                            }
+                        }
+                    }
+                    _state->accel_build_remapped.store(
+                        valid, std::memory_order_release);
+                    break;
+                }
+                default:
+                    expect(false) << "unexpected mock command";
+                    break;
+            }
+        }
+        auto stream = reinterpret_cast<MockStream *>(stream_handle);
+        if (stream->log_callback) { stream->log_callback("mock-dispatch"); }
+        for (auto &callback : callbacks) { callback(); }
+    }
+
+    void set_stream_log_callback(
+        uint64_t stream_handle,
+        const StreamLogCallback &callback) noexcept override {
+        reinterpret_cast<MockStream *>(stream_handle)->log_callback = callback;
+    }
+
+    SwapchainCreationInfo create_swapchain(
+        const SwapchainOption &, uint64_t) noexcept override {
+        SwapchainCreationInfo info{};
+        info.invalidate();
+        return info;
+    }
+    void destroy_swapchain(uint64_t) noexcept override {}
+    void present_display_in_stream(uint64_t, uint64_t, uint64_t) noexcept override {}
+
+    ShaderCreationInfo create_shader(
+        const ShaderOption &, Function kernel) noexcept override {
+        auto shader = new MockShader;
+        shader->block_size = kernel.block_size();
+        shader->usages.reserve(kernel.arguments().size());
+        for (auto argument : kernel.arguments()) {
+            shader->usages.emplace_back(kernel.variable_usage(argument.uid()));
+        }
+        shader->bindings.assign(
+            kernel.bound_arguments().begin(), kernel.bound_arguments().end());
+        shader->indirect_writer = std::any_of(
+            kernel.unbound_arguments().begin(),
+            kernel.unbound_arguments().end(),
+            [](auto argument) noexcept {
+                return argument.type()->is_custom() &&
+                       argument.type()->description() ==
+                           ast_json_indirect_dispatch_buffer_type_name;
+            });
+        _state->ast_received.store(true, std::memory_order_release);
+        _state->custom_callable_received.store(
+            !kernel.custom_callables().empty(), std::memory_order_release);
+        if (!shader->bindings.empty()) {
+            auto binding = get<Function::BufferBinding>(shader->bindings.front());
+            auto native_buffer = reinterpret_cast<MockBuffer *>(binding.handle);
+            std::scoped_lock lock{_mutex};
+            _state->ast_binding_remapped.store(
+                _buffers.contains(native_buffer), std::memory_order_release);
+        }
+        ShaderCreationInfo info{};
+        info.handle = reinterpret_cast<uint64_t>(shader);
+        info.native_handle = shader;
+        info.block_size = kernel.block_size();
+        return info;
+    }
+    ShaderCreationInfo load_shader(
+        string_view, span<const Type *const>) noexcept override {
+        return ShaderCreationInfo::make_invalid();
+    }
+    Usage shader_argument_usage(uint64_t handle, size_t index) noexcept override {
+        auto shader = reinterpret_cast<MockShader *>(handle);
+        return shader->usages.at(index);
+    }
+    void destroy_shader(uint64_t handle) noexcept override {
+        delete reinterpret_cast<MockShader *>(handle);
+    }
+
+    ResourceCreationInfo create_event() noexcept override {
+        auto event = new MockEvent;
+        return ResourceCreationInfo{
+            .handle = reinterpret_cast<uint64_t>(event),
+            .native_handle = event};
+    }
+    void destroy_event(uint64_t handle) noexcept override {
+        delete reinterpret_cast<MockEvent *>(handle);
+    }
+    void signal_event(uint64_t event, uint64_t, uint64_t value) noexcept override {
+        reinterpret_cast<MockEvent *>(event)->value.store(value);
+    }
+    void wait_event(uint64_t event, uint64_t, uint64_t value) noexcept override {
+        while (reinterpret_cast<MockEvent *>(event)->value.load() < value) {}
+    }
+    bool is_event_completed(uint64_t event, uint64_t value) const noexcept override {
+        return reinterpret_cast<MockEvent *>(event)->value.load() >= value;
+    }
+    void synchronize_event(uint64_t event, uint64_t value) noexcept override {
+        while (!is_event_completed(event, value)) {}
+    }
+
+    [[nodiscard]] ResourceCreationInfo _create_primitive(
+        Resource::Tag tag, size_t keyframe_count = 0u) noexcept {
+        auto primitive = new MockPrimitive{tag, keyframe_count};
+        {
+            std::scoped_lock lock{_mutex};
+            _primitives.emplace(primitive);
+        }
+        return ResourceCreationInfo{
+            .handle = reinterpret_cast<uint64_t>(primitive),
+            .native_handle = primitive};
+    }
+    void _destroy_primitive(uint64_t handle) noexcept {
+        auto primitive = reinterpret_cast<MockPrimitive *>(handle);
+        {
+            std::scoped_lock lock{_mutex};
+            _primitives.erase(primitive);
+        }
+        delete primitive;
+    }
+    ResourceCreationInfo create_mesh(const AccelOption &) noexcept override {
+        return _create_primitive(Resource::Tag::MESH);
+    }
+    void destroy_mesh(uint64_t handle) noexcept override {
+        _destroy_primitive(handle);
+    }
+    ResourceCreationInfo create_procedural_primitive(
+        const AccelOption &) noexcept override {
+        return _create_primitive(Resource::Tag::PROCEDURAL_PRIMITIVE);
+    }
+    void destroy_procedural_primitive(uint64_t handle) noexcept override {
+        _destroy_primitive(handle);
+    }
+    ResourceCreationInfo create_curve(const AccelOption &) noexcept override {
+        return _create_primitive(Resource::Tag::CURVE);
+    }
+    void destroy_curve(uint64_t handle) noexcept override {
+        _destroy_primitive(handle);
+    }
+    ResourceCreationInfo create_motion_instance(
+        const AccelMotionOption &option) noexcept override {
+        return _create_primitive(
+            Resource::Tag::MOTION_INSTANCE, option.keyframe_count);
+    }
+    void destroy_motion_instance(uint64_t handle) noexcept override {
+        _destroy_primitive(handle);
+    }
+    ResourceCreationInfo create_accel(const AccelOption &) noexcept override {
+        auto accel = new MockAccel;
+        {
+            std::scoped_lock lock{_mutex};
+            _accels.emplace(accel);
+        }
+        return ResourceCreationInfo{
+            .handle = reinterpret_cast<uint64_t>(accel),
+            .native_handle = accel};
+    }
+    void destroy_accel(uint64_t handle) noexcept override {
+        auto accel = reinterpret_cast<MockAccel *>(handle);
+        {
+            std::scoped_lock lock{_mutex};
+            _accels.erase(accel);
+        }
+        delete accel;
+    }
+
+    string query(string_view property) noexcept override {
+        return property == "mock.property" ? "mock.value" : "";
+    }
+    DeviceExtension *extension(string_view) noexcept override { return nullptr; }
+    void set_name(Resource::Tag, uint64_t, string_view) noexcept override {}
+};
+
+void test_remote_backend_e2e(const char *program_path) {
+    auto state = make_shared<MockState>();
+    auto native = make_shared<MockDevice>(Context{program_path}, state);
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "test-token";
+    server_options.max_blob_cache_bytes = 1u * 1024u * 1024u;
+    server_options.max_blob_entry_size = 1u * 1024u * 1024u;
+    server_options.blob_cache_min_size = 1u;
+    Server server{native, std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    {
+        Context context{program_path};
+        DeviceConfig config;
+        config.extension = make_unique<RemoteDeviceConfigExt>(
+            "127.0.0.1", server.port(), "test-token",
+            2'000u, 5'000u, 16u * 1024u * 1024u,
+            true, 1u);
+        auto device = context.create_device("remote", &config, false);
+        expect(device.compute_warp_size() == 32u);
+        expect(device.compute_max_shared_memory_size() == 32768u);
+        expect(device.memory_granularity() == 256u);
+        expect(device.query("remote.native_backend") == "mock");
+        expect(device.query("remote.blob_cache.enabled") == "true");
+        expect(device.query("mock.property") == "mock.value");
+
+        constexpr auto count = 16u;
+        auto source = device.create_buffer<uint>(count);
+        auto destination = device.create_buffer<uint>(count);
+        auto stream = device.create_stream();
+        vector<uint> upload(count);
+        vector<uint> download(count, 0u);
+        for (auto i = 0u; i < count; i++) { upload[i] = i * 3u; }
+        bool callback_called = false;
+        bool log_called = false;
+        stream.set_log_callback([&](string_view message) {
+            expect(message == "mock-dispatch");
+            log_called = true;
+        });
+        stream << source.copy_from(span{upload})
+               << source.copy_to(destination.view())
+               << destination.copy_to(span{download})
+               << [&] { callback_called = true; }
+               << synchronize();
+        expect(callback_called);
+        expect(log_called);
+        expect(download == upload);
+
+        auto cache_hits = parse_u64(
+            device.query("remote.blob_cache.hits"));
+        auto uploaded_bytes = parse_u64(
+            device.query("remote.blob_cache.uploaded_bytes"));
+        std::fill(download.begin(), download.end(), 0u);
+        stream << source.copy_from(span{upload})
+               << source.copy_to(destination.view())
+               << destination.copy_to(span{download})
+               << synchronize();
+        expect(download == upload);
+        expect(parse_u64(device.query("remote.blob_cache.hits")) >
+               cache_hits);
+        expect(parse_u64(
+                   device.query("remote.blob_cache.uploaded_bytes")) ==
+               uploaded_bytes);
+
+        constexpr auto image_size = 4u;
+        vector<float> image_upload(image_size * image_size);
+        vector<float> image_download(image_upload.size(), 0.0f);
+        for (auto i = 0u; i < image_upload.size(); i++) {
+            image_upload[i] = static_cast<float>(i) + 0.25f;
+        }
+        auto source_image = device.create_image<float>(
+            PixelStorage::FLOAT1, image_size, image_size);
+        auto destination_image = device.create_image<float>(
+            PixelStorage::FLOAT1, image_size, image_size);
+        stream << source_image.copy_from(span{image_upload})
+               << source_image.copy_to(destination_image)
+               << destination_image.copy_to(span{image_download})
+               << synchronize();
+        expect(image_download == image_upload);
+
+        auto image_buffer = device.create_buffer<float>(image_upload.size());
+        auto image_readback = device.create_buffer<float>(image_upload.size());
+        std::fill(image_download.begin(), image_download.end(), 0.0f);
+        stream << image_buffer.copy_from(span{image_upload})
+               << source_image.copy_from(image_buffer)
+               << source_image.copy_to(image_readback)
+               << image_readback.copy_to(span{image_download})
+               << synchronize();
+        expect(image_download == image_upload);
+        expect(state->texture_command_count.load(std::memory_order_acquire) == 5u);
+
+        auto bindless = device.create_bindless_array(count);
+        bindless.emplace_on_update(0u, source);
+        stream << bindless.update() << synchronize();
+        expect(state->bindless_update_remapped.load(std::memory_order_acquire));
+
+        Callable twice = [](UInt value) noexcept { return value * 2u; };
+        Kernel1D kernel = [&twice](BufferUInt output, UInt base) noexcept {
+            set_block_size(32u);
+            auto index = dispatch_id().x;
+            output.write(index, twice(base) + index);
+        };
+        auto shader = device.compile(kernel);
+        vector<uint> shader_output(count, 0u);
+        callback_called = false;
+        stream << shader(destination, 41u).dispatch(count)
+               << destination.copy_to(span{shader_output})
+               << [&] { callback_called = true; }
+               << synchronize();
+        expect(callback_called);
+        for (auto i = 0u; i < count; i++) {
+            expect(shader_output[i] == 41u + i);
+        }
+        expect(state->ast_received.load(std::memory_order_acquire));
+        expect(state->custom_callable_received.load(std::memory_order_acquire));
+
+        auto indirect = device.create_indirect_dispatch_buffer(4u);
+        Kernel1D write_indirect = [](IndirectDispatchBufferVar commands) noexcept {
+            set_block_size(32u);
+            commands.set_kernel(
+                0u, make_uint3(32u, 1u, 1u),
+                make_uint3(4u, 1u, 1u));
+            commands.set_dispatch_count(1u);
+        };
+        auto indirect_writer = device.compile(write_indirect);
+        stream << indirect_writer(indirect).dispatch(1u)
+               << shader(destination, 41u).dispatch(indirect, 0u, 1u)
+               << synchronize();
+        expect(state->indirect_buffer_created.load(
+            std::memory_order_acquire));
+        expect(state->indirect_writer_remapped.load(
+            std::memory_order_acquire));
+        expect(state->indirect_dispatch_remapped.load(
+            std::memory_order_acquire));
+
+        auto bound_shader = device.compile<1>([&] {
+            auto index = dispatch_id().x;
+            destination->write(index, index);
+        });
+        expect(static_cast<bool>(bound_shader));
+        expect(state->ast_binding_remapped.load(std::memory_order_acquire));
+
+        auto event = device.create_timeline_event();
+        stream << event.signal(7u);
+        expect(event.is_completed(7u));
+        event.synchronize(7u);
+
+        auto vertices = device.create_buffer<float3>(3u);
+        auto triangles = device.create_buffer<Triangle>(1u);
+        auto control_points = device.create_buffer<float4>(2u);
+        auto segments = device.create_buffer<uint>(1u);
+        auto aabbs = device.create_buffer<AABB>(1u);
+        auto mesh = device.create_mesh(vertices, triangles);
+        auto curve = device.create_curve(
+            CurveBasis::PIECEWISE_LINEAR, control_points, segments);
+        auto procedural = device.create_procedural_primitive(aabbs);
+        AccelMotionOption motion_option;
+        motion_option.keyframe_count = 2u;
+        auto motion = device.create_motion_instance(mesh, motion_option);
+        motion.set_keyframe(0u, make_float4x4(1.0f));
+        motion.set_keyframe(1u, make_float4x4(1.0f));
+        auto accel = device.create_accel();
+        accel.emplace_back(mesh);
+        accel.emplace_back(curve);
+        accel.emplace_back(procedural);
+        accel.emplace_back(motion);
+        stream << mesh.build()
+               << curve.build()
+               << procedural.build()
+               << motion.build()
+               << accel.build()
+               << synchronize();
+        expect(state->mesh_build_remapped.load(std::memory_order_acquire));
+        expect(state->curve_build_remapped.load(std::memory_order_acquire));
+        expect(state->procedural_build_remapped.load(std::memory_order_acquire));
+        expect(state->motion_build_remapped.load(std::memory_order_acquire));
+        expect(state->accel_build_remapped.load(std::memory_order_acquire));
+    }
+
+    server.stop();
+    server_thread.join();
+}
+
+void test_remote_backend_inline_fallback(const char *program_path) {
+    auto state = make_shared<MockState>();
+    auto native = make_shared<MockDevice>(Context{program_path}, state);
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "fallback-token";
+    server_options.max_blob_cache_bytes = 0u;
+    server_options.protocol_limits.max_frame_payload = 1024u;
+    server_options.protocol_limits.max_string_size = 256u;
+    server_options.protocol_limits.max_array_size = 64u;
+    Server server{native, std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    {
+        Context context{program_path};
+        DeviceConfig config;
+        config.extension = make_unique<RemoteDeviceConfigExt>(
+            "127.0.0.1", server.port(), "fallback-token",
+            2'000u, 5'000u, 1u * 1024u * 1024u,
+            true, 1u);
+        auto device = context.create_device("remote", &config, false);
+        expect(device.query("remote.blob_cache.enabled") == "false");
+        expect(device.query("remote.protocol.max_frame_payload") == "1024");
+        expect(device.query("remote.protocol.max_string_size") == "256");
+        expect(device.query("remote.protocol.max_array_size") == "64");
+        constexpr auto count = 8u;
+        vector<uint> upload(count);
+        vector<uint> download(count, 0u);
+        for (auto i = 0u; i < count; i++) { upload[i] = i + 17u; }
+        auto buffer = device.create_buffer<uint>(count);
+        auto stream = device.create_stream();
+        stream << buffer.copy_from(span{upload})
+               << buffer.copy_to(span{download})
+               << synchronize();
+        expect(download == upload);
+    }
+
+    server.stop();
+    server_thread.join();
+}
+
+void test_remote_blob_protocol_rejects_bad_bodies(
+    const char *program_path) {
+    auto state = make_shared<MockState>();
+    auto native = make_shared<MockDevice>(Context{program_path}, state);
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "blob-protocol-token";
+    server_options.max_blob_cache_bytes = 1024u;
+    server_options.max_blob_entry_size = 512u;
+    server_options.blob_cache_min_size = 1u;
+    Server server{native, std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    Connection connection;
+    string error;
+    expect(connection.connect(
+        "127.0.0.1", server.port(), 2s, error));
+    Writer hello;
+    hello.write_u32(0x01020304u);
+    hello.write_u8(sizeof(void *));
+    hello.write_u8(1u);
+    hello.write_u16(0u);
+    hello.write_string("blob-protocol-token");
+    expect(static_cast<bool>(connection.request(
+        MessageKind::HELLO, hello.bytes(), 2s)));
+    expect(static_cast<bool>(connection.request(
+        MessageKind::BLOB_CACHE_INFO, {}, 2s)));
+
+    vector<std::byte> good(4u, std::byte{0x11u});
+    vector<std::byte> tampered(4u, std::byte{0x22u});
+    auto key = compute_blob_key(good);
+    Writer duplicate_prepare;
+    duplicate_prepare.write_u64(1u);
+    duplicate_prepare.write_u64(2u);
+    write_blob_key(duplicate_prepare, key);
+    write_blob_key(duplicate_prepare, key);
+    auto duplicate = connection.request(
+        MessageKind::PREPARE_BLOBS,
+        duplicate_prepare.bytes(), 2s);
+    expect(!static_cast<bool>(duplicate));
+    expect(duplicate.status == Status::INVALID_REQUEST);
+
+    Writer prepare;
+    prepare.write_u64(2u);
+    prepare.write_u64(1u);
+    write_blob_key(prepare, key);
+    auto prepared = connection.request(
+        MessageKind::PREPARE_BLOBS, prepare.bytes(), 2s);
+    expect(static_cast<bool>(prepared));
+    Reader prepared_reader{prepared.body};
+    expect(prepared_reader.read_u64() == 2u);
+    expect(prepared_reader.read_u64() == 1u);
+    expect(prepared_reader.read_u32() == 0u);
+    expect(prepared_reader.finish());
+
+    auto make_upload = [&](span<const std::byte> body) {
+        Writer upload;
+        upload.write_u64(2u);
+        upload.write_u64(1u);
+        upload.write_u32(0u);
+        write_blob_key(upload, key);
+        upload.write_blob(body);
+        return upload;
+    };
+    auto bad_upload = make_upload(tampered);
+    auto bad_response = connection.request(
+        MessageKind::UPLOAD_BLOBS,
+        bad_upload.bytes(), 2s);
+    expect(!static_cast<bool>(bad_response));
+    expect(bad_response.status == Status::INVALID_REQUEST);
+
+    auto good_upload = make_upload(good);
+    auto good_response = connection.request(
+        MessageKind::UPLOAD_BLOBS,
+        good_upload.bytes(), 2s);
+    expect(static_cast<bool>(good_response));
+    Reader good_reader{good_response.body};
+    expect(good_reader.read_u64() == 2u);
+    expect(good_reader.finish());
+
+    expect(static_cast<bool>(connection.request(
+        MessageKind::GOODBYE, {}, 2s)));
+    connection.close();
+    server.stop();
+    server_thread.join();
+}
+
+void test_remote_server_survives_abrupt_disconnect(
+    const char *program_path) {
+    auto state = make_shared<MockState>();
+    auto native = make_shared<MockDevice>(
+        Context{program_path}, state);
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "reconnect-token";
+    Server server{native, std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    // Protocol 1.0 peers omit device-selection fields. The service accepts
+    // that payload and replies using the peer's minor version.
+    {
+        asio::io_context io;
+        asio::ip::tcp::socket socket{io};
+        socket.connect({asio::ip::make_address("127.0.0.1"), server.port()});
+        Writer hello;
+        hello.write_u32(0x01020304u);
+        hello.write_u8(sizeof(void *));
+        hello.write_u8(1u);
+        hello.write_u16(0u);
+        hello.write_string("reconnect-token");
+        auto header = encode_frame_header(FrameHeader{
+            .kind = MessageKind::HELLO,
+            .request_id = 1u,
+            .payload_size = hello.bytes().size(),
+            .payload_checksum = payload_checksum(hello.bytes()),
+            .wire_major = protocol_major,
+            .wire_minor = 0u});
+        std::array<asio::const_buffer, 2u> buffers{
+            asio::buffer(header), asio::buffer(hello.bytes())};
+        asio::write(socket, buffers);
+        std::array<std::byte, frame_header_size> response_header_bytes{};
+        asio::read(socket, asio::buffer(response_header_bytes));
+        FrameHeader response_header;
+        string response_error;
+        expect(decode_frame_header(
+            response_header_bytes, response_header, response_error));
+        expect(response_header.wire_minor == 0u);
+        vector<std::byte> response_payload(
+            static_cast<size_t>(response_header.payload_size));
+        asio::read(socket, asio::buffer(response_payload));
+        expect(payload_checksum(response_payload) ==
+               response_header.payload_checksum);
+        ResponseView response;
+        expect(decode_response_payload(
+            response_payload, response, response_error));
+        expect(response.status == Status::OK);
+        asio::error_code ignored;
+        socket.close(ignored);
+    }
+
+    auto connect_and_hello = [&](Connection &connection) {
+        string error;
+        expect(connection.connect(
+            "127.0.0.1", server.port(), 2s, error));
+        Writer hello;
+        hello.write_u32(0x01020304u);
+        hello.write_u8(sizeof(void *));
+        hello.write_u8(1u);
+        hello.write_u16(0u);
+        hello.write_string("reconnect-token");
+        return connection.request(
+            MessageKind::HELLO, hello.bytes(), 2s);
+    };
+
+    Connection first;
+    expect(static_cast<bool>(connect_and_hello(first)));
+    Writer create_buffer;
+    create_buffer.write_u8(static_cast<uint8_t>(BufferKind::BYTE));
+    create_buffer.write_u64(4096u);
+    expect(static_cast<bool>(first.request(
+        MessageKind::CREATE_BUFFER, create_buffer.bytes(), 2s)));
+    expect(state->live_buffers.load(std::memory_order_acquire) == 1u);
+    // Simulate a process/network loss: no GOODBYE and no explicit resource
+    // destruction. The session must reclaim its native resources.
+    first.close();
+    auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (state->live_buffers.load(std::memory_order_acquire) != 0u &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expect(state->live_buffers.load(std::memory_order_acquire) == 0u);
+
+    Connection second;
+    expect(static_cast<bool>(connect_and_hello(second)));
+    expect(static_cast<bool>(second.request(
+        MessageKind::GOODBYE, {}, 2s)));
+    second.close();
+
+    server.stop();
+    server_thread.join();
+}
+
+void test_remote_shader_usage_bounds(
+    const char *program_path) {
+    auto state = make_shared<MockState>();
+    auto native = make_shared<MockDevice>(
+        Context{program_path}, state);
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "shader-usage-token";
+    Server server{native, std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    Connection connection;
+    string error;
+    expect(connection.connect(
+        "127.0.0.1", server.port(), 2s, error));
+    Writer hello;
+    hello.write_u32(0x01020304u);
+    hello.write_u8(sizeof(void *));
+    hello.write_u8(1u);
+    hello.write_u16(0u);
+    hello.write_string("shader-usage-token");
+    expect(static_cast<bool>(connection.request(
+        MessageKind::HELLO, hello.bytes(), 2s)));
+
+    auto kernel = luisa::compute::detail::FunctionBuilder::define_kernel([] {
+        auto builder = luisa::compute::detail::FunctionBuilder::current();
+        builder->set_block_size(uint3{1u, 1u, 1u});
+        static_cast<void>(builder->buffer(
+            Type::buffer(Type::of<uint>())));
+    });
+    auto ast = try_to_json(Function{kernel.get()});
+    expect(static_cast<bool>(ast)) << ast.error;
+    Writer create_shader;
+    write_test_shader_option(create_shader, ShaderOption{});
+    create_shader.write_blob({reinterpret_cast<const std::byte *>(ast.json.data()),
+                              ast.json.size()});
+    auto created = connection.request(
+        MessageKind::CREATE_SHADER, create_shader.bytes(), 2s);
+    expect(static_cast<bool>(created)) << created.message;
+    Reader created_reader{created.body};
+    auto shader = created_reader.read_u64();
+    static_cast<void>(created_reader.read_u32());
+    static_cast<void>(created_reader.read_u32());
+    static_cast<void>(created_reader.read_u32());
+    expect(created_reader.finish());
+    expect(shader != invalid_resource_handle);
+
+    Writer bad_usage;
+    bad_usage.write_u64(shader);
+    bad_usage.write_u64(1u);
+    auto rejected = connection.request(
+        MessageKind::SHADER_ARGUMENT_USAGE,
+        bad_usage.bytes(), 2s);
+    expect(!static_cast<bool>(rejected));
+    expect(rejected.status == Status::INVALID_REQUEST);
+
+    Writer query;
+    query.write_string("mock.property");
+    auto queried = connection.request(
+        MessageKind::QUERY, query.bytes(), 2s);
+    expect(static_cast<bool>(queried));
+    Reader queried_reader{queried.body};
+    expect(queried_reader.read_string() == "mock.value");
+    expect(queried_reader.finish());
+
+    Writer destroy_shader;
+    destroy_shader.write_u64(shader);
+    expect(static_cast<bool>(connection.request(
+        MessageKind::DESTROY_SHADER,
+        destroy_shader.bytes(), 2s)));
+    expect(static_cast<bool>(connection.request(
+        MessageKind::GOODBYE, {}, 2s)));
+    connection.close();
+    server.stop();
+    server_thread.join();
+}
+
+void test_remote_device_disconnect_cleanup(
+    const char *program_path) {
+    auto state = make_shared<MockState>();
+    auto native = make_shared<MockDevice>(
+        Context{program_path}, state);
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "device-disconnect-token";
+    Server server{native, std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    {
+        Context context{program_path};
+        DeviceConfig config;
+        config.extension = make_unique<RemoteDeviceConfigExt>(
+            "127.0.0.1", server.port(), "device-disconnect-token",
+            2'000u, 5'000u, 1u * 1024u * 1024u,
+            false, 1u);
+        auto device = context.create_device("remote", &config, false);
+        auto buffer = device.create_buffer<uint>(16u);
+        auto stream = device.create_stream();
+        expect(device.query("remote.connected") == "true");
+        expect(static_cast<bool>(buffer));
+        expect(static_cast<bool>(stream));
+
+        server.stop();
+        server_thread.join();
+        auto deadline = std::chrono::steady_clock::now() + 2s;
+        while (device.query("remote.connected") == "true" &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::yield();
+        }
+        expect(device.query("remote.connected") == "false");
+    }
+    expect(state->live_buffers.load(std::memory_order_acquire) == 0u);
+}
+
+void test_remote_service_device_selection(
+    const char *program_path) {
+    auto state = make_shared<MockState>();
+    std::mutex requests_mutex;
+    vector<DeviceRequest> requests;
+    DeviceFactory factory =
+        [program_path, state, &requests_mutex, &requests](
+            const DeviceRequest &request,
+            string &error) -> shared_ptr<DeviceInterface> {
+        if (request.backend != "mock_a" &&
+            request.backend != "mock_b") {
+            error = "backend is not allowlisted by the test service";
+            return nullptr;
+        }
+        {
+            std::scoped_lock lock{requests_mutex};
+            requests.emplace_back(request);
+        }
+        return make_shared<MockDevice>(
+            Context{program_path}, state, request.backend);
+    };
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "service-token";
+    Server server{std::move(factory), std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    // A rejected device selection must only close that session.
+    Connection rejected;
+    string connection_error;
+    expect(rejected.connect(
+        "127.0.0.1", server.port(), 2s, connection_error));
+    Writer rejected_hello;
+    rejected_hello.write_u32(0x01020304u);
+    rejected_hello.write_u8(sizeof(void *));
+    rejected_hello.write_u8(1u);
+    rejected_hello.write_u16(0u);
+    rejected_hello.write_string("service-token");
+    rejected_hello.write_string("forbidden");
+    rejected_hello.write_u64(std::numeric_limits<size_t>::max());
+    rejected_hello.write_bool(false);
+    auto rejected_response = rejected.request(
+        MessageKind::HELLO, rejected_hello.bytes(), 2s);
+    expect(!static_cast<bool>(rejected_response));
+    expect(rejected_response.status == Status::UNSUPPORTED);
+    rejected.close();
+
+    {
+        Context context{program_path};
+        DeviceConfig config_a;
+        config_a.extension = make_unique<RemoteDeviceConfigExt>(
+            "127.0.0.1", server.port(), "service-token",
+            2'000u, 5'000u, 1u * 1024u * 1024u,
+            false, 1u, string{}, "mock_a", 0u, false);
+        auto device_a = context.create_device("remote", &config_a, false);
+        expect(device_a.query("remote.native_backend") == "mock_a");
+        expect(device_a.query("remote.device_selection") == "true");
+
+        DeviceConfig config_b;
+        config_b.extension = make_unique<RemoteDeviceConfigExt>(
+            "127.0.0.1", server.port(), "service-token",
+            2'000u, 5'000u, 1u * 1024u * 1024u,
+            false, 1u, string{}, "mock_b", 1u, true);
+        auto device_b = context.create_device("remote", &config_b, false);
+        expect(device_b.query("remote.native_backend") == "mock_b");
+        expect(device_b.query("remote.device_selection") == "true");
+
+        auto buffer_a = device_a.create_buffer<uint>(4u);
+        auto buffer_b = device_b.create_buffer<uint>(4u);
+        expect(static_cast<bool>(buffer_a));
+        expect(static_cast<bool>(buffer_b));
+        {
+            std::scoped_lock lock{requests_mutex};
+            expect(requests.size() == 2u);
+            if (requests.size() == 2u) {
+                expect(requests[0].backend == "mock_a");
+                expect(requests[0].device_index == 0u);
+                expect(!requests[0].enable_validation);
+                expect(requests[1].backend == "mock_b");
+                expect(requests[1].device_index == 1u);
+                expect(requests[1].enable_validation);
+            }
+        }
+    }
+
+    server.stop();
+    server_thread.join();
+}
+
+void test_remote_service_survives_device_factory_exception(
+    const char *program_path) {
+    auto state = make_shared<MockState>();
+    DeviceFactory factory =
+        [program_path, state](
+            const DeviceRequest &request,
+            string &) -> shared_ptr<DeviceInterface> {
+        if (request.backend == "throw") {
+            throw std::runtime_error{"test factory failure"};
+        }
+        return make_shared<MockDevice>(
+            Context{program_path}, state, request.backend);
+    };
+    ServerOptions server_options;
+    server_options.port = 0u;
+    server_options.token = "factory-exception-token";
+    Server server{std::move(factory), std::move(server_options)};
+    std::thread server_thread{[&] { server.run(); }};
+
+    Connection rejected;
+    string connection_error;
+    expect(rejected.connect(
+        "127.0.0.1", server.port(), 2s, connection_error));
+    Writer hello;
+    hello.write_u32(0x01020304u);
+    hello.write_u8(sizeof(void *));
+    hello.write_u8(1u);
+    hello.write_u16(0u);
+    hello.write_string("factory-exception-token");
+    hello.write_string("throw");
+    hello.write_u64(std::numeric_limits<size_t>::max());
+    hello.write_bool(false);
+    auto response = rejected.request(
+        MessageKind::HELLO, hello.bytes(), 2s);
+    expect(!static_cast<bool>(response));
+    expect(response.status == Status::BACKEND_ERROR);
+    expect(response.message.find("test factory failure") != string::npos);
+    rejected.close();
+
+    // A failure in one session must not prevent the service from accepting
+    // and provisioning another independent session.
+    Context context{program_path};
+    DeviceConfig config;
+    config.extension = make_unique<RemoteDeviceConfigExt>(
+        "127.0.0.1", server.port(), "factory-exception-token",
+        2'000u, 5'000u, 1u * 1024u * 1024u,
+        false, 1u, string{}, "mock", 0u, false);
+    auto device = context.create_device("remote", &config, false);
+    expect(device.query("remote.connected") == "true");
+    expect(device.query("remote.native_backend") == "mock");
+
+    server.stop();
+    server_thread.join();
+}
+
+}// namespace
+
+int main(int argc, char *argv[]) {
+    boost::ut::detail::cfg::parse_arg_with_fallback(
+        argc, const_cast<const char **>(argv));
+    "remote_backend_e2e"_test = [&] {
+        test_remote_backend_e2e(argv[0]);
+    };
+    "remote_backend_inline_fallback"_test = [&] {
+        test_remote_backend_inline_fallback(argv[0]);
+    };
+    "remote_blob_protocol_rejects_bad_bodies"_test = [&] {
+        test_remote_blob_protocol_rejects_bad_bodies(argv[0]);
+    };
+    "remote_server_survives_abrupt_disconnect"_test = [&] {
+        test_remote_server_survives_abrupt_disconnect(argv[0]);
+    };
+    "remote_shader_usage_bounds"_test = [&] {
+        test_remote_shader_usage_bounds(argv[0]);
+    };
+    "remote_device_disconnect_cleanup"_test = [&] {
+        test_remote_device_disconnect_cleanup(argv[0]);
+    };
+    "remote_service_device_selection"_test = [&] {
+        test_remote_service_device_selection(argv[0]);
+    };
+    "remote_service_survives_device_factory_exception"_test = [&] {
+        test_remote_service_survives_device_factory_exception(argv[0]);
+    };
+}

--- a/src/tests/unit/runtime/test_remote_backend_native.cpp
+++ b/src/tests/unit/runtime/test_remote_backend_native.cpp
@@ -1,0 +1,216 @@
+// Native-backend integration test for the C++ remote backend.
+//
+// A real backend is hosted by an independently launched server and driven
+// exclusively through a remote Device. The test covers AST reconstruction/JIT,
+// asynchronous stream completion, buffer and texture I/O, resource bindings,
+// timeline events, and cold/hot content-addressed upload paths.
+
+#include "ut/ut.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <limits>
+#include <system_error>
+
+#include <luisa/backends/ext/remote_config_ext.h>
+#include <luisa/luisa-compute.h>
+
+using namespace luisa;
+using namespace luisa::compute;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+
+namespace {
+
+[[nodiscard]] uint64_t parse_u64(string_view text) noexcept {
+    uint64_t value{};
+    auto result = std::from_chars(
+        text.data(), text.data() + text.size(), value);
+    expect(result.ec == std::errc{});
+    expect(result.ptr == text.data() + text.size());
+    return value;
+}
+
+void test_native_backend(const char *program_path, string_view backend,
+                         string_view host, uint16_t port,
+                         string_view token) {
+    Context remote_context{program_path};
+    DeviceConfig remote_config;
+    remote_config.headless = true;
+    remote_config.extension = make_unique<RemoteDeviceConfigExt>(
+        string{host}, port, string{token},
+        5'000u, 60'000u, 32u * 1024u * 1024u,
+        true, 64u * 1024u);
+    auto device = remote_context.create_device(
+        "remote", &remote_config, false);
+
+    expect(device.query("remote.native_backend") == backend);
+    expect(device.query("remote.blob_cache.enabled") == "true");
+
+    constexpr auto element_count = 32u * 1024u;
+    constexpr auto bias = 0x31415926u;
+    vector<uint> input(element_count);
+    vector<uint> output(element_count, 0u);
+    for (auto i = 0u; i < element_count; i++) {
+        input[i] = (i * 747796405u + 2891336453u) ^ (i >> 3u);
+    }
+
+    auto source = device.create_buffer<uint>(element_count);
+    auto copied = device.create_buffer<uint>(element_count);
+    auto transformed = device.create_buffer<uint>(element_count);
+    auto stream = device.create_stream();
+
+    auto initial_misses = parse_u64(
+        device.query("remote.blob_cache.misses"));
+    auto initial_uploaded_bytes = parse_u64(
+        device.query("remote.blob_cache.uploaded_bytes"));
+    stream << source.copy_from(span{input}) << synchronize();
+    auto cold_misses = parse_u64(
+        device.query("remote.blob_cache.misses"));
+    auto cold_uploaded_bytes = parse_u64(
+        device.query("remote.blob_cache.uploaded_bytes"));
+    expect(cold_misses > initial_misses);
+    expect(cold_uploaded_bytes ==
+           initial_uploaded_bytes + input.size() * sizeof(uint));
+
+    Callable transform = [](UInt value, UInt index, UInt offset) noexcept {
+        return (value ^ (index * 1664525u + 1013904223u)) + offset;
+    };
+    Kernel1D kernel = [&transform](
+                          BufferUInt in, BufferUInt out,
+                          UInt offset) noexcept {
+        set_block_size(64u);
+        auto index = dispatch_x();
+        out.write(index, transform(in.read(index), index, offset));
+    };
+    auto shader = device.compile(kernel);
+
+    auto hot_hits = parse_u64(
+        device.query("remote.blob_cache.hits"));
+    auto hot_uploaded_bytes = parse_u64(
+        device.query("remote.blob_cache.uploaded_bytes"));
+    auto completion_called = false;
+    stream << source.copy_from(span{input})
+           << source.copy_to(copied.view())
+           << shader(copied, transformed, bias).dispatch(element_count)
+           << transformed.copy_to(span{output})
+           << [&completion_called] { completion_called = true; }
+           << synchronize();
+    expect(completion_called);
+    expect(parse_u64(device.query("remote.blob_cache.hits")) > hot_hits);
+    expect(parse_u64(
+               device.query("remote.blob_cache.uploaded_bytes")) ==
+           hot_uploaded_bytes);
+
+    auto buffers_match = true;
+    for (auto i = 0u; i < element_count; i++) {
+        auto expected =
+            (input[i] ^ (i * 1664525u + 1013904223u)) + bias;
+        if (output[i] != expected) {
+            LUISA_WARNING(
+                "Remote native buffer mismatch at {}: expected {}, got {}.",
+                i, expected, output[i]);
+            buffers_match = false;
+            break;
+        }
+    }
+    expect(buffers_match);
+
+    constexpr auto bound_count = 257u;
+    auto bound_output = device.create_buffer<uint>(bound_count);
+    vector<uint> bound_readback(bound_count, 0u);
+    auto bound_shader = device.compile<1>([&]() noexcept {
+        auto index = dispatch_x();
+        bound_output->write(index, index * 17u + 9u);
+    });
+    stream << bound_shader().dispatch(bound_count)
+           << bound_output.copy_to(span{bound_readback})
+           << synchronize();
+    auto binding_matches = true;
+    for (auto i = 0u; i < bound_count; i++) {
+        if (bound_readback[i] != i * 17u + 9u) {
+            binding_matches = false;
+            break;
+        }
+    }
+    expect(binding_matches);
+
+    constexpr auto image_size = make_uint2(32u, 24u);
+    auto image = device.create_image<float>(PixelStorage::FLOAT4, image_size);
+    vector<float4> image_input(
+        static_cast<size_t>(image_size.x) * image_size.y);
+    vector<float4> image_output(image_input.size());
+    for (auto y = 0u; y < image_size.y; y++) {
+        for (auto x = 0u; x < image_size.x; x++) {
+            auto index = static_cast<size_t>(y) * image_size.x + x;
+            image_input[index] = make_float4(
+                static_cast<float>(x), static_cast<float>(y),
+                static_cast<float>(x + y), 1.0f);
+        }
+    }
+    Kernel2D image_kernel = [](ImageFloat target) noexcept {
+        auto coordinate = dispatch_id().xy();
+        auto value = target.read(coordinate);
+        target.write(coordinate, make_float4(
+                                     value.z + 0.5f,
+                                     value.x * 2.0f,
+                                     value.y + 1.0f,
+                                     value.w));
+    };
+    auto image_shader = device.compile(image_kernel);
+    stream << image.copy_from(span{image_input})
+           << image_shader(image).dispatch(image_size)
+           << image.copy_to(span{image_output})
+           << synchronize();
+    auto image_matches = true;
+    for (auto i = 0u; i < image_output.size(); i++) {
+        auto expected = make_float4(
+            image_input[i].z + 0.5f,
+            image_input[i].x * 2.0f,
+            image_input[i].y + 1.0f,
+            image_input[i].w);
+        if (any(image_output[i] != expected)) {
+            image_matches = false;
+            break;
+        }
+    }
+    expect(image_matches);
+
+    auto event = device.create_timeline_event();
+    stream << event.signal(5u);
+    event.synchronize(5u);
+    expect(event.is_completed(5u));
+}
+
+}// namespace
+
+int main(int argc, char *argv[]) {
+    if (argc < 5 || argv[1] == nullptr || argv[1][0] == '\0' ||
+        argv[2] == nullptr || argv[2][0] == '\0' ||
+        argv[3] == nullptr || argv[3][0] == '\0' ||
+        argv[4] == nullptr) {
+        LUISA_WARNING(
+            "Usage: {} <expected-native-backend> <host> <port> <token>",
+            argv[0]);
+        return 1;
+    }
+    uint64_t port{};
+    auto port_text = string_view{argv[3]};
+    auto port_result = std::from_chars(
+        port_text.data(), port_text.data() + port_text.size(), port);
+    if (port_result.ec != std::errc{} ||
+        port_result.ptr != port_text.data() + port_text.size() ||
+        port == 0u || port > std::numeric_limits<uint16_t>::max()) {
+        LUISA_WARNING("Invalid remote server port '{}'.", port_text);
+        return 1;
+    }
+    // Host, port, and token are client configuration, not Boost.UT filters.
+    // Parse a sanitized argv so the runner executes the test unconditionally.
+    const char *ut_argv[]{argv[0]};
+    boost::ut::detail::cfg::parse_arg_with_fallback(1, ut_argv);
+    "remote_native_backend_e2e"_test = [&] {
+        test_native_backend(
+            argv[0], argv[1], argv[2],
+            static_cast<uint16_t>(port), argv[4]);
+    };
+}

--- a/src/tests/unit/runtime/test_remote_backend_swapchain.cpp
+++ b/src/tests/unit/runtime/test_remote_backend_swapchain.cpp
@@ -1,0 +1,104 @@
+// Native local-presentation integration test for the C++ remote backend.
+//
+// A separately launched server executes the image kernel while the client owns
+// the Window and platform swapchain. The test presents several finite frames,
+// synchronizes both sides of the bridge, and validates the remote image data.
+
+#include "ut/ut.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <limits>
+#include <system_error>
+
+#include <luisa/backends/ext/remote_config_ext.h>
+#include <luisa/gui/window.h>
+#include <luisa/luisa-compute.h>
+
+using namespace luisa;
+using namespace luisa::compute;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+
+namespace {
+
+void test_local_swapchain(const char *program_path,
+                          string_view local_backend,
+                          string_view host, uint16_t port,
+                          string_view token) {
+    Context context{program_path};
+    DeviceConfig config;
+    config.extension = make_unique<RemoteDeviceConfigExt>(
+        string{host}, port, string{token},
+        5'000u, 60'000u, 32u * 1024u * 1024u,
+        true, 64u * 1024u, string{local_backend});
+    auto device = context.create_device("remote", &config, false);
+    expect(device.query("remote.local_present_backend") == local_backend);
+
+    constexpr auto resolution = make_uint2(160u, 96u);
+    auto stream = device.create_stream(StreamTag::GRAPHICS);
+    Window window{"Remote local swapchain", resolution};
+    auto swapchain = device.create_swapchain(
+        stream,
+        SwapchainOption{
+            .display = window.native_display(),
+            .window = window.native_handle(),
+            .size = resolution,
+            .wants_hdr = false,
+            .wants_vsync = false,
+            .back_buffer_count = 3u});
+    auto image = device.create_image<float>(
+        swapchain.backend_storage(), resolution);
+    Kernel2D render = [resolution](ImageFloat target, Float phase) noexcept {
+        auto p = dispatch_id().xy();
+        auto uv = make_float2(p) / make_float2(resolution);
+        target.write(p, make_float4(
+                            uv.x, uv.y, phase, 1.0f));
+    };
+    auto shader = device.compile(render);
+    for (auto frame = 0u; frame < 3u; frame++) {
+        stream << shader(image, static_cast<float>(frame + 1u) / 3.0f)
+                      .dispatch(resolution)
+               << swapchain.present(image)
+               << synchronize();
+        window.poll_events();
+    }
+
+    vector<std::byte> pixels(image.view().size_bytes());
+    stream << image.copy_to(span{pixels}) << synchronize();
+    expect(std::any_of(
+        pixels.begin(), pixels.end(),
+        [](std::byte value) noexcept { return value != std::byte{}; }));
+    window.set_should_close();
+    window.poll_events();
+}
+
+}// namespace
+
+int main(int argc, char *argv[]) {
+    if (argc < 5 || argv[1] == nullptr || argv[1][0] == '\0' ||
+        argv[2] == nullptr || argv[2][0] == '\0' ||
+        argv[3] == nullptr || argv[3][0] == '\0' ||
+        argv[4] == nullptr) {
+        LUISA_WARNING(
+            "Usage: {} <local-present-backend> <host> <port> <token>", argv[0]);
+        return 1;
+    }
+    uint64_t port{};
+    auto port_text = string_view{argv[3]};
+    auto port_result = std::from_chars(
+        port_text.data(), port_text.data() + port_text.size(), port);
+    if (port_result.ec != std::errc{} ||
+        port_result.ptr != port_text.data() + port_text.size() ||
+        port == 0u || port > std::numeric_limits<uint16_t>::max()) {
+        LUISA_WARNING("Invalid remote server port '{}'.", port_text);
+        return 1;
+    }
+    const char *ut_argv[]{argv[0]};
+    boost::ut::detail::cfg::parse_arg_with_fallback(1, ut_argv);
+    "remote_local_swapchain"_test = [&] {
+        test_local_swapchain(
+            argv[0], argv[1], argv[2],
+            static_cast<uint16_t>(port), argv[4]);
+    };
+}

--- a/src/tests/unit/runtime/test_remote_blob_cache.cpp
+++ b/src/tests/unit/runtime/test_remote_blob_cache.cpp
@@ -1,0 +1,162 @@
+// Tests for the remote backend content-addressed upload cache.
+
+#include "ut/ut.hpp"
+
+#include <cstring>
+
+#include "remote_blob_cache.h"
+#include "remote_command_codec.h"
+
+using namespace luisa;
+using namespace luisa::compute::remote;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+
+namespace {
+
+[[nodiscard]] vector<std::byte> bytes_of(string_view text) {
+    vector<std::byte> bytes(text.size());
+    if (!bytes.empty()) {
+        std::memcpy(bytes.data(), text.data(), text.size());
+    }
+    return bytes;
+}
+
+[[nodiscard]] string digest_string(const BlobKey &key) {
+    constexpr char hex[] = "0123456789abcdef";
+    string result;
+    result.resize(key.digest.size() * 2u);
+    for (size_t i = 0u; i < key.digest.size(); i++) {
+        auto value = std::to_integer<uint8_t>(key.digest[i]);
+        result[i * 2u] = hex[value >> 4u];
+        result[i * 2u + 1u] = hex[value & 0x0fu];
+    }
+    return result;
+}
+
+void test_sha256_and_wire_key() {
+    auto empty = bytes_of("");
+    auto abc = bytes_of("abc");
+    auto empty_key = compute_blob_key(empty);
+    auto abc_key = compute_blob_key(abc);
+    expect(empty_key.size == 0u);
+    expect(digest_string(empty_key) ==
+           "e3b0c44298fc1c149afbf4c8996fb924"
+           "27ae41e4649b934ca495991b7852b855");
+    expect(abc_key.size == 3u);
+    expect(digest_string(abc_key) ==
+           "ba7816bf8f01cfea414140de5dae2223"
+           "b00361a396177a9cb410ff61f20015ad");
+
+    Writer writer;
+    write_blob_key(writer, abc_key);
+    Reader reader{writer.bytes()};
+    BlobKey decoded;
+    expect(read_blob_key(reader, decoded));
+    expect(reader.finish());
+    expect(decoded == abc_key);
+}
+
+void test_lru_and_pinning() {
+    BlobCache cache{8u};
+    auto first = bytes_of("aaaa");
+    auto second = bytes_of("bbbbb");
+    auto first_key = compute_blob_key(first);
+    auto second_key = compute_blob_key(second);
+    string error;
+    BlobCacheError cache_error{};
+    auto first_blob = cache.publish(
+        first_key, first, cache_error, error);
+    expect(first_blob != nullptr);
+    expect(cache_error == BlobCacheError::NONE);
+
+    auto pin = cache.find(first_key);
+    expect(pin != nullptr);
+    auto blocked = cache.publish(
+        second_key, second, cache_error, error);
+    expect(blocked == nullptr);
+    expect(cache_error == BlobCacheError::CAPACITY);
+
+    pin.reset();
+    first_blob.reset();
+    error.clear();
+    auto second_blob = cache.publish(
+        second_key, second, cache_error, error);
+    expect(second_blob != nullptr);
+    expect(cache.find(first_key) == nullptr);
+    expect(cache.find(second_key) != nullptr);
+    auto stats = cache.stats();
+    expect(stats.evictions == 1u);
+    expect(stats.resident_entries == 1u);
+    expect(stats.resident_bytes == second.size());
+}
+
+void test_digest_mismatch_rejected() {
+    BlobCache cache{64u};
+    auto expected = bytes_of("expected");
+    auto actual = bytes_of("tampered");
+    auto key = compute_blob_key(expected);
+    string error;
+    BlobCacheError cache_error{};
+    expect(cache.publish(key, actual, cache_error, error) == nullptr);
+    expect(cache_error == BlobCacheError::DIGEST_MISMATCH);
+    expect(!error.empty());
+    expect(cache.stats().resident_entries == 0u);
+}
+
+void test_upload_plan_deduplicates_and_encodes_references() {
+    auto first = bytes_of("same upload bytes");
+    auto second = bytes_of("same upload bytes");
+    vector<unique_ptr<compute::Command>> commands;
+    commands.emplace_back(make_unique<compute::BufferUploadCommand>(
+        make_resource_id(ResourceKind::BUFFER, 1u),
+        0u, first.size(), first.data()));
+    commands.emplace_back(make_unique<compute::BufferUploadCommand>(
+        make_resource_id(ResourceKind::BUFFER, 2u),
+        0u, second.size(), second.data()));
+    auto plan = plan_upload_blobs(commands, 1u, 1024u);
+    expect(static_cast<bool>(plan));
+    expect(plan.blobs.size() == 1u);
+    expect(plan.references.size() == 2u);
+    expect(plan.find(0u) == 0u);
+    expect(plan.find(1u) == 0u);
+
+    auto encoded = encode_submission(
+        make_resource_id(ResourceKind::STREAM, 3u),
+        9u, commands, {}, &plan);
+    expect(static_cast<bool>(encoded));
+    Reader reader{encoded.payload};
+    expect(reader.read_u64() ==
+           make_resource_id(ResourceKind::STREAM, 3u));
+    expect(reader.read_u64() == 9u);
+    expect(reader.read_u64() == 2u);
+    for (auto i = 0u; i < 2u; i++) {
+        expect(static_cast<WireCommand>(reader.read_u16()) ==
+               WireCommand::BUFFER_UPLOAD_CACHED);
+        expect(reader.read_u64() ==
+               make_resource_id(ResourceKind::BUFFER, i + 1u));
+        expect(reader.read_u64() == 0u);
+        expect(reader.read_u64() == first.size());
+        expect(reader.read_u32() == 0u);
+    }
+    expect(reader.finish());
+}
+
+}// namespace
+
+static auto test_remote_blob_cache_registration = [] {
+    "remote_blob_cache_sha256_and_wire_key"_test =
+        test_sha256_and_wire_key;
+    "remote_blob_cache_lru_and_pinning"_test =
+        test_lru_and_pinning;
+    "remote_blob_cache_digest_mismatch"_test =
+        test_digest_mismatch_rejected;
+    "remote_blob_cache_upload_plan"_test =
+        test_upload_plan_deduplicates_and_encodes_references;
+    return 0;
+}();
+
+int main(int argc, char *argv[]) {
+    boost::ut::detail::cfg::parse_arg_with_fallback(
+        argc, const_cast<const char **>(argv));
+}

--- a/src/tests/unit/runtime/test_remote_protocol.cpp
+++ b/src/tests/unit/runtime/test_remote_protocol.cpp
@@ -1,0 +1,220 @@
+// Test for the C++ remote backend wire protocol.
+// This test covers:
+// - canonical little-endian encoding and frame headers
+// - bounded payload parsing and malformed input rejection
+// - response envelope round-tripping
+
+#include "ut/ut.hpp"
+
+#include <array>
+#include <bit>
+#include <cstring>
+
+#include "remote_protocol.h"
+
+using namespace luisa;
+using namespace luisa::compute::remote;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+
+namespace {
+
+[[nodiscard]] vector<std::byte> bytes_of(string_view text) {
+    vector<std::byte> bytes;
+    bytes.resize(text.size());
+    std::memcpy(bytes.data(), text.data(), text.size());
+    return bytes;
+}
+
+void test_primitive_round_trip() {
+    Writer writer;
+    writer.write_u8(0xabu);
+    writer.write_u16(0x1234u);
+    writer.write_u32(0x89abcdefu);
+    writer.write_u64(0x0123456789abcdefull);
+    writer.write_i64(-17);
+    writer.write_bool(true);
+    writer.write_bool(false);
+    writer.write_f32(3.5f);
+    writer.write_string("remote");
+    auto blob = bytes_of("blob");
+    writer.write_blob(blob);
+
+    auto encoded = std::move(writer).take();
+    expect(encoded.size() > 40u);
+    expect(std::to_integer<uint8_t>(encoded[1]) == 0x34u)
+        << "u16 must be little-endian";
+    expect(std::to_integer<uint8_t>(encoded[2]) == 0x12u)
+        << "u16 must be little-endian";
+
+    Reader reader{encoded};
+    expect(reader.read_u8() == 0xabu);
+    expect(reader.read_u16() == 0x1234u);
+    expect(reader.read_u32() == 0x89abcdefu);
+    expect(reader.read_u64() == 0x0123456789abcdefull);
+    expect(reader.read_i64() == -17);
+    expect(reader.read_bool());
+    expect(!reader.read_bool());
+    expect(std::bit_cast<uint32_t>(reader.read_f32()) ==
+           std::bit_cast<uint32_t>(3.5f));
+    expect(reader.read_string() == "remote");
+    auto decoded_blob = reader.read_blob();
+    expect(decoded_blob.size() == blob.size());
+    expect(std::memcmp(decoded_blob.data(), blob.data(), blob.size()) == 0);
+    expect(reader.finish());
+}
+
+void test_frame_header_round_trip() {
+    auto payload = bytes_of("frame payload");
+    FrameHeader expected{
+        .kind = MessageKind::DISPATCH,
+        .flags = 0x12u,
+        .request_id = 0x0102030405060708ull,
+        .payload_size = payload.size(),
+        .payload_checksum = payload_checksum(payload)};
+    auto bytes = encode_frame_header(expected);
+    expect(bytes.size() == frame_header_size);
+
+    FrameHeader decoded;
+    string error;
+    expect(decode_frame_header(bytes, decoded, error));
+    expect(error.empty());
+    expect(decoded.kind == expected.kind);
+    expect(decoded.flags == expected.flags);
+    expect(decoded.request_id == expected.request_id);
+    expect(decoded.payload_size == expected.payload_size);
+    expect(decoded.payload_checksum == expected.payload_checksum);
+    expect(decoded.wire_major == protocol_major);
+    expect(decoded.wire_minor == protocol_minor);
+    expect(payload_checksum(payload) != payload_checksum({}));
+
+    expected.wire_minor = 0u;
+    bytes = encode_frame_header(expected);
+    error.clear();
+    expect(decode_frame_header(bytes, decoded, error));
+    expect(decoded.wire_minor == 0u);
+}
+
+void test_malformed_frame_headers() {
+    auto bytes = encode_frame_header(FrameHeader{
+        .kind = MessageKind::HELLO,
+        .request_id = 1u});
+    FrameHeader decoded;
+    string error;
+
+    expect(!decode_frame_header(span{bytes}.first(bytes.size() - 1u),
+                                decoded, error));
+    expect(!error.empty());
+
+    auto bad_magic = bytes;
+    bad_magic[0] = std::byte{0u};
+    error.clear();
+    expect(!decode_frame_header(bad_magic, decoded, error));
+    expect(error == "Invalid remote protocol magic.");
+
+    auto bad_version = bytes;
+    bad_version[4] = std::byte{protocol_major + 1u};
+    error.clear();
+    expect(!decode_frame_header(bad_version, decoded, error));
+    expect(error == "Unsupported remote protocol version.");
+
+    auto bad_reserved = bytes;
+    bad_reserved[12] = std::byte{1u};
+    error.clear();
+    expect(!decode_frame_header(bad_reserved, decoded, error));
+    expect(error == "Remote protocol reserved frame bits are nonzero.");
+
+    auto oversized = bytes;
+    for (auto i = 0u; i < 8u; i++) {
+        oversized[24u + i] = std::byte{0xffu};
+    }
+    error.clear();
+    expect(!decode_frame_header(oversized, decoded, error,
+                                ProtocolLimits{.max_frame_payload = 1024u}));
+    expect(error ==
+           "Remote protocol frame exceeds the configured payload limit.");
+}
+
+void test_reader_rejects_malformed_values() {
+    {
+        const std::array bytes{std::byte{2u}};
+        Reader reader{bytes};
+        static_cast<void>(reader.read_bool());
+        expect(!reader.ok());
+        expect(reader.error() == "Invalid remote protocol boolean.");
+    }
+    {
+        Writer writer;
+        writer.write_u64(128u);
+        writer.write_bytes(bytes_of("short"));
+        auto bytes = std::move(writer).take();
+        Reader reader{bytes};
+        static_cast<void>(reader.read_blob());
+        expect(!reader.ok());
+        expect(reader.error() == "Truncated remote protocol payload.");
+    }
+    {
+        Writer writer;
+        writer.write_string("too long");
+        auto bytes = std::move(writer).take();
+        Reader reader{bytes, ProtocolLimits{.max_string_size = 3u}};
+        static_cast<void>(reader.read_string());
+        expect(!reader.ok());
+        expect(reader.error() ==
+               "Remote protocol string exceeds the configured limit.");
+    }
+    {
+        Writer writer;
+        writer.write_u32(1u);
+        writer.write_u32(2u);
+        auto bytes = std::move(writer).take();
+        Reader reader{bytes};
+        expect(reader.read_u32() == 1u);
+        expect(!reader.finish());
+        expect(reader.error() ==
+               "Unexpected trailing bytes in remote protocol payload.");
+    }
+}
+
+void test_response_round_trip() {
+    auto body = bytes_of("result");
+    auto payload = make_response_payload(
+        MessageKind::CREATE_BUFFER, Status::OK, {}, body);
+    ResponseView response;
+    string error;
+    expect(decode_response_payload(payload, response, error));
+    expect(response.request_kind == MessageKind::CREATE_BUFFER);
+    expect(response.status == Status::OK);
+    expect(response.message.empty());
+    expect(response.body.size() == body.size());
+    expect(std::memcmp(response.body.data(), body.data(), body.size()) == 0);
+
+    auto failed = make_response_payload(
+        MessageKind::CREATE_SHADER,
+        Status::UNSUPPORTED,
+        "native include is disabled");
+    expect(decode_response_payload(failed, response, error));
+    expect(response.request_kind == MessageKind::CREATE_SHADER);
+    expect(response.status == Status::UNSUPPORTED);
+    expect(response.message == "native include is disabled");
+    expect(response.body.empty());
+}
+
+}// namespace
+
+static auto test_remote_protocol_registration = [] {
+    "remote_protocol_primitive_round_trip"_test = test_primitive_round_trip;
+    "remote_protocol_frame_header_round_trip"_test =
+        test_frame_header_round_trip;
+    "remote_protocol_malformed_frame_headers"_test =
+        test_malformed_frame_headers;
+    "remote_protocol_malformed_values"_test =
+        test_reader_rejects_malformed_values;
+    "remote_protocol_response_round_trip"_test = test_response_round_trip;
+    return 0;
+}();
+
+int main(int argc, char *argv[]) {
+    boost::ut::detail::cfg::parse_arg_with_fallback(
+        argc, const_cast<const char **>(argv));
+}

--- a/src/tests/unit/runtime/test_remote_transport.cpp
+++ b/src/tests/unit/runtime/test_remote_transport.cpp
@@ -1,0 +1,228 @@
+// Test for the C++ remote backend TCP transport.
+// This test covers:
+// - request/response correlation over a localhost socket
+// - asynchronous notification delivery
+// - checksum failure closing the connection and waking waiters
+
+#include "ut/ut.hpp"
+
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <thread>
+
+#include <asio.hpp>
+
+#include "remote_protocol.h"
+#include "remote_transport.h"
+
+using namespace luisa;
+using namespace luisa::compute::remote;
+using namespace boost::ut;
+using namespace boost::ut::literals;
+using namespace std::chrono_literals;
+
+namespace {
+
+using Tcp = asio::ip::tcp;
+
+[[nodiscard]] vector<std::byte> bytes_of(string_view text) {
+    vector<std::byte> bytes;
+    bytes.resize(text.size());
+    std::memcpy(bytes.data(), text.data(), text.size());
+    return bytes;
+}
+
+[[nodiscard]] bool equal_bytes(span<const std::byte> lhs,
+                               span<const std::byte> rhs) noexcept {
+    return lhs.size() == rhs.size() &&
+           std::memcmp(lhs.data(), rhs.data(), lhs.size()) == 0;
+}
+
+struct ReceivedFrame {
+    FrameHeader header;
+    vector<std::byte> payload;
+};
+
+[[nodiscard]] bool read_frame(Tcp::socket &socket, ReceivedFrame &frame) {
+    std::array<std::byte, frame_header_size> header_bytes{};
+    asio::error_code error;
+    asio::read(socket, asio::buffer(header_bytes), error);
+    if (error) { return false; }
+    string decode_error;
+    if (!decode_frame_header(
+            header_bytes, frame.header, decode_error)) {
+        return false;
+    }
+    frame.payload.resize(static_cast<size_t>(frame.header.payload_size));
+    asio::read(socket, asio::buffer(frame.payload), error);
+    return !error &&
+           payload_checksum(frame.payload) == frame.header.payload_checksum;
+}
+
+void write_frame(Tcp::socket &socket, MessageKind kind, uint64_t request_id,
+                 span<const std::byte> payload, bool valid_checksum = true) {
+    auto header = encode_frame_header(FrameHeader{
+        .kind = kind,
+        .request_id = request_id,
+        .payload_size = payload.size(),
+        .payload_checksum = valid_checksum ? payload_checksum(payload) : 1u});
+    std::array<asio::const_buffer, 2u> buffers{
+        asio::buffer(static_cast<const void *>(header.data()), header.size()),
+        asio::buffer(payload.data(), payload.size())};
+    asio::error_code error;
+    asio::write(socket, buffers, error);
+    expect(!error);
+}
+
+void test_request_and_notification() {
+    asio::io_context io;
+    Tcp::acceptor acceptor{io, {Tcp::v4(), 0u}};
+    auto port = acceptor.local_endpoint().port();
+    std::thread server{[&] {
+        Tcp::socket socket{io};
+        asio::error_code error;
+        acceptor.accept(socket, error);
+        expect(!error);
+        ReceivedFrame request;
+        expect(read_frame(socket, request));
+        expect(request.header.kind == MessageKind::QUERY);
+        expect(request.payload == bytes_of("backend"));
+        auto response_body = bytes_of("metal");
+        auto response = make_response_payload(
+            MessageKind::QUERY, Status::OK, {}, response_body);
+        write_frame(socket, MessageKind::RESPONSE,
+                    request.header.request_id, response);
+        auto notification = bytes_of("done");
+        write_frame(socket, MessageKind::STREAM_LOG, 91u, notification);
+        std::this_thread::sleep_for(50ms);
+    }};
+
+    Connection connection;
+    std::mutex notification_mutex;
+    std::condition_variable notification_cv;
+    bool notified = false;
+    connection.set_notification_handler(
+        [&](MessageKind kind, uint64_t id, span<const std::byte> payload) {
+            std::scoped_lock lock{notification_mutex};
+            expect(kind == MessageKind::STREAM_LOG);
+            expect(id == 91u);
+            auto expected = bytes_of("done");
+            expect(equal_bytes(payload, expected));
+            notified = true;
+            notification_cv.notify_one();
+        });
+    string error;
+    expect(connection.connect("127.0.0.1", port, 2s, error));
+    auto query = bytes_of("backend");
+    auto response = connection.request(MessageKind::QUERY, query, 2s);
+    expect(static_cast<bool>(response));
+    expect(response.request_kind == MessageKind::QUERY);
+    expect(response.body == bytes_of("metal"));
+    {
+        std::unique_lock lock{notification_mutex};
+        expect(notification_cv.wait_for(lock, 2s, [&] { return notified; }));
+    }
+    connection.close();
+    server.join();
+}
+
+void test_bad_checksum_closes_connection() {
+    asio::io_context io;
+    Tcp::acceptor acceptor{io, {Tcp::v4(), 0u}};
+    auto port = acceptor.local_endpoint().port();
+    std::thread server{[&] {
+        Tcp::socket socket{io};
+        asio::error_code error;
+        acceptor.accept(socket, error);
+        expect(!error);
+        ReceivedFrame request;
+        expect(read_frame(socket, request));
+        auto response = make_response_payload(
+            MessageKind::QUERY, Status::OK, {});
+        write_frame(socket, MessageKind::RESPONSE,
+                    request.header.request_id, response, false);
+        std::this_thread::sleep_for(20ms);
+    }};
+
+    Connection connection;
+    string error;
+    expect(connection.connect("127.0.0.1", port, 2s, error));
+    auto response = connection.request(MessageKind::QUERY, {}, 2s);
+    expect(!static_cast<bool>(response));
+    expect(response.status == Status::CONNECTION_CLOSED);
+    expect(response.message ==
+           "Remote protocol payload checksum mismatch.");
+    expect(!connection.connected());
+    connection.close();
+    server.join();
+}
+
+void test_reconnect_same_connection() {
+    asio::io_context io;
+    Tcp::acceptor acceptor{io, {Tcp::v4(), 0u}};
+    auto port = acceptor.local_endpoint().port();
+    std::thread server{[&] {
+        for (auto attempt = 0u; attempt < 2u; attempt++) {
+            Tcp::socket socket{io};
+            asio::error_code error;
+            acceptor.accept(socket, error);
+            expect(!error);
+            ReceivedFrame request;
+            expect(read_frame(socket, request));
+            expect(request.header.kind == MessageKind::QUERY);
+            Writer body;
+            body.write_u32(attempt);
+            auto response = make_response_payload(
+                MessageKind::QUERY, Status::OK, {}, body.bytes());
+            write_frame(socket, MessageKind::RESPONSE,
+                        request.header.request_id, response);
+            socket.shutdown(Tcp::socket::shutdown_both, error);
+            socket.close(error);
+        }
+    }};
+
+    Connection connection;
+    string error;
+    expect(connection.connect("127.0.0.1", port, 2s, error));
+    auto first = connection.request(MessageKind::QUERY, {}, 2s);
+    expect(static_cast<bool>(first));
+    Reader first_reader{first.body};
+    expect(first_reader.read_u32() == 0u);
+    expect(first_reader.finish());
+    auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (connection.connected() &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    expect(!connection.connected());
+
+    error.clear();
+    expect(connection.connect("127.0.0.1", port, 2s, error)) << error;
+    auto second = connection.request(MessageKind::QUERY, {}, 2s);
+    expect(static_cast<bool>(second));
+    Reader second_reader{second.body};
+    expect(second_reader.read_u32() == 1u);
+    expect(second_reader.finish());
+    connection.close();
+    server.join();
+}
+
+}// namespace
+
+static auto test_remote_transport_registration = [] {
+    "remote_transport_request_and_notification"_test =
+        test_request_and_notification;
+    "remote_transport_bad_checksum"_test =
+        test_bad_checksum_closes_connection;
+    "remote_transport_reconnect_same_connection"_test =
+        test_reconnect_same_connection;
+    return 0;
+}();
+
+int main(int argc, char *argv[]) {
+    boost::ut::detail::cfg::parse_arg_with_fallback(
+        argc, const_cast<const char **>(argv));
+}


### PR DESCRIPTION
## Summary

- add a pure C++ remote backend over standalone Asio, with typed resource handles, asynchronous stream submission/completion, events, resource operations, ray tracing commands, and a content-addressed blob cache
- transport shaders as Luisa AST JSON and add bounded yyjson-based AST round-trip serde; no Rust or `CallableLibrary` dependency
- keep swapchain creation and presentation on the client while copying remote render results back to a local presentation image
- add resilient disconnect cleanup and reconnect support, per-session native device construction, backend/device allowlisting, quotas, and graceful server shutdown
- document the protocol, trust boundary, lifecycle, reconnect semantics, and future service/multi-backend extension points

## Validation

- full Debug Metal build
- CTest: 131/131 passed
- focused AST/remote tests under ASan + UBSan
- 17/17 finite remote Metal rendering examples passed, including path tracing, black hole, procedural and callable scenes
- installed backend/server/header smoke test passed
- `git diff --check` passed

## Notes

- protocol version 1.1 retains 1.0 compatibility
- reconnect creates a fresh session/resource namespace; existing remote handles are intentionally invalidated
- authenticated clients remain a semantic trust boundary; this is not presented as a hostile multi-tenant sandbox