### PR TITLE
Fix Metal4 downgrade integration for LLVM 22

### DIFF
--- a/.agents/skills/cmake/SKILL.md
+++ b/.agents/skills/cmake/SKILL.md
@@ -68,7 +68,7 @@ Auto-finds `cmake` and `ninja` (PATH → `.deps/` → pip). Auto-prepares MSVC e
 | `LUISA_COMPUTE_ENABLE_DSL` | ON | C++ DSL |
 | `LUISA_COMPUTE_ENABLE_CUDA` | ON | CUDA backend |
 | `LUISA_COMPUTE_ENABLE_METAL` | ON | Metal backend (macOS only) |
-| `LUISA_COMPUTE_ENABLE_METAL4` | OFF | Independent Metal4 XIR→LLVM→AIR backend; requires LLVM 21 and Apple Metal 4 tools |
+| `LUISA_COMPUTE_ENABLE_METAL4` | OFF | Independent Metal4 XIR→LLVM→AIR backend; requires LLVM 22 and Apple Metal 4 tools |
 | `LUISA_COMPUTE_ENABLE_DX` | ON | DirectX backend (Windows only) |
 | `LUISA_COMPUTE_ENABLE_VULKAN` | ON | Vulkan backend |
 | `LUISA_COMPUTE_ENABLE_HIP` | OFF | HIP backend (work in progress) |
@@ -195,26 +195,26 @@ luisa_compute_add_backend(cuda SOURCES ${LUISA_COMPUTE_CUDA_SOURCES})
 Key: output renamed to `luisa-backend-<name>`, installed to `bin/`, supports `luisa_embed_device_lib` for builtin device libs.
 
 On iOS, the same helper emits a static backend. A signed Metal4 AIR device app
-also requires static arm64 iPhoneOS LLVM 21 archives; an arm64 macOS LLVM build
+also requires static arm64 iPhoneOS LLVM 22 archives; an arm64 macOS LLVM build
 is not platform-compatible. Prefer the checked scripts so local and CI options
 remain identical:
 
 ```bash
 scripts/build_ios_llvm.sh \
-  --host-llvm-prefix "$(brew --prefix llvm@21)"
+  --host-llvm-prefix "$(brew --prefix llvm@22)"
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --team <team-id> --mode all
 
 # CI/link closure only; these bundles are not installable.
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --mode all --unsigned
 scripts/audit_ios_bundles.sh \
   --bin-dir cmake-build-ios-metal4-device-air-xcode/bin/Release
 ```
 
-`build_ios_llvm.sh` downloads the official LLVM 21.1.8 source when needed and
+`build_ios_llvm.sh` downloads the official LLVM 22.1.8 source when needed and
 uses CMake/Ninja with `arm64-apple-ios<deployment>` host/default triples. The
 application script uses CMake's Xcode generator only because provisioning and
 automatic signing are Xcode workflows. `--mode examples`, `tests`, or `all`

--- a/.agents/skills/ir_pipeline/SKILL.md
+++ b/.agents/skills/ir_pipeline/SKILL.md
@@ -372,7 +372,7 @@ Preserve these ABI rules when changing lowering or adding types:
   `t_max`, guard procedural commit to the inclusive
   `[ray_min_distance, committed_distance]` interval, and lower terminate to
   native abort.
-- Keep LLVM 21 query pointers opaque in the IR but attach downgrade metadata:
+- Keep LLVM 22 query pointers opaque in the IR but attach downgrade metadata:
   allocate has `ret_eltype = %struct._intersection_query_t`, every query
   argument zero has the matching `arg_eltypes` entry, and reset argument five
   has `%struct._instance_acceleration_structure_t`. Native getters are
@@ -578,7 +578,7 @@ LUISA_ENABLE_VALIDATION=1 MTL_DEBUG_LAYER=1 \
 ~~~
 
 For physical-device iOS validation, configure the project with the Xcode
-generator, `iphoneos`, LLVM 21 iOS static libraries, Metal4 enabled, and the
+generator, `iphoneos`, LLVM 22 iOS static libraries, Metal4 enabled, and the
 signing team, then build the
 `luisa-metal4-ios-device-air-path-tracer` application target. Verify the final
 link contains `libluisa-backend-metal4.a` and the static create/destroy symbols,

--- a/.agents/skills/test/SKILL.md
+++ b/.agents/skills/test/SKILL.md
@@ -454,9 +454,9 @@ Use the repository scripts rather than copying a desktop toolchain:
 
 ```bash
 scripts/build_ios_llvm.sh \
-  --host-llvm-prefix "$(brew --prefix llvm@21)"
+  --host-llvm-prefix "$(brew --prefix llvm@22)"
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --team <team-id> --mode tests
 ```
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-src/ext/llvm-downgrade-llvm21-air.patch -whitespace
+src/ext/llvm-downgrade-llvm22-air.patch -whitespace
 src/backends/metal4/metal-tex-compress/** -whitespace

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  LLVM_VERSION: 21.1.8
+  LLVM_VERSION: 22.1.8
   IOS_DEPLOYMENT_TARGET: '26.0'
 
 jobs:
@@ -30,10 +30,10 @@ jobs:
           if [[ -d /Applications/Xcode_26.6.app ]]; then
             sudo xcode-select --switch /Applications/Xcode_26.6.app/Contents/Developer
           fi
-          brew install llvm@21 ninja
+          brew install llvm@22 ninja
           xcodebuild -version
           xcrun --sdk iphoneos --show-sdk-version
-          echo "host_llvm_prefix=$(brew --prefix llvm@21)" >> "$GITHUB_OUTPUT"
+          echo "host_llvm_prefix=$(brew --prefix llvm@22)" >> "$GITHUB_OUTPUT"
           echo "xcode_key=$(xcodebuild -version | shasum -a 256 | cut -c 1-16)" >> "$GITHUB_OUTPUT"
 
       - name: Cache static iPhoneOS LLVM
@@ -45,7 +45,7 @@ jobs:
             .ci/llvm-source
           key: ios-llvm-${{ runner.os }}-${{ runner.arch }}-${{ env.LLVM_VERSION }}-${{ env.IOS_DEPLOYMENT_TARGET }}-${{ steps.toolchain.outputs.xcode_key }}-${{ hashFiles('scripts/build_ios_llvm.sh') }}
 
-      - name: Build static arm64 iPhoneOS LLVM 21
+      - name: Build static arm64 iPhoneOS LLVM 22
         if: steps.cache-ios-llvm.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -38,22 +38,22 @@ cutout IFT/loop comparison documented in the AIR report.
 
 ## Reproducible build scripts
 
-The shortest complete setup uses two repository scripts. Homebrew LLVM 21 is
+The shortest complete setup uses two repository scripts. Homebrew LLVM 22 is
 only a host tool provider for `llvm-tblgen`; none of its macOS libraries are
 linked into the phone application:
 
 ~~~sh
-brew install llvm@21 ninja
+brew install llvm@22 ninja
 
-# Downloads the official llvm-project-21.1.8 source release when it is not
+# Downloads the official llvm-project-22.1.8 source release when it is not
 # already cached, then builds static arm64 iPhoneOS libraries with Ninja.
 scripts/build_ios_llvm.sh \
-  --host-llvm-prefix "$(brew --prefix llvm@21)"
+  --host-llvm-prefix "$(brew --prefix llvm@22)"
 
 # Configure all 19 examples, the matched Metal4 benchmark, and the independent
 # device-test mirror; sign the bundles through Xcode automatic signing.
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --team <apple-development-team> \
   --mode all
 ~~~
@@ -64,7 +64,7 @@ those bundles cannot be installed on a device:
 
 ~~~sh
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --mode all --unsigned
 
 scripts/audit_ios_bundles.sh \
@@ -74,11 +74,11 @@ scripts/audit_ios_bundles.sh \
 
 The LLVM script also accepts `--source <llvm-project>` to use an existing
 official source checkout/tarball, `--llvm-version`, `--source-cache`, and
-`--build-dir`. It rejects a non-LLVM-21 source or host `llvm-tblgen`, because
+`--build-dir`. It rejects a non-LLVM-22 source or host `llvm-tblgen`, because
 mixing LLVM majors would invalidate the AIR/downgrade integration.
 
 Xcode's system toolchain is sufficient for compiling ordinary iOS C++, but it
-does not expose the complete linkable LLVM 21 development archives needed by
+does not expose the complete linkable LLVM 22 development archives needed by
 runtime XIR-to-AIR generation. Official prebuilt arm64 macOS LLVM packages are
 also tagged for the macOS Mach-O platform, not iPhoneOS, and cannot replace the
 cross-built libraries. An AOT-only application could omit LLVM by shipping
@@ -102,7 +102,7 @@ normal builds:
   comparison under `examples/ios/benchmark`.
 
 The examples and device tests require an iOS toolchain, Metal4, GUI support,
-and an arm64 iPhoneOS LLVM 21 static build. The comparison selects exactly one
+and an arm64 iPhoneOS LLVM 22 static build. The comparison selects exactly one
 of `metal` or `metal4`; the generic benchmark build script configures those
 backend requirements without linking both into one app.
 
@@ -116,7 +116,7 @@ cmake -S . -B cmake-build-ios-metal4-device-air-xcode -G Xcode \
   -DCMAKE_OSX_SYSROOT=iphoneos \
   -DCMAKE_OSX_ARCHITECTURES=arm64 \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0 \
-  -DLLVM_DIR=<ios-llvm21>/lib/cmake/llvm \
+  -DLLVM_DIR=<ios-llvm22>/lib/cmake/llvm \
   -DLUISA_COMPUTE_BUILD_TESTS=OFF \
   -DLUISA_COMPUTE_BUILD_IOS_EXAMPLES=ON \
   -DLUISA_COMPUTE_BUILD_IOS_TESTS=ON \
@@ -174,7 +174,7 @@ rendering thread. Camera accumulation is reset when touch changes the view.
 ## Static application layout and LLVM
 
 Each bundle contains one arm64 Mach-O executable. Luisa runtime, DSL, XIR,
-Metal4, coroutine support when needed, llvm-downgrade, and LLVM 21 component
+Metal4, coroutine support when needed, llvm-downgrade, and LLVM 22 component
 archives are linked statically and dead-stripped. No Luisa or LLVM dynamic
 library is expected in `otool -L`; only Apple system frameworks and libraries
 should remain.
@@ -227,7 +227,7 @@ build, execution, cache interpretation, and A19 Pro measurements.
 ## Continuous integration boundary
 
 `.github/workflows/build-ios.yml` runs on GitHub's arm64 `macos-26` image with
-Xcode 26.6. It downloads/caches the same official LLVM 21.1.8 source, builds the
+Xcode 26.6. It downloads/caches the same official LLVM 22.1.8 source, builds the
 static iPhoneOS libraries, compiles all Metal4 example/test/benchmark bundles
 and a separate old-Metal benchmark without code signing, and runs
 `scripts/audit_ios_bundles.sh`. CI therefore enforces target count, arm64

--- a/examples/ios/benchmark/README.md
+++ b/examples/ios/benchmark/README.md
@@ -20,9 +20,9 @@ and their common Window/Swapchain presentation remain under `examples/ios`.
 Build the iPhoneOS LLVM archives once for Metal4:
 
 ~~~sh
-brew install llvm@21 ninja
+brew install llvm@22 ninja
 scripts/build_ios_llvm.sh \
-  --host-llvm-prefix "$(brew --prefix llvm@21)"
+  --host-llvm-prefix "$(brew --prefix llvm@22)"
 ~~~
 
 Then configure two independent static application builds. Distinct bundle
@@ -35,7 +35,7 @@ scripts/build_ios_backend_benchmark.sh \
 
 scripts/build_ios_backend_benchmark.sh \
   --backend metal4 \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --team <apple-development-team>
 ~~~
 
@@ -58,7 +58,7 @@ then signs the complete app:
 ~~~sh
 scripts/build_ios_backend_benchmark.sh \
   --backend metal4 \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --profile ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/<id>.mobileprovision \
   --identity <codesign-identity-sha1>
 ~~~

--- a/examples/ios/metal4_path_tracing/README.md
+++ b/examples/ios/metal4_path_tracing/README.md
@@ -1,14 +1,14 @@
 # Metal4 AIR iOS Device Conformance and Path Tracing
 
 This application is the physical-device closure test for Luisa's Metal4 AIR
-backend. It links the real static `DeviceInterface`, DSL, XIR passes, LLVM 21
+backend. It links the real static `DeviceInterface`, DSL, XIR passes, LLVM 22
 AIR code generator, LLVM 14 downgrade, MTLB writer, and Metal4 runtime into one
 signed arm64 iOS application. No MSL code generator is linked or used.
 
 The iPhone performs the complete shader path at runtime:
 
 ~~~text
-DSL/AST -> XIR -> XIR optimization -> LLVM 21 IR -> LLVM O2
+DSL/AST -> XIR -> XIR optimization -> LLVM 22 IR -> LLVM O2
         -> LLVM 14 downgrade -> Apple AIR -> MTLB -> MTL4 compiler/runtime
 ~~~
 
@@ -45,7 +45,7 @@ physical-device provisioning and automatic signing are Xcode workflows.
 - Developer Mode enabled on the iPhone.
 - An Apple Development identity and development team. A Personal Team works;
   its provisioning profile expires after seven days.
-- LLVM 21 built as arm64 iOS static libraries. Configure the Luisa iOS build
+- LLVM 22 built as arm64 iOS static libraries. Configure the Luisa iOS build
   with its `lib/cmake/llvm` directory through `LLVM_DIR`.
 - The current metal-cpp headers under `src/backends/common/metal-cpp`.
 
@@ -58,9 +58,9 @@ The reproducible shortcut is:
 
 ~~~sh
 scripts/build_ios_llvm.sh \
-  --host-llvm-prefix "$(brew --prefix llvm@21)"
+  --host-llvm-prefix "$(brew --prefix llvm@22)"
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --team <apple-development-team> --mode all
 ~~~
 
@@ -73,7 +73,7 @@ cmake -S . -B cmake-build-ios-metal4-device-air-xcode -G Xcode \
   -DCMAKE_OSX_ARCHITECTURES=arm64 \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0 \
   -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_DIR=<ios-llvm21>/lib/cmake/llvm \
+  -DLLVM_DIR=<ios-llvm22>/lib/cmake/llvm \
   -DLUISA_COMPUTE_BUILD_TESTS=OFF \
   -DLUISA_COMPUTE_BUILD_IOS_TESTS=ON \
   -DLUISA_COMPUTE_BUILD_IOS_EXAMPLES=ON \
@@ -105,7 +105,7 @@ codesign --verify --deep --strict --verbose=2 \
 and repository path-tracing sources but a test-specific bundle identifier.
 
 The resulting executable is intentionally large because it contains the iOS
-LLVM 21 static libraries. That size is acceptable for this conformance runner;
+LLVM 22 static libraries. That size is acceptable for this conformance runner;
 shipping applications should normally cache or distribute precompiled MTLB
 artifacts while keeping this dynamic path available for development.
 
@@ -173,14 +173,14 @@ CMake/Ninja build registers it as `test_metal4_device_conformance`, so CodeGen,
 ABI, image, and runtime failures can be found before provisioning the phone:
 
 ~~~sh
-cmake --build cmake-build-metal-air-llvm21 \
+cmake --build cmake-build-metal-air-llvm22 \
   --target test_metal4_device_conformance -j 8
 
-ctest --test-dir cmake-build-metal-air-llvm21 \
+ctest --test-dir cmake-build-metal-air-llvm22 \
   -R '^test_metal4_device_conformance$' --output-on-failure -V
 
 LUISA_ENABLE_VALIDATION=1 MTL_DEBUG_LAYER=1 \
-ctest --test-dir cmake-build-metal-air-llvm21 \
+ctest --test-dir cmake-build-metal-air-llvm22 \
   -R '^test_metal4_device_conformance$' --output-on-failure -V
 ~~~
 

--- a/scripts/build_ios_llvm.sh
+++ b/scripts/build_ios_llvm.sh
@@ -10,19 +10,19 @@ usage() {
     }' "$0"
 }
 
-# Build a static arm64 iPhoneOS LLVM 21 tree for Luisa's Metal4 AIR backend.
+# Build a static arm64 iPhoneOS LLVM 22 tree for Luisa's Metal4 AIR backend.
 #
 # Usage:
-#   scripts/build_ios_llvm.sh --source /path/to/llvm-project-21.1.8.src
+#   scripts/build_ios_llvm.sh --source /path/to/llvm-project-22.1.8.src
 #
 # Options:
 #   --source PATH             llvm-project root or its llvm/ directory.
 #   --llvm-version VERSION    Official source release to download when
-#                             --source is omitted (default: 21.1.8).
+#                             --source is omitted (default: 22.1.8).
 #   --source-cache PATH       Download/extraction directory.
 #   --verify-attestation      Verify the downloaded release with GitHub CLI.
-#   --build-dir PATH          Output directory (default: cmake-build-llvm21-ios).
-#   --host-llvm-prefix PATH   Host LLVM 21 prefix containing llvm-tblgen.
+#   --build-dir PATH          Output directory (default: cmake-build-llvm22-ios).
+#   --host-llvm-prefix PATH   Host LLVM 22 prefix containing llvm-tblgen.
 #   --deployment-target VER   iOS deployment target (default: 26.0).
 #   --configuration NAME      CMake configuration (default: Release).
 #   --jobs N                  Parallel build jobs (default: logical CPU count).
@@ -33,9 +33,9 @@ script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 repo_dir=$(cd -- "$script_dir/.." && pwd -P)
 
 llvm_source=${LUISA_IOS_LLVM_SOURCE:-}
-llvm_version=${LUISA_IOS_LLVM_VERSION:-21.1.8}
-llvm_source_cache=${LUISA_IOS_LLVM_SOURCE_CACHE:-"$repo_dir/cmake-build-llvm21-ios-source"}
-llvm_build_dir=${LUISA_IOS_LLVM_BUILD_DIR:-"$repo_dir/cmake-build-llvm21-ios"}
+llvm_version=${LUISA_IOS_LLVM_VERSION:-22.1.8}
+llvm_source_cache=${LUISA_IOS_LLVM_SOURCE_CACHE:-"$repo_dir/cmake-build-llvm22-ios-source"}
+llvm_build_dir=${LUISA_IOS_LLVM_BUILD_DIR:-"$repo_dir/cmake-build-llvm22-ios"}
 host_llvm_prefix=${LUISA_HOST_LLVM_PREFIX:-}
 deployment_target=26.0
 configuration=Release
@@ -151,8 +151,8 @@ llvm_version_file="$llvm_source/../cmake/Modules/LLVMVersion.cmake"
 llvm_source_major=$(sed -n \
     's/^[[:space:]]*set(LLVM_VERSION_MAJOR \([0-9][0-9]*\)).*/\1/p' \
     "$llvm_version_file" 2>/dev/null | head -n 1)
-if [[ "$llvm_source_major" != 21 ]]; then
-    printf 'Luisa Metal4 AIR requires LLVM 21 source, found major %s.\n' \
+if [[ "$llvm_source_major" != 22 ]]; then
+    printf 'Luisa Metal4 AIR requires LLVM 22 source, found major %s.\n' \
         "${llvm_source_major:-unknown}" >&2
     exit 1
 fi
@@ -160,24 +160,24 @@ mkdir -p "$llvm_build_dir"
 llvm_build_dir=$(cd -- "$llvm_build_dir" && pwd -P)
 
 if [[ -z "$host_llvm_prefix" ]] && command -v brew >/dev/null 2>&1; then
-    host_llvm_prefix=$(brew --prefix llvm@21 2>/dev/null || true)
+    host_llvm_prefix=$(brew --prefix llvm@22 2>/dev/null || true)
 fi
 if [[ -z "$host_llvm_prefix" ]]; then
     printf '%s\n' \
-        'Pass --host-llvm-prefix or install host LLVM 21 with Homebrew.' >&2
+        'Pass --host-llvm-prefix or install host LLVM 22 with Homebrew.' >&2
     exit 1
 fi
 host_tblgen="$host_llvm_prefix/bin/llvm-tblgen"
 host_llvm_config="$host_llvm_prefix/bin/llvm-config"
 if [[ ! -x "$host_tblgen" || ! -x "$host_llvm_config" ]]; then
-    printf 'Host LLVM 21 tools not found under: %s\n' "$host_llvm_prefix" >&2
+    printf 'Host LLVM 22 tools not found under: %s\n' "$host_llvm_prefix" >&2
     exit 1
 fi
 host_llvm_version=$($host_llvm_config --version)
 case "$host_llvm_version" in
-    21.*) ;;
+    22.*) ;;
     *)
-        printf 'Host llvm-tblgen must be LLVM 21, found %s.\n' \
+        printf 'Host llvm-tblgen must be LLVM 22, found %s.\n' \
             "$host_llvm_version" >&2
         exit 1
         ;;

--- a/scripts/build_ios_metal4.sh
+++ b/scripts/build_ios_metal4.sh
@@ -21,7 +21,7 @@ usage() {
 #       --unsigned --mode all
 #
 # Options:
-#   --llvm-dir PATH           arm64 iOS LLVM 21 lib/cmake/llvm directory.
+#   --llvm-dir PATH           arm64 iOS LLVM 22 lib/cmake/llvm directory.
 #   --build-dir PATH          Output directory (default shown below).
 #   --team ID                 Apple Development team for automatic signing.
 #   --mode MODE               all, examples, tests, or benchmark (default: all).
@@ -137,7 +137,7 @@ for required_tool in cmake xcodebuild xcrun; do
 done
 
 if [[ -z "$llvm_dir" ]]; then
-    default_llvm_dir="$repo_dir/cmake-build-llvm21-ios/lib/cmake/llvm"
+    default_llvm_dir="$repo_dir/cmake-build-llvm22-ios/lib/cmake/llvm"
     if [[ -f "$default_llvm_dir/LLVMConfig.cmake" ]]; then
         llvm_dir=$default_llvm_dir
     else

--- a/src/backends/metal4/llvm_codegen/AIR_INTRINSICS_AND_TRANSLATION.md
+++ b/src/backends/metal4/llvm_codegen/AIR_INTRINSICS_AND_TRANSLATION.md
@@ -87,7 +87,7 @@ XIR support preflight
     +-- unsupported compute or raster: explicit shader-creation error
     |
     v
-LLVM 21 IR with AIR target, intrinsics, and metadata
+LLVM 22 IR with AIR target, intrinsics, and metadata
     |
     +-- LLVM verification
     +-- LLVM default O2 module pipeline
@@ -235,7 +235,7 @@ llvm::BitcodeWriter140::prepareModule(*module);
 llvm::WriteBitcode140ToFile(*module, stream);
 ~~~
 
-The downgrade code is compiled against the same LLVM 21 installation as the
+The downgrade code is compiled against the same LLVM 22 installation as the
 Metal backend. It rewrites/serializes the module in the LLVM 14 bitcode dialect
 accepted by the tested Apple Metal toolchain. The resulting bytes begin with
 the LLVM bitcode magic `42 43 c0 de`; the backend does not invoke the
@@ -250,11 +250,11 @@ directly. Section 14 documents the container records and validator.
 
 The submodule is [JuliaLLVM/llvm-downgrade](https://github.com/JuliaLLVM/llvm-downgrade),
 whose upstream base is pinned by this branch at
-`1e04ee99aff7c059606502ee86d03eb7d1c5d781`. Luisa builds only its LLVM 14
+`6ab0b538c9302bd44f1d2a02f8d064ba9c5f2efb`. Luisa builds only its LLVM 14
 writer and the required pointer/module rewriters, not its older 5.0 or 7.0
-writers. The submodule checkout remains pristine. LLVM 21 compatibility and
+writers. The submodule checkout remains pristine. LLVM 22 compatibility and
 the AIR typed-pointer recovery extensions described below live in the parent-
-owned `llvm-downgrade-llvm21-air.patch`, which CMake applies only to a build-
+owned `llvm-downgrade-llvm22-air.patch`, which CMake applies only to a build-
 tree mirror.
 
 CMake verifies the submodule commit and cleanliness when Git metadata is
@@ -272,7 +272,7 @@ LLVM-exception licensing.
 
 ### 2.3 Typed-pointer recovery directives
 
-LLVM 21 represents every pointer as opaque `ptr addrspace(N)`, but the LLVM 14
+LLVM 22 represents every pointer as opaque `ptr addrspace(N)`, but the LLVM 14
 bitcode consumed by the AIR loader still encodes pointee types. Those pointee
 types are semantically significant for textures, samplers, argument buffers,
 and resources nested inside structures. A remaining unannotated opaque pointer
@@ -298,7 +298,7 @@ declare !arg_eltypes !0 !ret_eltype !1
 
 During `prepareModule`, the pointer rewriter reconstructs a legacy typed
 function signature from both attachments and inserts no-op bitcasts around
-call operands and pointer results where the opaque LLVM 21 values meet that
+call operands and pointer results where the opaque LLVM 22 values meet that
 signature. The writer's pointer map then serializes the recovered typed uses.
 
 Opaque pointer fields nested in named structures use a separate module-level
@@ -554,7 +554,7 @@ type.
 
 ### 4.7 Textures and samplers
 
-A direct 2D or 3D texture is represented in LLVM 21 as an opaque pointer in
+A direct 2D or 3D texture is represented in LLVM 22 as an opaque pointer in
 address space 1. The root-argument structure field and every texture intrinsic
 parameter are additionally marked for downgrade to a pointer to the opaque
 named handle `%struct._texture_2d_t` or `%struct._texture_3d_t`. AIR reflection
@@ -595,7 +595,7 @@ packed & 0x0000ffffffffffff  = buffer byte size
 (packed >> 56) & 0xff       = 3D sampler code
 ~~~
 
-The LLVM 21 representation deliberately uses one-field texture wrappers for
+The LLVM 22 representation deliberately uses one-field texture wrappers for
 resources nested inside the slot:
 
 ~~~llvm
@@ -698,7 +698,7 @@ writing it stores only those twelve affine elements. Field 56 is named
 `intersection_function_offset` in Apple's reflected `LCInstance` layout and
 is also the field used by Luisa's instance-user-ID API.
 
-The LLVM 21 representation retains both wrapper storage and legacy AIR
+The LLVM 22 representation retains both wrapper storage and legacy AIR
 pointee identity:
 
 ~~~llvm
@@ -1787,7 +1787,7 @@ Metal API Validation.
 The native query pointee is the opaque type from Section 4.12. Each local XIR
 query object produces one `allocate` call, one `reset`, any number of
 `next`/getter/commit/abort calls, and one `deallocate` on each function exit.
-The declaration spellings and LLVM 21 signatures are:
+The declaration spellings and LLVM 22 signatures are:
 
 ~~~llvm
 declare ptr @air.allocate_intersection_query<query-suffix>()
@@ -2694,7 +2694,7 @@ argument metadata is exactly the entry index followed by `air.front_facing`,
 register ABI: the use of `i1` here does not change Luisa's byte-addressable
 memory ABI, where a scalar bool and each member of `{bool, bool, bool, bool}`
 occupy one byte. The convention was recovered with `xcrun metal -std=metal3.2
--S -emit-llvm -c` and then validated through Luisa's LLVM-21 emission,
+-S -emit-llvm -c` and then validated through Luisa's LLVM-22 emission,
 LLVM-14 downgrade, `metallib`, pipeline creation, and GPU execution.
 
 The selectable interpolation spellings were recovered from a single
@@ -2714,7 +2714,7 @@ The emitted argument-metadata pairs are respectively
 `air.sample + air.perspective`, `air.sample + air.no_perspective`, and the
 single `air.flat` token. Metadata order is significant: the location token
 precedes the correction token. These conventions were recovered with Apple
-metalfe 32023.883 and are strict-runtime tested after Luisa's LLVM-21 emission
+metalfe 32023.883 and are strict-runtime tested after Luisa's LLVM-22 emission
 and in-tree LLVM-14 downgrade.
 
 Fragment derivatives are ordinary AIR calls such as
@@ -3063,17 +3063,17 @@ compiled only when:
 APPLE
 CMAKE_CXX_COMPILER_ID matches Clang
 LUISA_COMPUTE_ENABLE_METAL4=ON
-LLVM_VERSION_MAJOR=21
+LLVM_VERSION_MAJOR=22
 ~~~
 
 The CMake option is experimental and defaults to OFF. Enabling the `metal4`
 module requires its complete XIR/LLVM/AIR generator, the pinned in-tree
-`llvm-downgrade` source, and LLVM 21; there is no partially built Metal4 module
+`llvm-downgrade` source, and LLVM 22; there is no partially built Metal4 module
 that contains only the archive loader. The original `metal` backend is selected
 independently with `LUISA_COMPUTE_ENABLE_METAL`.
 
 The Metal4 module is currently integrated through CMake/Ninja only. Its
-LLVM-21 discovery, pinned llvm-downgrade validation, disposable patched-source
+LLVM-22 discovery, pinned llvm-downgrade validation, disposable patched-source
 mirror, and backend link graph have no xmake equivalent yet; no placeholder
 xmake target is provided under `backends/metal4`.
 
@@ -3269,7 +3269,7 @@ I/O destination is available.
 ### 15.6 LLVM/AIR runtime-support library
 
 `MetalDevice` constructs one five-function runtime-support metallib for the
-current platform. Each function starts in a separate LLVM 21 module, receives
+current platform. Each function starts in a separate LLVM 22 module, receives
 the same AIR target triple, module flags, fast-math policy, pointer-element
 recovery metadata, and source-file convention as ordinary user shaders, then
 passes the following fail-closed sequence:
@@ -3311,14 +3311,14 @@ Metal to create a pipeline compiles GPU code through the system Metal service;
 it does not create CPU executable pages in the application.
 
 The current iOS device app implements dynamic on-device XIR-to-AIR without
-`MAP_JIT`. It cross-builds LLVM 21, the in-tree LLVM downgrade, AST, XIR,
+`MAP_JIT`. It cross-builds LLVM 22, the in-tree LLVM downgrade, AST, XIR,
 runtime, DSL, Metal4 AIR codegen, and the Metal4 backend as arm64 iOS static
 libraries. The signed app then performs this sequence inside the iPhone
 process:
 
 1. Build the conformance and path-tracing DSL/AST and translate/optimize it as
    XIR.
-2. Construct and optimize LLVM 21 IR for the running iOS target.
+2. Construct and optimize LLVM 22 IR for the running iOS target.
 3. Serialize LLVM 14-compatible AIR and assemble the deterministic iOS MTLB.
 4. Load the bytes with `MTLDevice::newLibrary(data)` and create the GPU
    pipeline through the system Metal service.
@@ -3352,11 +3352,23 @@ can build and sign the app.
 
 The patched JuliaLLVM tree retains its standalone FileCheck suite. Its
 `ret_eltype` and `struct_eltypes` regressions generate LLVM 14 bitcode with the
-LLVM 21-built downgrader, disassemble it with an actual LLVM 14 `llvm-dis`, and
+LLVM 22-built downgrader, disassemble it with an actual LLVM 14 `llvm-dis`, and
 verify the reconstructed return, argument, nested-structure pointer types, and
 removal of the private `llvm.struct_eltypes` directive. Both tests pass on the
 reference setup; tests for LLVM 5 or 7 remain independently skippable when
 those legacy disassemblers are unavailable.
+
+The LLVM 22 migration was revalidated on 2026-09-02 against upstream commit
+`6ab0b538c9302bd44f1d2a02f8d064ba9c5f2efb`. The complete standalone
+downgrader suite passed all 56 registered tests (42 executed and 14 skipped
+only because optional legacy LLVM 5/7/15/18 tools were absent), including real
+LLVM 14 disassembly and verification of the AIR `ret_eltype` and
+`struct_eltypes` extensions. A clean desktop build then compiled and executed
+`test_metal4_device_conformance` on an Apple M1 Max. Finally, the repository's
+CI-equivalent unsigned iPhoneOS path built official static arm64 LLVM 22.1.8,
+all 19 rendering examples, the path-tracing benchmark, and the physical-device
+test bundle; `scripts/audit_ios_bundles.sh` accepted all 21 bundles as arm64
+iPhoneOS binaries with only Apple system dylibs.
 
 ### 16.1 Runtime tests
 
@@ -4158,7 +4170,7 @@ correct atomic lowering requires an explicit AIR intrinsic/ABI convention.
 | MotionInstance capture and native motion-TLAS packing | [metal_motion_instance.cpp](../metal_motion_instance.cpp), [metal_accel_motion.cpp](../metal_accel_motion.cpp) |
 | Apple9 MTL4 versus Apple7/Apple8 compatibility AS build | [metal_acceleration_structure_build.cpp](../metal_acceleration_structure_build.cpp), [metal_stream.cpp](../metal_stream.cpp) |
 | JuliaLLVM wrapper | [llvm_downgrade.cpp](../../../ext/llvm_downgrade.cpp) |
-| Parent-owned LLVM 21/AIR downgrade overlay and regressions | [llvm-downgrade-llvm21-air.patch](../../../ext/llvm-downgrade-llvm21-air.patch) |
+| Parent-owned LLVM 22/AIR downgrade overlay and regressions | [llvm-downgrade-llvm22-air.patch](../../../ext/llvm-downgrade-llvm22-air.patch) |
 | Pinned upstream typed-pointer and LLVM 14 writer base | [PointerRewriter.cpp](../../../ext/llvm-downgrade/src/PointerRewriter.cpp), [ValueEnumerator140.cpp](../../../ext/llvm-downgrade/src/ValueEnumerator140.cpp), [BitcodeWriter140.cpp](../../../ext/llvm-downgrade/src/BitcodeWriter140.cpp) |
 | AIR-only shader creation | [metal_device.cpp](../metal_device.cpp) |
 | Build-time BC6H/BC7 metallib embedding and runtime binary loading | [metal_tex_compress.cpp](../metal_tex_compress.cpp), [CMakeLists.txt](../CMakeLists.txt) |

--- a/src/ext/CMakeLists.txt
+++ b/src/ext/CMakeLists.txt
@@ -2,10 +2,10 @@ add_library(luisa-compute-ext INTERFACE)
 
 if (APPLE AND LUISA_COMPUTE_ENABLE_METAL4)
     find_package(LLVM CONFIG REQUIRED)
-    if (NOT LLVM_VERSION_MAJOR EQUAL 21)
+    if (NOT LLVM_VERSION_MAJOR EQUAL 22)
         message(FATAL_ERROR
-                "The in-tree llvm-downgrade sources currently require LLVM 21, "
-                "but LLVM ${LLVM_PACKAGE_VERSION} was found. Point LLVM_DIR at LLVM 21.")
+                "The in-tree llvm-downgrade sources currently require LLVM 22, "
+                "but LLVM ${LLVM_PACKAGE_VERSION} was found. Point LLVM_DIR at LLVM 22.")
     endif ()
     # LLVM may have been configured on a generic Unix host while targeting
     # iOS, in which case its exported LLVMSupport target carries a standalone
@@ -26,11 +26,11 @@ if (APPLE AND LUISA_COMPUTE_ENABLE_METAL4)
 
     set(LUISA_LLVM_DOWNGRADE_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/llvm-downgrade")
     set(LUISA_LLVM_DOWNGRADE_PATCH
-            "${CMAKE_CURRENT_SOURCE_DIR}/llvm-downgrade-llvm21-air.patch")
+            "${CMAKE_CURRENT_SOURCE_DIR}/llvm-downgrade-llvm22-air.patch")
     set(LUISA_LLVM_DOWNGRADE_EXPECTED_COMMIT
-            "1e04ee99aff7c059606502ee86d03eb7d1c5d781")
+            "6ab0b538c9302bd44f1d2a02f8d064ba9c5f2efb")
     set(LUISA_LLVM_DOWNGRADE_EXPECTED_SOURCE_FINGERPRINT
-            "7679006d0b2b529998de888e03a812ff311632f58f5d8e4a3c07fca3519c02b6")
+            "52b685b225f004e0b776ec784d3a4eda0afde4bbc21a150fc95b33f9eee2cbea")
     if (NOT EXISTS "${LUISA_LLVM_DOWNGRADE_SOURCE_DIR}/src/BitcodeWriter140.cpp")
         message(FATAL_ERROR
                 "The llvm-downgrade submodule is missing. Run "
@@ -126,12 +126,12 @@ if (APPLE AND LUISA_COMPUTE_ENABLE_METAL4)
     string(SHA256 LUISA_LLVM_DOWNGRADE_FINGERPRINT
             "${LUISA_LLVM_DOWNGRADE_FINGERPRINT_INPUT}")
 
-    # Keep the pinned third-party checkout pristine. The LLVM 21 and AIR typed-
+    # Keep the pinned third-party checkout pristine. The LLVM 22 and AIR typed-
     # pointer extensions live in the parent repository as a reviewable patch,
     # which is applied to a disposable copy in the build tree. Reuse a matching
     # mirror so ordinary reconfiguration does not invalidate its object files.
     set(LUISA_LLVM_DOWNGRADE_DIR
-            "${CMAKE_CURRENT_BINARY_DIR}/llvm-downgrade-llvm21-air")
+            "${CMAKE_CURRENT_BINARY_DIR}/llvm-downgrade-llvm22-air")
     set(LUISA_LLVM_DOWNGRADE_FINGERPRINT_FILE
             "${LUISA_LLVM_DOWNGRADE_DIR}/.luisa-source-fingerprint")
     set(LUISA_LLVM_DOWNGRADE_REFRESH_MIRROR ON)

--- a/src/ext/llvm-downgrade-llvm22-air.patch
+++ b/src/ext/llvm-downgrade-llvm22-air.patch
@@ -1,12 +1,12 @@
-# LuisaCompute LLVM 21/AIR overlay for JuliaLLVM/llvm-downgrade.
-# Base commit: 1e04ee99aff7c059606502ee86d03eb7d1c5d781.
+# LuisaCompute LLVM 22/AIR overlay for JuliaLLVM/llvm-downgrade.
+# Base commit: 6ab0b538c9302bd44f1d2a02f8d064ba9c5f2efb.
 # CMake applies this patch only to a disposable build-tree mirror.
 
 diff --git a/src/BitcodeWriter140.cpp b/src/BitcodeWriter140.cpp
-index ba329b22f5b710aa54cae3241e5bd473eaf60319..a25e2d9641d01f91561484066b3e09a0cf9c52d0 100644
+index 047e09b529e208cb24c3cff6bfac8814bacddeca..7a591c9a8c399961a676784c156c2d6a863ac308 100644
 --- a/src/BitcodeWriter140.cpp
 +++ b/src/BitcodeWriter140.cpp
-@@ -154,6 +154,8 @@ protected:
+@@ -155,6 +155,8 @@ protected:
    /// The Module to write to bitcode.
    const Module &M;
  
@@ -15,22 +15,17 @@ index ba329b22f5b710aa54cae3241e5bd473eaf60319..a25e2d9641d01f91561484066b3e09a0
    /// Enumerates ids for all values in the module.
    ValueEnumerator140 VE;
  
-@@ -182,12 +184,12 @@ public:
+@@ -183,7 +185,8 @@ public:
                            bool ShouldPreserveUseListOrder,
                            const ModuleSummaryIndex *Index)
        : BitcodeWriterBase140(Stream, StrtabBuilder), M(M),
 -        VE(M, ShouldPreserveUseListOrder), Index(Index) {
 +        StructPointerMap(PointerRewriter::buildStructPointerTypeMap(M)),
 +        VE(M, ShouldPreserveUseListOrder, &StructPointerMap), Index(Index) {
-     // Enumerate typed pointers
+     // Enumerate typed pointers, in a deterministic module order so the emitted
+     // type table (and thus the whole bitcode) is reproducible across runs.
      PointerMap = PointerRewriter::buildPointerMap(M);
-     for (auto El : PointerMap)
-       VE.EnumerateType(El.second);
--
-     // Assign ValueIds to any callee values in the index that came from
-     // indirect call profiles and were recorded as a GUID not a Value*
-     // (which would have been assigned an ID by the ValueEnumerator140).
-@@ -1019,8 +1021,13 @@ void ModuleBitcodeWriter140::writeTypeTable() {
+@@ -1086,8 +1089,13 @@ void ModuleBitcodeWriter140::writeTypeTable() {
        // STRUCT: [ispacked, eltty x N]
        TypeVals.push_back(ST->isPacked());
        // Output all of the element types.
@@ -45,7 +40,7 @@ index ba329b22f5b710aa54cae3241e5bd473eaf60319..a25e2d9641d01f91561484066b3e09a0
  
        if (ST->isLiteral()) {
          Code = bitc::TYPE_CODE_STRUCT_ANON;
-@@ -2209,6 +2216,9 @@ void ModuleBitcodeWriter140::writeNamedMetadata(
+@@ -2267,6 +2275,9 @@ void ModuleBitcodeWriter140::writeNamedMetadata(
  
    unsigned Abbrev = createNamedMetadataAbbrev();
    for (const NamedMDNode &NMD : M.named_metadata()) {
@@ -55,7 +50,7 @@ index ba329b22f5b710aa54cae3241e5bd473eaf60319..a25e2d9641d01f91561484066b3e09a0
      // Write name.
      StringRef Str = NMD.getName();
      Record.append(Str.bytes_begin(), Str.bytes_end());
-@@ -2779,7 +2789,8 @@ void ModuleBitcodeWriter140::writeConstants(unsigned FirstVal, unsigned LastVal,
+@@ -2893,7 +2904,8 @@ void ModuleBitcodeWriter140::writeConstants(unsigned FirstVal, unsigned LastVal,
        Record.push_back(VE.getValueID(NC->getGlobalValue()));
      } else {
  #ifndef NDEBUG
@@ -66,10 +61,10 @@ index ba329b22f5b710aa54cae3241e5bd473eaf60319..a25e2d9641d01f91561484066b3e09a0
        llvm_unreachable("Unknown constant!");
      }
 diff --git a/src/BitcodeWriter50.cpp b/src/BitcodeWriter50.cpp
-index 7e710c32af64862cbe87fee8f72cf9fb12493b83..5bffa62d2702bf72fdd8eb8cc3256c77611b4d51 100644
+index a7b7d1fed8d2c546feba609ede256ae6389ec19c..ba6c684be7b30fb885e329ab86eb551d4d4e1ddb 100644
 --- a/src/BitcodeWriter50.cpp
 +++ b/src/BitcodeWriter50.cpp
-@@ -2477,7 +2477,8 @@ void ModuleBitcodeWriter50::writeConstants(unsigned FirstVal, unsigned LastVal,
+@@ -2625,7 +2625,8 @@ void ModuleBitcodeWriter50::writeConstants(unsigned FirstVal, unsigned LastVal,
        Record.push_back(VE.getGlobalBasicBlockID(BA->getBasicBlock()));
      } else {
  #ifndef NDEBUG
@@ -80,10 +75,10 @@ index 7e710c32af64862cbe87fee8f72cf9fb12493b83..5bffa62d2702bf72fdd8eb8cc3256c77
        llvm_unreachable("Unknown constant!");
      }
 diff --git a/src/BitcodeWriter70.cpp b/src/BitcodeWriter70.cpp
-index d7cc68708b6375b246117e390a2d033a66f22b23..6ac412cf5b2a26a0320ec00c4802f9d436ebeb5d 100644
+index 1c6dbe9c67d1a49ab7c193fe86bf45f3f00d4e32..c9e0d1a89b44e7fccad540934a90d2b614aa21d5 100644
 --- a/src/BitcodeWriter70.cpp
 +++ b/src/BitcodeWriter70.cpp
-@@ -2525,7 +2525,8 @@ void ModuleBitcodeWriter70::writeConstants(unsigned FirstVal, unsigned LastVal,
+@@ -2678,7 +2678,8 @@ void ModuleBitcodeWriter70::writeConstants(unsigned FirstVal, unsigned LastVal,
        Record.push_back(VE.getGlobalBasicBlockID(BA->getBasicBlock()));
      } else {
  #ifndef NDEBUG
@@ -94,48 +89,42 @@ index d7cc68708b6375b246117e390a2d033a66f22b23..6ac412cf5b2a26a0320ec00c4802f9d4
        llvm_unreachable("Unknown constant!");
      }
 diff --git a/src/PointerRewriter.cpp b/src/PointerRewriter.cpp
-index 0a604c3630beb02f81f6f62e5f486dcbd62422f6..06f91e5b09ff59ab3364a6f752fecfa667975f79 100644
+index 04d6773109acfd2a36f94a9ed87b4a0afe2dc482..d25008741b2db610d27ac5de2af148b8a5eea05b 100644
 --- a/src/PointerRewriter.cpp
 +++ b/src/PointerRewriter.cpp
-@@ -220,24 +220,35 @@ static FunctionType *getTypedFunctionType(const Function *F) {
+@@ -298,10 +298,13 @@ static FunctionType *getTypedFunctionType(const Function *F) {
      }
    }
  
--  // look at the !arg_eltypes metadata
--  MDNode *MD = F->getMetadata("arg_eltypes");
--  if (!MD)
--    return FTy;
--
 +  // Look at front-end pointer element metadata. `arg_eltypes` contains pairs
 +  // of parameter indices and undef values whose types are the pointee types.
 +  // `ret_eltype` contains one such undef value for a pointer return. The
 +  // latter is needed by AIR functions such as air.get_read_sampler().
    auto Args = FTy->params().vec();
--  for (unsigned i = 0; i < MD->getNumOperands(); i += 2) {
--    auto IdxConstant = cast<ConstantAsMetadata>(MD->getOperand(i))->getValue();
--    int Idx = cast<ConstantInt>(IdxConstant)->getZExtValue();
--    Type *ElTy =
--        cast<ValueAsMetadata>(MD->getOperand(i + 1))->getValue()->getType();
--
--    auto OpaquePtrTy = cast<PointerType>(Args[Idx]);
--    auto TypedPtrTy =
--        TypedPointerType::get(ElTy, OpaquePtrTy->getAddressSpace());
--    Args[Idx] = TypedPtrTy;
 +  auto *ReturnTy = FTy->getReturnType();
-+  auto Changed = false;
-+  if (MDNode *MD = F->getMetadata("arg_eltypes")) {
-+    for (unsigned i = 0; i < MD->getNumOperands(); i += 2) {
-+      auto IdxConstant = cast<ConstantAsMetadata>(MD->getOperand(i))->getValue();
-+      int Idx = cast<ConstantInt>(IdxConstant)->getZExtValue();
-+      Type *ElTy =
-+          cast<ValueAsMetadata>(MD->getOperand(i + 1))->getValue()->getType();
-+
-+      auto OpaquePtrTy = cast<PointerType>(Args[Idx]);
+   bool Changed = false;
+-
+-  // look at the !arg_eltypes metadata
+   if (MDNode *MD = F->getMetadata("arg_eltypes")) {
+     for (unsigned i = 0; i < MD->getNumOperands(); i += 2) {
+       auto IdxConstant = cast<ConstantAsMetadata>(MD->getOperand(i))->getValue();
+@@ -310,9 +313,8 @@ static FunctionType *getTypedFunctionType(const Function *F) {
+           cast<ValueAsMetadata>(MD->getOperand(i + 1))->getValue()->getType();
+ 
+       auto OpaquePtrTy = cast<PointerType>(Args[Idx]);
+-      auto TypedPtrTy =
 +      Args[Idx] =
-+          TypedPointerType::get(ElTy, OpaquePtrTy->getAddressSpace());
-+      Changed = true;
-+    }
+           TypedPointerType::get(ElTy, OpaquePtrTy->getAddressSpace());
+-      Args[Idx] = TypedPtrTy;
+       Changed = true;
+     }
    }
+@@ -340,9 +342,15 @@ static FunctionType *getTypedFunctionType(const Function *F) {
+     Changed = true;
+   }
+ 
+-  if (!Changed)
+-    return FTy;
 -  return FunctionType::get(FTy->getReturnType(), Args, FTy->isVarArg());
 +  if (MDNode *MD = F->getMetadata("ret_eltype")) {
 +    assert(MD->getNumOperands() == 1 && ReturnTy->isPointerTy() &&
@@ -149,7 +138,7 @@ index 0a604c3630beb02f81f6f62e5f486dcbd62422f6..06f91e5b09ff59ab3364a6f752fecfa6
  }
  
  static bool isNoopCast(const Value *V) {
-@@ -379,6 +390,7 @@ bool bitcastInstructionOperands(Module &M) {
+@@ -527,6 +535,7 @@ bool bitcastInstructionOperands(Module &M) {
  // bitcast operands to calls, whose type can be altered by metadata attached to
  // the function
  bool bitcastFunctionOperands(Module &M) {
@@ -157,16 +146,24 @@ index 0a604c3630beb02f81f6f62e5f486dcbd62422f6..06f91e5b09ff59ab3364a6f752fecfa6
    for (Function &F : M) {
      auto *FTy = F.getFunctionType();
      auto *NewFTy = getTypedFunctionType(&F);
-@@ -395,12 +407,17 @@ bool bitcastFunctionOperands(Module &M) {
+@@ -543,18 +552,22 @@ bool bitcastFunctionOperands(Module &M) {
              continue;
  
            prependBitcast(M, CI, Idx);
 +          Changed = true;
-+        }
-+        if (FTy->getReturnType() != NewFTy->getReturnType()) {
-+          appendBitcast(M, CI);
-+          Changed = true;
          }
+         // A retyped return reads back with its typed pointer type; wrap the
+         // call's uses so operands the reader type-checks against their
+-        // user's opaque type (phi incoming values) see the opaque type.
+-        if (NewFTy->getReturnType() != FTy->getReturnType() &&
+-            !CI->use_empty())
++        // user's opaque type (phi incoming values) see the opaque type. Keep
++        // the cast even for an otherwise unused call: buildPointerMap relies
++        // on it to attach the legacy typed-pointer return type.
++        if (NewFTy->getReturnType() != FTy->getReturnType()) {
+           appendBitcast(M, CI);
++          Changed = true;
++        }
        }
      }
    }
@@ -175,8 +172,8 @@ index 0a604c3630beb02f81f6f62e5f486dcbd62422f6..06f91e5b09ff59ab3364a6f752fecfa6
 +  return Changed;
  }
  
- // build a map of values to typed pointer types
-@@ -480,11 +497,60 @@ PointerTypeMap PointerRewriter::buildPointerMap(const Module &M) {
+ // The value type a global value is emitted with (the pointee of its typed
+@@ -725,6 +738,15 @@ PointerTypeMap PointerRewriter::buildPointerMap(const Module &M) {
          }
        }
      }
@@ -192,6 +189,8 @@ index 0a604c3630beb02f81f6f62e5f486dcbd62422f6..06f91e5b09ff59ab3364a6f752fecfa6
    }
  
    return PointerMap;
+@@ -982,6 +1004,46 @@ static bool bitcastBlockAddresses(Module &M) {
+   return !BAs.empty();
  }
  
 +// Build typed-pointer overrides for pointer fields embedded in structs. Opaque
@@ -235,20 +234,14 @@ index 0a604c3630beb02f81f6f62e5f486dcbd62422f6..06f91e5b09ff59ab3364a6f752fecfa6
 +}
 +
  bool PointerRewriter::run() {
-   // get rid of constant expressions so that we can more easily rewrite them
-   bool Changed = demotePointerConstexprs(M);
+   bool Changed = demotePointerConstants(M);
+ 
 diff --git a/src/PointerRewriter.h b/src/PointerRewriter.h
-index 450b49402c34d870a05a4b700442eea2cdc82443..21be09f687ec9f8eab3062c81667cfdd86bdcf5b 100644
+index c0532223fe7b7a0f1c094c743cc2316b39ebc7e4..50b0fbfd6b68a0495fbd57b8a74eef75199586f0 100644
 --- a/src/PointerRewriter.h
 +++ b/src/PointerRewriter.h
-@@ -15,14 +15,18 @@
- #define LLVM_LIB_BITCODE_LEGACYWRITER_POINTERREWRITER_H
- 
- #include "llvm/ADT/DenseMap.h"
-+#include "llvm/ADT/SmallVector.h"
- 
- namespace llvm {
- 
+@@ -22,9 +22,12 @@ namespace llvm {
+ class Constant;
  class Value;
  class Module;
 +class StructType;
@@ -260,19 +253,19 @@ index 450b49402c34d870a05a4b700442eea2cdc82443..21be09f687ec9f8eab3062c81667cfdd
  
  class PointerRewriter {
  public:
-@@ -31,6 +35,7 @@ public:
+@@ -33,6 +36,7 @@ public:
    bool run();
  
    static PointerTypeMap buildPointerMap(const Module &M);
 +  static StructPointerTypeMap buildStructPointerTypeMap(const Module &M);
+   static bool requiresPointerRewriting(const Constant *C);
  
- private:
-   Module &M;
+   // Lower intrinsics to their legacy form: drop lifetime markers (whose
 diff --git a/src/ValueEnumerator140.cpp b/src/ValueEnumerator140.cpp
-index fb0ba442d2ae64df9495d981df4762101e29ef3b..f1a93650a8138c4e56f87dcde0be09e33e9682e9 100644
+index 746330af92a98f061adf969d9c3bb760da184753..71da19baad82edeac6ae454d063f8e8d007078af 100644
 --- a/src/ValueEnumerator140.cpp
 +++ b/src/ValueEnumerator140.cpp
-@@ -30,6 +30,7 @@
+@@ -31,6 +31,7 @@
  #include "llvm/IR/Module.h"
  #include "llvm/IR/Operator.h"
  #include "llvm/IR/Type.h"
@@ -280,7 +273,7 @@ index fb0ba442d2ae64df9495d981df4762101e29ef3b..f1a93650a8138c4e56f87dcde0be09e3
  #include "llvm/IR/Use.h"
  #include "llvm/IR/User.h"
  #include "llvm/IR/Value.h"
-@@ -360,9 +361,11 @@ static bool isIntOrIntVectorValue(const std::pair<const Value*, unsigned> &V) {
+@@ -367,9 +368,11 @@ static bool isIntOrIntVectorValue(const std::pair<const Value*, unsigned> &V) {
    return V.first->getType()->isIntOrIntVectorTy();
  }
  
@@ -295,7 +288,7 @@ index fb0ba442d2ae64df9495d981df4762101e29ef3b..f1a93650a8138c4e56f87dcde0be09e3
    if (ShouldPreserveUseListOrder)
      UseListOrders = predictUseListOrder(M);
  
-@@ -978,10 +981,22 @@ void ValueEnumerator140::EnumerateType(Type *Ty) {
+@@ -1022,10 +1025,22 @@ void ValueEnumerator140::EnumerateType(Type *Ty) {
      if (!STy->isLiteral())
        *TypeID = ~0U;
  
@@ -322,7 +315,7 @@ index fb0ba442d2ae64df9495d981df4762101e29ef3b..f1a93650a8138c4e56f87dcde0be09e3
    // Refresh the TypeID pointer in case the table rehashed.
    TypeID = &TypeMap[Ty];
 diff --git a/src/ValueEnumerator140.h b/src/ValueEnumerator140.h
-index 08920b09e11b3c7452d916bffa31cb0266b01620..d7a1b9f88a335e0ba6bb1078edaf8beb612ee173 100644
+index de6f81c23e065ed9f6d8bd15833644553a46699b..8b26b3e16a957ad287151c3a3bedeb0e146e214a 100644
 --- a/src/ValueEnumerator140.h
 +++ b/src/ValueEnumerator140.h
 @@ -13,6 +13,7 @@
@@ -333,7 +326,7 @@ index 08920b09e11b3c7452d916bffa31cb0266b01620..d7a1b9f88a335e0ba6bb1078edaf8beb
  #include "llvm/ADT/ArrayRef.h"
  #include "llvm/ADT/DenseMap.h"
  #include "llvm/ADT/UniqueVector.h"
-@@ -104,6 +105,7 @@ private:
+@@ -115,6 +116,7 @@ private:
    SmallDenseMap<unsigned, MDRange, 1> FunctionMDInfo;
  
    bool ShouldPreserveUseListOrder;
@@ -341,7 +334,7 @@ index 08920b09e11b3c7452d916bffa31cb0266b01620..d7a1b9f88a335e0ba6bb1078edaf8beb
  
    using AttributeGroupMapType = DenseMap<IndexAndAttrSet, unsigned>;
    AttributeGroupMapType AttributeGroupMap;
-@@ -138,7 +140,8 @@ private:
+@@ -149,7 +151,8 @@ private:
    unsigned FirstInstID;
  
  public:
@@ -408,3 +401,4 @@ index 0000000000000000000000000000000000000000..d6db9495315496828de11e61e7d55198
 +; CHECK-DAG: %argument_buffer = type { i32, %resource_wrapper addrspace(2)* }
 +; CHECK: define void @consume_argument_buffer(%argument_buffer addrspace(2)*
 +; CHECK-NOT: !llvm.struct_eltypes
+

--- a/src/tests/ios/README.md
+++ b/src/tests/ios/README.md
@@ -22,9 +22,9 @@ For the supported configure/build flags, use:
 
 ~~~sh
 scripts/build_ios_llvm.sh \
-  --host-llvm-prefix "$(brew --prefix llvm@21)"
+  --host-llvm-prefix "$(brew --prefix llvm@22)"
 scripts/build_ios_metal4.sh \
-  --llvm-dir cmake-build-llvm21-ios/lib/cmake/llvm \
+  --llvm-dir cmake-build-llvm22-ios/lib/cmake/llvm \
   --team <apple-development-team> --mode tests
 ~~~
 


### PR DESCRIPTION
The llvm-downgrade submodule was advanced to `6ab0b538c9302bd44f1d2a02f8d064ba9c5f2efb`, whose build requires LLVM 22, while the parent pin, AIR overlay, iOS scripts, and CI still required LLVM 21. That made the iOS workflow fail before compilation.

This change:
- rebases Luisa's AIR typed-pointer overlay onto the pinned LLVM 22 upstream revision and updates its exact source fingerprint;
- moves desktop/iOS Metal4 integration and CI to LLVM 22.1.8;
- updates iOS build documentation and repository skills while preserving historical LLVM 21 benchmark records;
- keeps the third-party submodule pristine and applies the overlay only in the disposable build-tree mirror.

Validated locally:
- clean CMake/Ninja LLVM 22 Metal4 backend build;
- llvm-downgrade: 56/56 registered tests without failures (42 executed, 14 optional legacy-tool skips), including LLVM 14 `ret_eltype` and `struct_eltypes` verification;
- `test_metal4_device_conformance` on Apple M1 Max;
- official static arm64 iPhoneOS LLVM 22.1.8 build;
- CI-equivalent `scripts/build_ios_metal4.sh --mode all --unsigned` build;
- bundle audit: all 21 arm64 iPhoneOS apps, Apple system dylibs only;
- `actionlint`, shell syntax checks, patch replay, and `git diff --check`.